### PR TITLE
added arg parser to module_utils

### DIFF
--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -1,0 +1,508 @@
+from collections import OrderedDict, defaultdict
+import types
+import re
+
+# TODO: add some additional type checking and error messages to parser
+# TODO: validate provided arguments are valid with other args
+# TODO: add mututally exclusive parameter
+    # ? maybe list of lists at arg level?
+
+class BetterArg(object):
+    def __init__(self, arg_parser, name, elements=None, options=None, aliases=[], dependencies=[], required=False, default=None, choices=[], arg_type='str'):
+        """Holds all of the attributes that define a particular argument.
+        A BetterArg object can contain nested BetterArg objects.
+
+        Arguments:
+            object {object} -- The most base class type.
+            arg_parser {BetterArgParser} -- The instance of BetterArgParser used to create the BetterArg.
+            Used to call BetterArgParser.handle_args() when nested BetterArg objects need to be defined.
+            name {str} -- The name of the argument to define.
+
+        Keyword Arguments:
+            elements {Union[str, function]} -- Used to specify the expected type for each list element when the arg_type is 'list'. (default: {None})
+            options {dict} -- When arg_type or elements = 'dict', a dictionary containing details for a nested group of arguments should be provided. (default: {None})
+            aliases {list[str]} -- A list of alternative names that can be used to refer to the argument. (default: {[]})
+            dependencies {list} -- A list of arguments that should be resolved before parsing this argument. (default: {[]})
+            required {Union[bool, function]} -- Determines if later parsing should fail when no value is provided for the argument. Not necessary if default is provided. (default: {False})
+            default {Union[str, int, bool, function]} -- The default value that the argument should be set to when none is provided. (default: {None})
+            choices {list[Union[str, int, bool]]} -- The list of valid contents for the argument.
+            arg_type {Union[str, function]} -- The type the argument contents should be. (default: {'str'})
+        """
+        self.arg_parser = arg_parser
+        self.name = name
+        self.elements = elements
+        self.options = None
+        self.aliases = aliases
+        self.dependencies = dependencies
+        self.required = required
+        self.default = default
+        self.choices = choices
+        self.arg_type = arg_type
+        if options:
+            self.options = self.arg_parser.handle_args(options)
+
+
+class BetterArgHandler(object):
+    def __init__(self, arg_name, contents, resolved_args, arg_defs):
+        """Sets, formats and validates an argument and its contents based on its 
+        matching BetterArg object.
+
+        Arguments:
+            object {object} -- The most base class type.
+            arg_name {str} -- The name of the argument.
+            contents {dict} -- The argument contents to be handled by the argument's BetterArg object
+            resolved_args {dict} -- Contains all of the dependencies and their contents, which have already been handled by a BetterArgHandler, for use during current arguments handling operations.
+            arg_defs {dict[str, BetterArg]} -- All of the BetterArg argument definitions for current argument depth.
+        """
+        self.arg_name = arg_name
+        self.arg_defs = arg_defs
+        self.arg_def = arg_defs.get(arg_name)
+        self.contents = contents
+        self.resolved_dependencies = self.build_resolved_dependency_dict(
+            resolved_args)
+        # TODO: determine if we should optioanlly allow top-level args to be passed
+        self.type_handlers = {
+            'dict': self._dict_type,
+            'list': self._list_type,
+            'str': self._str_type,
+            'bool': self._bool_type,
+            'int': self._int_type
+        }
+
+    def handle_arg(self):
+        """Performs all setting, formatting and validation operations for a single argument.
+
+        Returns:
+            dict -- The arguments contents after any necessary operations.
+        """
+        # self._verify_valid_arg()
+        self._resolve_required()
+        self.contents = self._resolve_default()
+        if self.contents != None:
+            # ? is this the best way to handle this?
+            self.contents = self._resolve_arg_type()
+            self._resolve_choices()
+        return self.contents
+
+    def _list_type(self, contents, resolved_dependencies):
+        """Resolver for list type arguments.
+
+        Arguments:
+            contents {list[Union[int, str, bool, dict]]} -- The contents of the argument.
+            resolved_dependencies {dict} -- Contains all of the dependencies and their contents, 
+            which have already been handled,
+            for use during current arguments handling operations.
+
+        Returns:
+            list[Union[int, str, bool, dict]] -- The arguments contents after any necessary operations.
+        """
+        # TODO: determine how to handle resolved dependencies for list items, probably good as-is
+        updated_contents = []
+        if BetterArgHandler.is_function(self.arg_def.elements):
+            for item in contents:
+                updated_contents.append(self.arg_def.elements(
+                    item, self.resolved_dependencies))
+        elif self.type_handlers.get(self.arg_def.elements):
+            for item in contents:
+                updated_contents.append(self.type_handlers.get(
+                    self.arg_def.elements)(item, self.resolved_dependencies))
+        contents = updated_contents
+        return contents
+
+    def _dict_type(self, contents, resolved_dependencies):
+        """Resolver for dict type arguments.
+
+        Arguments:
+            contents {dict} -- The contents of the argument.
+            resolved_dependencies {dict} -- Contains all of the dependencies and their contents, 
+            which have already been handled,
+            for use during current arguments handling operations.
+
+        Returns:
+            dict -- The arguments contents after any necessary operations.
+        """
+        updated_contents = {}
+        for key, value in contents.items():
+            handler = BetterArgHandler(
+                key, value, updated_contents, self.arg_def.options)
+            updated_value = handler.handle_arg()
+            updated_contents[key] = updated_value
+        contents = updated_contents
+        return contents
+
+    def _str_type(self, contents, resolve_dependencies):
+        """Resolver for str type arguments.
+
+        Arguments:
+            contents {str} -- The contents of the argument.
+            resolved_dependencies {dict} -- Contains all of the dependencies and their contents, 
+            which have already been handled,
+            for use during current arguments handling operations.
+
+        Raises:
+            ValueError: When contents is invalid argument type
+
+        Returns:
+            str -- The arguments contents after any necessary operations.
+        """
+        if not isinstance(contents, str):
+            raise ValueError(
+                'Invalid argument type for "{}". expected "str"'.format(contents))
+        return contents
+
+    def _int_type(self, contents, resolve_dependencies):
+        """Resolver for int type arguments.
+
+        Arguments:
+            contents {Union[int, str]} -- The contents of the argument.
+            resolved_dependencies {dict} -- Contains all of the dependencies and their contents, 
+            which have already been handled,
+            for use during current arguments handling operations.
+
+        Raises:
+            ValueError: When contents is invalid argument type
+
+        Returns:
+            int -- The arguments contents after any necessary operations.
+        """
+        if not re.match(r'[0-9]+', str(contents)):
+            raise ValueError(
+                'Invalid argument type for "{}". expected "int"'.format(contents))
+        return int(contents)
+
+    def _bool_type(self, contents, resolve_dependencies):
+        """Resolver for bool type arguments.
+
+        Arguments:
+            contents {bool} -- The contents of the argument.
+            resolved_dependencies {dict} -- Contains all of the dependencies and their contents, 
+            which have already been handled,
+            for use during current arguments handling operations.
+
+        Raises:
+            ValueError: When contents is invalid argument type
+
+        Returns:
+            bool -- The arguments contents after any necessary operations.
+        """
+        if not isinstance(contents, bool):
+            raise ValueError(
+                'Invalid argument type for "{}". expected "bool"'.format(contents))
+        return contents
+
+    @staticmethod
+    def is_function(some_var):
+        """Determines if variable is a function.
+
+        Arguments:
+            some_var {Union[str, int, bool, function]} -- The variable to test for type.
+
+        Returns:
+            bool -- True if variable some_var is function, False otherwise.
+        """
+        return isinstance(some_var, types.FunctionType)
+
+    def _resolve_required(self):
+        """Perform operations to determine if an argument is required.
+
+        Raises:
+            ValueError: When no value or defaults are provided for a required argument.
+        """
+        if BetterArgHandler.is_function(self.arg_def.required):
+            self.arg_def.required = self.arg_def.required(
+                self.contents, self.resolved_dependencies)
+        if self.contents == None and self.arg_def.required == True and self.arg_def.default == None:
+            raise ValueError(
+                'Missing required argument {}'.format(self.arg_name))
+        return
+
+    # TODO: add additional skips when argument type should never use default even when set
+    def _resolve_default(self):
+        """Resolve the default value of an argument when no value is provided.
+
+        Returns:
+            Union[str, int, bool, list, dict] -- The updated contents of the argument.
+        """
+        if self.contents != None:
+            return self.contents
+        new_contents = None
+        if BetterArgHandler.is_function(self.arg_def.default):
+            new_contents = self.arg_def.default(
+                self.contents, self.resolved_dependencies)
+        else:
+            new_contents = self.arg_def.default
+        self.contents = new_contents
+        return self.contents
+
+    def _resolve_choices(self):
+        """Verify the argument contents are a valid choice when list of choices is provided. 
+        
+        Raises:
+            ValueError: The provided value is not a valid choice.
+        """
+        if self.arg_def.choices and len(self.arg_def.choices) > 0:
+            if self.contents not in self.arg_def.choices:
+                raise ValueError('Provided value: {} for arg: {} is not in a valid choice. Choices: {}'.format(self.contents, self.arg_name, ', '.join(self.arg_def.choices)))
+
+    def _resolve_arg_type(self):
+        """Perform type-specific operations for an argument.
+        This may include manipulating argument contents and/or 
+        any necessary validation.
+
+        Raises:
+            ValueError: When the provided arg_type is invalid.
+
+        Returns:
+            Union[str, int, bool, list, dict] -- The argument's contents after any necessary processing by type handler.
+        """
+        if BetterArgHandler.is_function(self.arg_def.arg_type):
+            return self.arg_def.arg_type(self.contents, self.resolved_dependencies)
+        elif self.type_handlers.get(self.arg_def.arg_type):
+            return self.type_handlers.get(self.arg_def.arg_type)(self.contents, self.resolved_dependencies)
+        else:
+            raise ValueError('Provided arg_type "{}" for argument "{}" is invalid.'.format(
+                self.arg_name, self.arg_def.arg_type))
+
+    # ? resolved_args should be a dict?
+    def build_resolved_dependency_dict(self, resolved_args):
+        """Gather all arguments for which the current argument has
+        a dependency. These dependency arguments should already be 
+        resolved by the time this method is called.
+
+        Arguments:
+            resolved_args {dict} -- Arguments that have already finished parser processing.
+
+        Returns:
+            dict -- Subset of resolved_args containing any dependencies required by current argument.
+        """
+        resolved_dependencies = {}
+        for dependency in self.arg_def.dependencies:
+            resolved_dependencies[dependency] = resolved_args.get(
+                dependency)
+        return resolved_dependencies
+
+
+class BetterArgParser(object):
+    def __init__(self, arg_dict):
+        """Parser used to verify provided arguments
+        match defined criteria, and perform any
+        necessary operations on the provided arguments.
+
+        Arguments:
+            object {object} -- The most base type
+            arg_dict {dict[str, dict]} -- a list of key:value pairs where key = argument name
+            and value = BetterArg object
+        """
+        self.aliases = {}
+        self.args = self.handle_args(arg_dict)
+
+    def handle_args(self, arg_dict):
+        """Handles argument definition operations.
+        Builds dict of BetterArg objects based on argument 
+        definitions, swaps out alias names, and sorts and verifies no
+        invalid or cyclic dependencies exist.
+
+        Arguments:
+            arg_dict {dict} -- The argument definitions used to generate BetterArg objects. 
+
+        Returns:
+            OrderedDict[str, BetterArg] -- The defined arguments, sorted based on their dependencies.
+        """
+        args = {}
+        # self.aliases = {}
+        for key, value in arg_dict.items():
+            args[key] = BetterArg(self, key, **value)
+            self.aliases = self._add_alias(
+                key, value.get('aliases', []), self.aliases)
+        args = self._swap_alias_for_real_names(args, self.aliases)
+        self._assert_no_invalid_dependencies(args)
+        args = self._sort_args_by_dependencies(args)
+        return args
+
+    def parse_args(self, arg_dict):
+        """Parse provided argument values using corresponding 
+        BetterArg argument definition.
+
+        Arguments:
+            arg_dict {dict} -- The arguments to parse where key=argument name/alias 
+            and value=argument contents 
+
+        Returns:
+            dict -- The arguments with alias names swapped for real names
+            and contents after any necessary operations and checks have been performed.
+        """
+        parsed_args = {}
+        arg_dict = self._swap_alias_for_real_names(arg_dict, self.aliases)
+        for key in self.args:
+            handler = BetterArgHandler(
+                key, arg_dict.get(key), parsed_args, self.args)
+            updated_value = handler.handle_arg()
+            parsed_args[key] = updated_value
+        return parsed_args
+
+    def _add_alias(self, arg_name, arg_aliases=[], aliases={}):
+        """Add alias to an alias dictionary that can be
+        used to simplify alias->name determinations.
+        
+        Arguments:
+            arg_name {str} -- the name of the argument
+        
+        Keyword Arguments:
+            arg_aliases {list[str]} -- The list of aliases for the argument name (default: {[]})
+            aliases {dict} -- The dictionary containing all of the currently defined aliases. (default: {{}})
+        
+        Raises:
+            ValueError: When conflicting aliases are found.
+        
+        Returns:
+            dict -- The updated dict of aliases
+        """
+        arg_aliases.append(arg_name)
+        for alternate_name in arg_aliases:
+            if aliases.get(alternate_name, arg_name) != arg_name:
+                raise ValueError('Conflicting aliases "{}" and "{}" found for name "{}"'.format(
+                    aliases.get(alternate_name), alternate_name, arg_name))
+            aliases[alternate_name] = arg_name
+        return aliases
+
+    def _swap_alias_for_real_names(self, args, aliases):
+        """Swap any arguments provided with alias for a name
+        with their 'real' name used to refer to the argument
+        throughout parser.
+
+        Arguments:
+            args {dict} -- Arguments for BetterArgParser to parse
+            aliases {dict} -- The dictionary containing all of the currently defined aliases. 
+
+        Returns:
+            dict -- The contents from provided argument where they keys
+            have been swapped for 'real' argument names where necessary.
+        """
+        renamed_args = {}
+        for alias_name, value in args.items():
+            renamed_args[aliases.get(alias_name)] = value
+        args = renamed_args
+        return args
+
+    def _assert_no_invalid_dependencies(self, args):
+        """Verify that no dependencies are requested
+        that do not have an argument with matching name.
+        
+        Arguments:
+            args {dict[str, BetterArg]} -- All of the BetterArg argument definitions for current argument depth.
+        
+        Raises:
+            ValueError: When invalid dependency found.
+        
+        Returns:
+            bool -- Always returns True when no invalid dependencies found.
+        """
+        valid_names = args.keys()
+        dependencies = []
+        for key, value in args.items():
+            dependencies += value.dependencies
+        bad_dependencies = list(set(dependencies) - set(valid_names))
+        if bad_dependencies:
+            raise ValueError('One or more invalid dependencies found: {}'.format(
+                ', '.join(bad_dependencies)))
+        return True
+
+    def _sort_args_by_dependencies(self, args):
+        """Sort arguments based on their dependencies to other arguments.
+        Used with _dependency_sort_helper() to implement topographical sorting.
+        
+        Arguments:
+            args {dict[str, BetterArg]} -- All of the BetterArg argument definitions for current argument depth.
+        
+        Returns:
+            OrderedDict[str, BetterArg] -- All of the BetterArg argument definitions for current argument depth,
+            sorted based on dependencies.
+        """
+        visited = {name: False for name in args}
+        dependencies = {}
+        ordered_arg_defs = OrderedDict()
+        for name in args:
+            if not visited.get(name):
+                self._dependency_sort_helper(
+                    args, name, visited, dependencies, ordered_arg_defs)
+        args = ordered_arg_defs
+        return args
+
+    def _dependency_sort_helper(self, args, name, visited, dependencies, ordered_arg_defs):
+        """Recursive helper function for _sort_args_by_dependencies().
+        Used with _sort_args_by_dependencies() to implement topographical sorting.
+
+        Arguments:
+            args {dict[str, BetterArg]} -- All of the BetterArg argument definitions for current argument depth.
+            name {str} -- the name of the argument
+            visited {dict[str, bool]} -- holds the name of each argument in a key with
+            a boolean value to identify whether operations have already been performed on the argument
+            dependencies {dict[str, dict[str, bool]]} -- Each outer key represents one argument where the
+            value is a dictionary with key=name of argument outer key argument is dependent on. Boolean value
+            is always true and is a placeholder.
+            ordered_arg_defs {dict[str, BetterArg]} -- argument definitions from arg_defs sorted based on their dependencies,
+            output is in the reverse of the order desired. Reverse sorting is handled in _sort_args_by_dependencies().
+
+        Raises:
+            RuntimeError: When cyclic dependencies are found
+        """
+        visited[name] = True
+        dependencies[name] = {dep_name: True for dep_name in args.get(
+            name).dependencies}
+        # TODO: fix dependency cycles
+        if self._has_cycle(args):
+            raise RuntimeError('Cyclic dependency found.')
+        for dependency_name in args.get(name).dependencies:
+            if not visited.get(dependency_name):
+                self._dependency_sort_helper(
+                    args, dependency_name, visited, dependencies, ordered_arg_defs)
+        ordered_arg_defs[name] = args.get(name)
+        return
+
+    def _has_cycle(self, args):
+        """Determines if cyclic dependencies exist between arguments.
+        
+        Arguments:
+            args {dict[str, BetterArg]} -- All of the BetterArg argument definitions for current argument depth.
+        
+        Returns:
+            bool -- True if cycle exists False otherwise
+        """
+        graph = defaultdict(list)
+        arg_name_to_num = {}
+        for i, arg in enumerate(args):
+            arg_name_to_num[arg] = i
+        visited = [False for x in range(len(arg_name_to_num))]
+        stack = [False for x in range(len(arg_name_to_num))]
+        for name, value in args.items():
+            for dependency_name in value.dependencies:
+                graph[arg_name_to_num.get(name)].append(
+                    arg_name_to_num.get(dependency_name))
+        for i in arg_name_to_num.values():
+            if not visited[i]:
+                if self._is_cyclic_helper(i, visited, stack, graph):
+                    return True
+        return False
+
+    def _is_cyclic_helper(self, i, visited, stack, graph):
+        """Works with _has_cycle() to determine if cyclic dependencies exist between arguments.
+        
+        Arguments:
+            i {integer} -- The index for the current argument
+            visited {list[bool]} -- Maintains a record of which arguments have been visited
+            stack {list[bool]} -- Used with visited to identify cycles.
+            graph {defaultdict[list]} -- The graph representing our argument dependencies as numbers
+        
+        Returns:
+            bool -- True if cycle exists, False otherwise
+        """
+        visited[i] = True
+        stack[i] = True
+        for neighbor in graph[i]:
+            if visited[neighbor] == False:
+                if self._is_cyclic_helper(neighbor, visited, stack, graph):
+                    return True
+            elif stack[neighbor] == True:
+                return True
+        stack[i] = False
+        return False


### PR DESCRIPTION
##### SUMMARY
This PR relates to NAZARE-129. Because of the often complex nature of z/OS operations, arguments often have dependencies on each other. For that reason, I have created an additional argument parser to be used in conjunction with Ansible's default parser build in to *module_utils.basic.AnsibleModule*.



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
better_arg_parser.py

##### ADDITIONAL INFORMATION

Features:

- Arguments dependencies on other arguments
- Multiple levels of nested arguments (dict of dict, list of dict, dict of lists, etc.)
- Type checking and modification
- Default value handling
- Required arguments
- Providing list of valid choices
- Argument aliases
- Custom functions for type checking, defaults, and required arguments.
    - Can leverage contents of arguments specified as dependencies.

