### PR TITLE
refactor and patch job output checking

### DIFF
--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -1,0 +1,163 @@
+# Copyright (c) IBM Corporation 2019, 2020
+# Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
+
+from tempfile import NamedTemporaryFile
+from os import chmod, path, remove
+import json
+
+
+def job_output(module, job_id='', owner='', job_name='', dd_name=''):
+    job_detail_json = {}
+    rc, out, err = _get_job_json_str(module, job_id, owner, job_name, dd_name)
+    if rc != 0:
+        raise RuntimeError(
+            'Failed to retrieve job output. RC: {} Error: {}'.format(str(rc), str(err)))
+    if not out:
+        raise RuntimeError(
+            'Failed to retrieve job output. No job output found.')
+    job_detail_json = json.loads(out, strict=False)
+    return job_detail_json
+
+
+def _get_job_json_str(module, job_id='', owner='', job_name='', dd_name=''):
+    get_job_detail_json_rexx = """/* REXX */
+arg options
+parse var options param
+upper param
+parse var param 'JOBID=' jobid ' OWNER=' owner,
+' JOBNAME=' jobname ' DDNAME=' ddname
+
+rc=isfcalls('ON')
+
+jobid = strip(jobid,'L')
+if (jobid <> '') then do
+ISFFILTER='JobID EQ '||jobid
+end
+owner = strip(owner,'L')
+if (owner <> '') then do
+ISFOWNER=owner
+end
+jobname = strip(jobname,'L')
+if (jobname <> '') then do
+ISFPREFIX=jobname
+end
+ddname = strip(ddname,'L')
+if (ddname == '?') then do
+ddname = ''
+end
+
+Address SDSF "ISFEXEC ST (ALTERNATE DELAYED)"
+if rc<>0 then do
+Say '{"jobs":[]}'
+Exit 0
+end
+
+if isfrows == 0 then do
+Say '{"jobs":[]}'
+end
+else do
+Say '{"jobs":['
+do ix=1 to isfrows
+    if ix<>1 then do
+    Say ','
+    end
+    Say '{'
+    Say '"'||'job_id'||'":"'||value('JOBID'||"."||ix)||'",'
+    Say '"'||'job_name'||'":"'||value('JNAME'||"."||ix)||'",'
+    Say '"'||'subsystem'||'":"'||value('ESYSID'||"."||ix)||'",'
+    Say '"'||'owner'||'":"'||value('OWNERID'||"."||ix)||'",'
+    Say '"'||'ret_code'||'":{"'||'msg'||'":"'||value('RETCODE'||"."||ix)||'"},'
+    Say '"'||'class'||'":"'||value('JCLASS'||"."||ix)||'",'
+    Say '"'||'content-type'||'":"'||value('JTYPE'||"."||ix)||'",'
+    Say '"'||'changed'||'":"'||'false'||'",'
+    Say '"'||'failed'||'":"'||'false'||'",'
+    Address SDSF "ISFACT ST TOKEN('"TOKEN.ix"') PARM(NP ?)",
+"("prefix JDS_
+    lrc=rc
+    if lrc<>0 | JDS_DDNAME.0 == 0 then do
+    Say '"ddnames":[]'
+    end
+    else do
+    Say '"ddnames":['
+    do jx=1 to JDS_DDNAME.0
+        if jx<>1 & ddname == '' then do
+        Say ','
+        end
+        if ddname == '' | ddname == value('JDS_DDNAME'||"."||jx) then do
+        Say '{'
+        Say '"'||'ddname'||'":"'||value('JDS_DDNAME'||"."||jx)||'",'
+        Say '"'||'record-count'||'":"'||value('JDS_RECCNT'||"."||jx)||'",'
+        Say '"'||'id'||'":"'||value('JDS_DSID'||"."||jx)||'",'
+        Say '"'||'stepname'||'":"'||value('JDS_STEPN'||"."||jx)||'",'
+        Say '"'||'procstep'||'":"'||value('JDS_PROCS'||"."||jx)||'",'
+        Say '"'||'byte-count'||'":"'||value('JDS_BYTECNT'||"."||jx)||'",'
+        Say '"'||'content'||'":['
+        Address SDSF "ISFBROWSE ST TOKEN('"TOKEN.ix"')"
+        do kx=1 to isfline.0
+            if kx<>1 then do
+            Say ','
+            end
+            Say '"'||escapeNewLine(escapeDoubleQuote(isfline.kx))||'"'
+        end
+        Say ']'
+        Say '}'
+        end
+    end
+    Say ']'
+    end
+    Say '}'
+end
+Say ']}'
+end
+
+rc=isfcalls('OFF')
+
+return 0
+
+escapeDoubleQuote: Procedure
+Parse Arg string
+out=''
+Do While Pos('"',string)<>0
+Parse Var string prefix '"' string
+out=out||prefix||'\\"'
+End
+Return out||string
+
+escapeNewLine: Procedure
+Parse Arg string
+Return translate(string, '4040'x, '1525'x)
+"""
+    try:
+        dirname, scriptname = _write_script(get_job_detail_json_rexx)
+        if dd_name is None or dd_name == '?':
+            dd_name = ''
+        jobid_param = 'jobid=' + job_id
+        owner_param = 'owner=' + owner
+        jobname_param = 'jobname=' + job_name
+        ddname_param = 'ddname=' + dd_name
+        cmd = [dirname + '/' + scriptname, jobid_param, owner_param,
+               jobname_param, ddname_param]
+
+        rc, out, err = module.run_command(args=" ".join(cmd),
+                                          cwd=dirname,
+                                          use_unsafe_shell=True)
+    except Exception:
+        raise
+    finally:
+        remove(dirname + "/" + scriptname)
+    return rc, out, err
+
+
+def _write_script(content):
+    delete_on_close = False
+    try:
+        tmp_file = NamedTemporaryFile(delete=delete_on_close)
+        with open(tmp_file.name, 'w') as f:
+            f.write(content)
+        chmod(tmp_file.name, 0o755)
+        dirname = path.dirname(tmp_file.name)
+        scriptname = path.basename(tmp_file.name)
+    except Exception:
+        remove(tmp_file)
+        raise
+    return dirname, scriptname

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -35,7 +35,10 @@ def job_output(module, job_id='', owner='', job_name='', dd_name=''):
             'Failed to retrieve job output. No job output found.')
     job_detail_json = json.loads(out, strict=False)
     for job in job_detail_json.get('jobs'):
-        job['return_code'] = _get_return_code_num(job.get('ret_code', {}).get('msg', ''))
+        job['ret_code'] = {} if job.get('ret_code') == None else job.get('ret_code')
+        job['ret_code']['code'] = _get_return_code_num(job.get('ret_code', {}).get('msg', ''))
+        job['ret_code']['msg_code'] = _get_return_code_str(job.get('ret_code', {}).get('msg', ''))
+        job['ret_code']['msg_txt'] = ''
     return job_detail_json
 
 
@@ -221,4 +224,20 @@ def _get_return_code_num(rc_str):
     match = re.search(r'\s*CC\s*([0-9]+)', rc_str)
     if match:
         rc = int(match.group(1))
+    return rc
+
+def _get_return_code_str(rc_str):
+    """Parse an intestrger return code from
+    z/OS job output return code string.
+    
+    Arguments:
+        rc_str {str} -- The return code message from z/OS job log (eg. "CC 0000" or "ABEND")
+    
+    Returns:
+        Union[str, NoneType] -- Returns string RC or ABEND code if possible, if not returns NoneType
+    """
+    rc = None
+    match = re.search(r'(?:\s*CC\s*([0-9]+))|(?:ABEND(\s*(?:S|U)[0-9]+))', rc_str)
+    if match:
+        rc = match.group(1)
     return rc

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -237,7 +237,7 @@ def _get_return_code_str(rc_str):
         Union[str, NoneType] -- Returns string RC or ABEND code if possible, if not returns NoneType
     """
     rc = None
-    match = re.search(r'(?:\s*CC\s*([0-9]+))|(?:ABEND(\s*(?:S|U)[0-9]+))', rc_str)
+    match = re.search(r'(?:\s*CC\s*([0-9]+))|(?:ABEND\s*((?:S|U)[0-9]+))', rc_str)
     if match:
-        rc = match.group(1)
+        rc = match.group(1) or match.group(2)
     return rc

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -113,164 +113,9 @@ zos_job_output:
 
 import json
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import job_output
 from os import chmod, path, remove
 from tempfile import NamedTemporaryFile
-
-
-def get_job_json(jobid, owner, jobname, ddname, module):
-    get_job_detail_json_rexx = """/* REXX */
-arg options
-parse var options param
-upper param
-parse var param 'JOBID=' jobid ' OWNER=' owner,
-  ' JOBNAME=' jobname ' DDNAME=' ddname
-
-rc=isfcalls('ON')
-
-jobid = strip(jobid,'L')
-if (jobid <> '') then do
-  ISFFILTER='JobID EQ '||jobid
-end
-owner = strip(owner,'L')
-if (owner <> '') then do
-  ISFOWNER=owner
-end
-jobname = strip(jobname,'L')
-if (jobname <> '') then do
-  ISFPREFIX=jobname
-end
-ddname = strip(ddname,'L')
-if (ddname == '?') then do
-  ddname = ''
-end
-
-Address SDSF "ISFEXEC ST (ALTERNATE DELAYED)"
-if rc<>0 then do
-  Say '{"jobs":[]}'
-  Exit 0
-end
-
-if isfrows == 0 then do
-  Say '{"jobs":[]}'
-end
-else do
-  Say '{"jobs":['
-  do ix=1 to isfrows
-    if ix<>1 then do
-      Say ','
-    end
-    Say '{'
-    Say '"'||'job_id'||'":"'||value('JOBID'||"."||ix)||'",'
-    Say '"'||'job_name'||'":"'||value('JNAME'||"."||ix)||'",'
-    Say '"'||'subsystem'||'":"'||value('ESYSID'||"."||ix)||'",'
-    Say '"'||'owner'||'":"'||value('OWNERID'||"."||ix)||'",'
-    Say '"'||'ret_code'||'":{"'||'msg'||'":"'||value('RETCODE'||"."||ix)||'"},'
-    Say '"'||'class'||'":"'||value('JCLASS'||"."||ix)||'",'
-    Say '"'||'content-type'||'":"'||value('JTYPE'||"."||ix)||'",'
-    Say '"'||'changed'||'":"'||'false'||'",'
-    Say '"'||'failed'||'":"'||'false'||'",'
-    Address SDSF "ISFACT ST TOKEN('"TOKEN.ix"') PARM(NP ?)",
-"("prefix JDS_
-    lrc=rc
-    if lrc<>0 | JDS_DDNAME.0 == 0 then do
-      Say '"ddnames":[]'
-    end
-    else do
-      Say '"ddnames":['
-      do jx=1 to JDS_DDNAME.0
-        if jx<>1 & ddname == '' then do
-          Say ','
-        end
-        if ddname == '' | ddname == value('JDS_DDNAME'||"."||jx) then do
-          Say '{'
-          Say '"'||'ddname'||'":"'||value('JDS_DDNAME'||"."||jx)||'",'
-          Say '"'||'record-count'||'":"'||value('JDS_RECCNT'||"."||jx)||'",'
-          Say '"'||'id'||'":"'||value('JDS_DSID'||"."||jx)||'",'
-          Say '"'||'stepname'||'":"'||value('JDS_STEPN'||"."||jx)||'",'
-          Say '"'||'procstep'||'":"'||value('JDS_PROCS'||"."||jx)||'",'
-          Say '"'||'byte-count'||'":"'||value('JDS_BYTECNT'||"."||jx)||'",'
-          Say '"'||'content'||'":['
-          Address SDSF "ISFBROWSE ST TOKEN('"TOKEN.ix"')"
-          do kx=1 to isfline.0
-            if kx<>1 then do
-              Say ','
-            end
-            Say '"'||escapeNewLine(escapeDoubleQuote(isfline.kx))||'"'
-          end
-          Say ']'
-          Say '}'
-        end
-      end
-      Say ']'
-    end
-    Say '}'
-  end
-  Say ']}'
-end
-
-rc=isfcalls('OFF')
-
-return 0
-
-escapeDoubleQuote: Procedure
-Parse Arg string
-out=''
-Do While Pos('"',string)<>0
-   Parse Var string prefix '"' string
-   out=out||prefix||'\\"'
-End
-Return out||string
-
-escapeNewLine: Procedure
-Parse Arg string
-Return translate(string, '4040'x, '1525'x)
-"""
-    try:
-        dirname, scriptname = _copy_temp_file(get_job_detail_json_rexx)
-        if jobid is None:
-            jobid = ''
-        if owner is None:
-            owner = ''
-        if jobname is None:
-            jobname = ''
-        if ddname is None or ddname == '?':
-            ddname = ''
-        jobid_param = 'jobid=' + jobid
-        owner_param = 'owner=' + owner
-        jobname_param = 'jobname=' + jobname
-        ddname_param = 'ddname=' + ddname
-        cmd = [dirname + '/' + scriptname, jobid_param, owner_param,
-               jobname_param, ddname_param]
-
-        rc, out, err = module.run_command(args=_list_to_string(cmd),
-                                          cwd=dirname,
-                                          use_unsafe_shell=True)
-    except Exception:
-        raise
-    finally:
-        remove(dirname + "/" + scriptname)
-    return rc, out, err
-
-
-def _list_to_string(s):
-    str1 = " "
-    return str1.join(s)
-
-
-def _copy_temp_file(content):
-    delete_on_close = False
-    try:
-        tmp_file = NamedTemporaryFile(delete=delete_on_close)
-        with open(tmp_file.name, 'w') as f:
-            f.write(content)
-        f.close()
-        chmod(tmp_file.name, 0o755)
-        dirname = path.dirname(tmp_file.name)
-        scriptname = path.basename(tmp_file.name)
-    except Exception:
-        remove(tmp_file)
-        raise
-    return dirname, scriptname
 
 
 def run_module():
@@ -283,29 +128,19 @@ def run_module():
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
 
-    job_id = module.params.get("job_id")
-    job_name = module.params.get("job_name")
-    owner = module.params.get("owner")
-    ddname = module.params.get("ddname")
+    job_id = module.params.get("job_id") or ""
+    job_name = module.params.get("job_name") or ""
+    owner = module.params.get("owner") or ""
+    ddname = module.params.get("ddname") or ""
 
-    if job_id is None and job_name is None and owner is None:
+    if not job_id and not job_name and not owner:
         module.fail_json(msg="Please provide a job_id or job_name or owner")
 
-    job_detail_json = {}
-    rc, out, err = get_job_json(job_id, owner,
-                                job_name, ddname, module)
-    if rc != 0:
-        module.fail_json(msg=err, rc=rc)
-    if not out:
-        module.fail_json(msg="No job output was found.")
-    else:
-        job_detail_json = json.loads(out, strict=False)
-
+    try:
+        job_detail_json = job_output(module, job_id, owner, job_name, ddname)
+    except Exception as e:
+        module.fail_json(msg=str(e))
     module.exit_json(zos_job_output=job_detail_json)
-
-
-class Error(Exception):
-    pass
 
 
 def main():

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -116,9 +116,15 @@ jobs:
                 msg:
                     description: Holds the return code (eg. "CC 0000")
                     type: str
-        return_code:
-            description: return code converted to integer value
-            type: int
+                msg_code: 
+                    description: Holds the return code string (eg. "00", "S0C4")
+                    type: str
+                msg_txt: 
+                    description: Holds additional information related to the job that may be useful to the user.
+                    type: str
+                code: 
+                    description: return code converted to integer value (when possible)
+                    type: int
 changed:
   description: Indicates if any changes were made during module operation
   type: bool

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -64,7 +64,7 @@ EXAMPLES = r'''
     ddname: "?"
 '''
 RETURN = '''
-zos_job_output:
+jobs:
     description: list of job output.
     returned: success
     type: list[dict]
@@ -81,7 +81,7 @@ zos_job_output:
         class:
             description: class
             type: str
-        content-type:
+        content_type:
             description: content type
             type: str
         ddnames:
@@ -91,7 +91,7 @@ zos_job_output:
                 ddname:
                     description: data definition name
                     type: str
-                record-count:
+                record_count:
                     description: record count
                     type: int
                 id:
@@ -103,12 +103,25 @@ zos_job_output:
                 procstep:
                     description: proc step
                     type: str
-                byte-count:
+                byte_count:
                     description: byte count
                     type: int
                 content:
                     description: ddname content
                     type: list[str]
+        ret_code:
+            description: return code output taken directly from job log
+            type: dict
+            contains:
+                msg:
+                    description: Holds the return code (eg. "CC 0000")
+                    type: str
+        return_code:
+            description: return code converted to integer value
+            type: int
+changed:
+  description: Indicates if any changes were made during module operation
+  type: bool
 '''
 
 import json
@@ -137,10 +150,11 @@ def run_module():
         module.fail_json(msg="Please provide a job_id or job_name or owner")
 
     try:
-        job_detail_json = job_output(module, job_id, owner, job_name, ddname)
+        results = job_output(module, job_id, owner, job_name, ddname)
+        results['changed'] = False
     except Exception as e:
         module.fail_json(msg=str(e))
-    module.exit_json(zos_job_output=job_detail_json)
+    module.exit_json(**results)
 
 
 def main():

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -7,7 +7,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION=r'''
+DOCUMENTATION='''
 module: zos_job_submit
 author: Xiao Yuan Ma <bjmaxy@cn.ibm.com>
 short_description: The zos_job_submit module allows you to submit a job and optionally monitor for its execution.
@@ -20,11 +20,11 @@ options:
   src:
     required: true
     description:
-      - The source directory or data set containing the JCL to submit. 
-      - It could be Physical sequential data set or a partitioned data set qualified 
+      - The source directory or data set containing the JCL to submit.
+      - It could be Physical sequential data set or a partitioned data set qualified
         by a member or a path. (e.g "USER.TEST","USER.JCL(TEST)")
       - Or an USS file. (e.g "/u/tester/demo/sample.jcl")
-      - Or an LOCAL file in ansible control node.(e.g "/User/tester/ansible-playbook/sample.jcl") 
+      - Or an LOCAL file in ansible control node.(e.g "/User/tester/ansible-playbook/sample.jcl")
   location:
     required: true
     default: DATA_SET
@@ -37,37 +37,44 @@ options:
       - DATA_SET can be a PDS, PDSE, or sequential data set.
       - LOCAL means locally to the ansible control node.
   wait:
-    required: false 
+    required: false
     choices:
       - true
       - false
     description:
       - Wait for the Job to finish and capture the output. Default is false.
-      - User can specify the wait time in option duration_s, default is 60s. 
+      - User can specify the wait time in option duration_s, default is 60s.
   wait_time_s:
-    required: false 
+    required: false
     type: int
     description:
-      - When wait is true, the module will wait for a maximum of 60s by default. 
-      - User can set the wait time manually in this option. 
+      - When wait is true, the module will wait for a maximum of 60s by default.
+      - User can set the wait time manually in this option.
+  max_rc:
+    required: false
+    type: int
+    description:
+      - Specifies the maximum return code  for the submitted job that should be allowed without failing the module.
+      - max_rc is only checked when wait=True, otherwise, it is ignored.
   return_output:
-    required: false 
+    required: false
+    default: true
     choices:
       - true
-      - false 
+      - false
     description:
       - Whether to print the DD output.
       - If false, null will be returned in ddnames field.
   volume:
     required: false
     description:
-      - The volume serial (VOLSER) where the data set resides. The option 
-        is required only when the data set is not catalogued on the system. 
+      - The volume serial (VOLSER) where the data set resides. The option
+        is required only when the data set is not catalogued on the system.
         Ignored for USS and LOCAL.
   encoding:
     required: false
-    default: UTF-8 
-    choices: 
+    default: UTF-8
+    choices:
       - UTF-8
       - ASCII
       - ISO-8859-1
@@ -75,194 +82,150 @@ options:
       - IBM-037
       - IBM-1047
     description:
-      - The encoding of the local file on the ansible control node. 
-      - If it is UTF-8, ASCII, ISO-8859-1, the file will be converted to EBCDIC on the z/OS platform. 
-      - If it is EBCDIC, IBM-037, IBM-1047, the file will be unchanged when submitted on the z/OS platform. 
+      - The encoding of the local file on the ansible control node.
+      - If it is UTF-8, ASCII, ISO-8859-1, the file will be converted to EBCDIC on the z/OS platform.
+      - If it is EBCDIC, IBM-037, IBM-1047, the file will be unchanged when submitted on the z/OS platform.
 '''
 
 RETURN = '''
-zos_job_output:
-    description: list of job output.
-    returned: success
-    type: list[dict]
-    contains:
-        job_id:
-            description: job ID
-            type: str
-        job_name:
-            description: job name
-            type: str
-        subsystem:
-            description: subsystem
-            type: str
-        class:
-            description: class
-            type: str
-        content-type:
-            description: content type
-            type: str
-        ddnames:
-            description: list of data definition name
-            type: list[dict]
-            contains:
-                ddname:
-                    description: data definition name
-                    type: str
-                record-count:
-                    description: record count
-                    type: int
-                id:
-                    description: id
-                    type: str
-                stepname:
-                    description: step name
-                    type: str
-                procstep:
-                    description: proc step
-                    type: str
-                byte-count:
-                    description: byte count
-                    type: int
-                content:
-                    description: ddname content
-                    type: list[str]
-'''
-
-RETURN = r'''
 jobs:
-    description: The list of jobs that matches the job name or job id and optionally the owner
-    returned: success
-    type: list[dict]
-    contains:
-       job_name:
-          description: job name
+  description: The list of jobs that matches the job name or job id and optionally the owner
+  returned: success
+  type: list[dict]
+  contains:
+    job_name:
+      description: job name
+      type: str
+    job_id:
+      description: job name
+      type: str
+    duration:
+      description: duration
+      type: int
+    ddnames:
+      description: all ddnames
+      type: list[dict]
+      contains:
+        ddname:
+          description: data definition name
           type: str
-       job_id:
-          description: job name
-          type: str
-       change:
-          description: change
-          type: bool
-       failed:
-          description: failed
-          type: bool
-       duration:
-          description: duration
+        record_count:
+          description: record count
           type: int
-       ddnames:
-           description: all ddnames
-           type: list[dict]
-           contains:
-               ddname:
-                 description: ddname
-                 type: str
-               step_name:
-                  description: step name
-                  type: str
-               content:
-                  description: conetent
-                  type: str
-               ret_code: 
-                   description: return code
-                   type: list[dict]
-                   contains:
-                      msg:
-                        description: contains
-                        type: str
-                      code:
-                        description: code
-                        type: str
-                      msg_details: 
-                        description: message
-                        type: str
-changed: 
-    description: Indicates if any changes were made during module operation
-    type: bool  
-message:
-    description: The output message that the sample module generates
-    returned: success
-    type: str 
+        id:
+          description: id
+          type: str
+        stepname:
+          description: step name
+          type: str
+        procstep:
+          description: proc step
+          type: str
+        byte_count:
+          description: byte count
+          type: int
+        content:
+          description: ddname content
+          type: list[str]
+    ret_code:
+      description: return code output taken directly from job log
+      type: dict
+      contains:
+        msg:
+          description: Holds the return code (eg. "CC 0000")
+          type: str
+    return_code:
+      description: return code converted to integer value
+      type: int
 
+changed:
+  description: Indicates if any changes were made during module operation
+  type: bool
+message:
+  description: The output message that the sample module generates
+  returned: success
+  type: str
 '''
 
-EXAMPLES = r'''
-  - name: Submit the JCL 
-    zos_job_submit:
-       src: TEST.UTILs(SAMPLE)
-       location: DATA_SET
-       wait: false
-       volume:
-    register: response
-  
-  - name: Submit USS job
-    zos_job_submit:
-        src: /u/tester/demo/sample.jcl
-        location: USS
-        wait: false
-        volume:
-        return_output: false
-  
-  - name: Submit LOCAL job
-    zos_job_submit:
-      src: /Users/maxy/ansible-playbooks/provision/sample.jcl
-      location: LOCAL
-      wait: false
-      encoding: UTF-8
-      volume:
-  
-  - name: Submit uncatalogued PDS job
-    zos_job_submit:
-       src: TEST.UNCATLOG.JCL(SAMPLE)
-       location: DATA_SET
-       wait: false
-       volume: P2SS01
-  
-  - name: Submit long running PDS job, and wait for the job to finish
-    zos_job_submit:
-       src: TEST.UTILs(LONGRUN)
-       location: DATA_SET
-       wait: true  
-       wait_time_s: 30    
+EXAMPLES = '''
+- name: Submit the JCL
+  zos_job_submit:
+    src: TEST.UTILs(SAMPLE)
+    location: DATA_SET
+    wait: false
+    volume:
+  register: response
+
+- name: Submit USS job
+  zos_job_submit:
+    src: /u/tester/demo/sample.jcl
+    location: USS
+    wait: false
+    volume:
+    return_output: false
+
+- name: Submit LOCAL job
+  zos_job_submit:
+    src: /Users/maxy/ansible-playbooks/provision/sample.jcl
+    location: LOCAL
+    wait: false
+    encoding: UTF-8
+    volume:
+
+- name: Submit uncatalogued PDS job
+  zos_job_submit:
+    src: TEST.UNCATLOG.JCL(SAMPLE)
+    location: DATA_SET
+    wait: false
+    volume: P2SS01
+
+- name: Submit long running PDS job, and wait for the job to finish
+  zos_job_submit:
+    src: TEST.UTILs(LONGRUN)
+    location: DATA_SET
+    wait: true
+    wait_time_s: 30
+ 
 
 EXAMPLE RESULTS:
-     "msg": {
-         "jobs":[
-      {
-         "job_id":"JOB32881",
-         "job_name":"TEST",
-         "changed":true,
-         "failed":false,
-         "duration":0,
-         "ddnames":[
+"jobs": [
+    {
+        "job_id": "JOB32881",
+        "job_name": "TEST",
+        "changed": true,
+        "failed": false,
+        "duration": 0,
+        "ddnames": [
             {
-               "ddname":"JESMSGLG",
-               "step_name":"JES2",
-               "content":[
-                  "J E S 2  J O B  L O G  --  S Y S T E M  M V 2 C  --  N O D E ...."
-               ]
+                "ddname": "JESMSGLG",
+                "step_name": "JES2",
+                "content": [
+                    "J E S 2  J O B  L O G  --  S Y S T E M  M V 2 C  --  N O D E ...."
+                ]
             },
             {
-               "ddname":"JESJCL",
-               "step_name":"JES2",
-               "content":[
-                  "1 //TEST JOB                       JOB32881"
-               ]
+                "ddname": "JESJCL",
+                "step_name": "JES2",
+                "content": [
+                    "1 //TEST JOB                       JOB32881"
+                ]
             },
             {
-               "ddname":"JESYSMSG",
-               "step_name":"JES2",
-               "content":[
-                  "ICH70001I TESTER"
-               ]
+                "ddname": "JESYSMSG",
+                "step_name": "JES2",
+                "content": [
+                    "ICH70001I TESTER"
+                ]
             }
-         ],
-         "ret_code":{
-            "msg":  "CC 0000" ,
-            "code": "0000" ,
+        ],
+        "ret_code": {
+            "msg": "CC 0000",
+            "code": "0000",
             "msg_detail": "Submit JCL operation succeeded",
-         },
-      },
-   ]
+        },
+        "return_code": 0,
+    },
+]
 '''
 
 from ansible.module_utils.basic import *
@@ -338,30 +301,12 @@ def get_job_info(module, jobId, return_output):
         output = query_jobs_status(jobId)
     except SubmitJCLError as e:
         raise SubmitJCLError(e.msg)
-    # dds = Jobs.list_dds(job_id=jobId)
-    # joboutput = []
+
     if return_output is True:
         result = job_output(module, job_id=jobId)
-        # for item in dds:
-        #     dataset = item.get("dataset")
-        #     stepname = item.get("stepname")
-        #     content = Jobs.read_output(jobId, stepname, dataset)
-        #     joboutput.append({
-        #         'stepname': stepname,
-        #         'ddname': dataset,
-        #         'content': content,
-        #     })
-        # result['ddnames'] = joboutput
-        
-    # else:
-    #     result['ddnames'] = None
 
-    # # ret_code = parsing_job(output[0])
-
-    # result['job_id'] = jobId
     result['changed'] = True
-    # result['job_name'] = output[0].get("name")
-    # result['ret_code'] = ret_code
+
     
 
     return result
@@ -444,6 +389,11 @@ def parsing_job(job_raw):
 
     return ret_code
 
+def assert_valid_return_code(max_rc, found_rc):
+    if found_rc == None or max_rc < int(found_rc):
+        raise SubmitJCLError('')
+        
+
 def run_module():
     location_type = {'DATA_SET', 'USS', 'LOCAL', None}
 
@@ -454,7 +404,8 @@ def run_module():
         encoding=dict(type='str', required=False, default='UTF-8'),
         volume=dict(type='str', required=False),
         return_output=dict(type='bool', required=False, default='True'),
-        wait_time_s=dict(type='int', required=False)
+        wait_time_s=dict(type='int', required=False),
+        max_rc=dict(type='int', required=False)
     )
 
     module = AnsibleModule(
@@ -474,7 +425,7 @@ def run_module():
     results = dict(
         jobs=[]
     )
-    jobs = []
+
 
     location = module.params.get("location")
     volume = module.params.get("volume")
@@ -482,7 +433,8 @@ def run_module():
     src = module.params.get('src')
     return_output = module.params.get('return_output')
     wait_time_s = module.params.get('wait_time_s')
-
+    max_rc = module.params.get('max_rc')
+    
     if wait_time_s is None:
         wait_time_s = POLLING_THRESHOLD
     else:
@@ -548,17 +500,18 @@ def run_module():
 
     try:
         result = get_job_info(module, jobId, return_output)
+        if wait == True and return_output == True and max_rc != None:
+            assert_valid_return_code(max_rc, result.get('jobs')[0].get('return_code'))
     except SubmitJCLError as e:
-        module.fail_json(msg=e.msg, **result)
+        module.fail_json(msg=str(e), **result)
     except Exception as e:
-        module.fail_json(msg=e.msg, **result)
+        module.fail_json(msg=str(e), **result)
     result['duration'] = duration
     if duration == wait_time_s:
         results['message'] = {'msg': 'Submit JCL operation succeeded but it is a long running job. Timeout is '+ str(wait_time_s)+' seconds.'}
 
-    jobs.append(result)
     results['changed'] = True
-    results['jobs'] = jobs
+    # results['jobs'] = jobs
     module.exit_json(**results)
 
 

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -196,43 +196,129 @@ EXAMPLES = '''
 
 EXAMPLE RESULTS:
 "jobs": [
+{
+    "class": "R",
+    "content_type": "JOB",
+    "ddnames": [
     {
-        "job_id": "JOB32881",
-        "job_name": "TEST",
-        "changed": true,
-        "failed": false,
-        "duration": 0,
-        "ddnames": [
-            {
-                "ddname": "JESMSGLG",
-                "step_name": "JES2",
-                "content": [
-                    "J E S 2  J O B  L O G  --  S Y S T E M  M V 2 C  --  N O D E ...."
-                ]
-            },
-            {
-                "ddname": "JESJCL",
-                "step_name": "JES2",
-                "content": [
-                    "1 //TEST JOB                       JOB32881"
-                ]
-            },
-            {
-                "ddname": "JESYSMSG",
-                "step_name": "JES2",
-                "content": [
-                    "ICH70001I TESTER"
-                ]
-            }
+        "byte_count": "775",
+        "content": [
+        "1                       J E S 2  J O B  L O G  --  S Y S T E M  S T L 1  --  N O D E  S T L 1            ",
+        "0 ",
+        " 10.25.48 JOB00134 ---- TUESDAY,   18 FEB 2020 ----",
+        " 10.25.48 JOB00134  IRR010I  USERID OMVSADM  IS ASSIGNED TO THIS JOB.",
+        " 10.25.48 JOB00134  $HASP375 JES2     ESTIMATED  LINES EXCEEDED",
+        " 10.25.48 JOB00134  ICH70001I OMVSADM  LAST ACCESS AT 10:25:47 ON TUESDAY, FEBRUARY 18, 2020",
+        " 10.25.48 JOB00134  $HASP375 HELLO    ESTIMATED  LINES EXCEEDED",
+        " 10.25.48 JOB00134  $HASP373 HELLO    STARTED - INIT 3    - CLASS R        - SYS STL1",
+        " 10.25.48 JOB00134  SMF000I  HELLO       STEP0001    IEBGENER    0000",
+        " 10.25.48 JOB00134  $HASP395 HELLO    ENDED - RC=0000",
+        "0------ JES2 JOB STATISTICS ------",
+        "-  18 FEB 2020 JOB EXECUTION DATE",
+        "-           16 CARDS READ",
+        "-           59 SYSOUT PRINT RECORDS",
+        "-            0 SYSOUT PUNCH RECORDS",
+        "-            6 SYSOUT SPOOL KBYTES",
+        "-         0.00 MINUTES EXECUTION TIME"
         ],
-        "ret_code": {
-            "msg": "CC 0000",
-            "code": "0000",
-            "msg_detail": "Submit JCL operation succeeded",
-        },
-        "return_code": 0,
+        "ddname": "JESMSGLG",
+        "id": "2",
+        "procstep": "",
+        "record_count": "17",
+        "stepname": "JES2"
     },
+    {
+        "byte_count": "574",
+        "content": [
+        "         1 //HELLO    JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,       JOB00134",
+        "           //             MSGCLASS=X,MSGLEVEL=1,NOTIFY=S0JM                                ",
+        "           //*                                                                             ",
+        "           //* PRINT \"HELLO WORLD\" ON JOB OUTPUT                                           ",
+        "           //*                                                                             ",
+        "           //* NOTE THAT THE EXCLAMATION POINT IS INVALID EBCDIC FOR JCL                   ",
+        "           //*   AND WILL CAUSE A JCL ERROR                                                ",
+        "           //*                                                                             ",
+        "         2 //STEP0001 EXEC PGM=IEBGENER                                                    ",
+        "         3 //SYSIN    DD DUMMY                                                             ",
+        "         4 //SYSPRINT DD SYSOUT=*                                                          ",
+        "         5 //SYSUT1   DD *                                                                 ",
+        "         6 //SYSUT2   DD SYSOUT=*                                                          ",
+        "         7 //                                                                              "
+        ],
+        "ddname": "JESJCL",
+        "id": "3",
+        "procstep": "",
+        "record_count": "14",
+        "stepname": "JES2"
+    },
+    {
+        "byte_count": "1066",
+        "content": [
+        " ICH70001I OMVSADM  LAST ACCESS AT 10:25:47 ON TUESDAY, FEBRUARY 18, 2020",
+        " IEF236I ALLOC. FOR HELLO STEP0001",
+        " IEF237I DMY  ALLOCATED TO SYSIN",
+        " IEF237I JES2 ALLOCATED TO SYSPRINT",
+        " IEF237I JES2 ALLOCATED TO SYSUT1",
+        " IEF237I JES2 ALLOCATED TO SYSUT2",
+        " IEF142I HELLO STEP0001 - STEP WAS EXECUTED - COND CODE 0000",
+        " IEF285I   OMVSADM.HELLO.JOB00134.D0000102.?            SYSOUT        ",
+        " IEF285I   OMVSADM.HELLO.JOB00134.D0000101.?            SYSIN         ",
+        " IEF285I   OMVSADM.HELLO.JOB00134.D0000103.?            SYSOUT        ",
+        " IEF373I STEP/STEP0001/START 2020049.1025",
+        " IEF032I STEP/STEP0001/STOP  2020049.1025 ",
+        "         CPU:     0 HR  00 MIN  00.00 SEC    SRB:     0 HR  00 MIN  00.00 SEC    ",
+        "         VIRT:    60K  SYS:   240K  EXT:        0K  SYS:    11548K",
+        "         ATB- REAL:                     8K  SLOTS:                     0K",
+        "              VIRT- ALLOC:      10M SHRD:       0M",
+        " IEF375I  JOB/HELLO   /START 2020049.1025",
+        " IEF033I  JOB/HELLO   /STOP  2020049.1025 ",
+        "         CPU:     0 HR  00 MIN  00.00 SEC    SRB:     0 HR  00 MIN  00.00 SEC    "
+        ],
+        "ddname": "JESYSMSG",
+        "id": "4",
+        "procstep": "",
+        "record_count": "19",
+        "stepname": "JES2"
+    },
+    {
+        "byte_count": "251",
+        "content": [
+        "1DATA SET UTILITY - GENERATE                                                                       PAGE 0001             ",
+        "-IEB352I WARNING: ONE OR MORE OF THE OUTPUT DCB PARMS COPIED FROM INPUT                                                  ",
+        "                                                                                                                         ",
+        " PROCESSING ENDED AT EOD                                                                                                 "
+        ],
+        "ddname": "SYSPRINT",
+        "id": "102",
+        "procstep": "",
+        "record_count": "4",
+        "stepname": "STEP0001"
+    },
+    {
+        "byte_count": "49",
+        "content": [
+        " HELLO, WORLD                                                                    "
+        ],
+        "ddname": "SYSUT2",
+        "id": "103",
+        "procstep": "",
+        "record_count": "1",
+        "stepname": "STEP0001"
+    }
+    ],
+    "job_id": "JOB00134",
+    "job_name": "HELLO",
+    "owner": "OMVSADM",
+    "ret_code": {
+    "code": 0,
+    "msg": "CC 0000",
+    "msg_code": "0000",
+    "msg_txt": ""
+    },
+    "subsystem": "STL1"
+}
 ]
+
 '''
 
 from ansible.module_utils.basic import *


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There was an issue in *zos_job_submit* that caused failure when attempting to retrieve the output of a job with a large log size. This PR removes the offending API and replaces it with a shared job output retrieval utility.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Hotfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- modules/zos_job_submit module 
- modules/zos_job_output module
- module_utils/job
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Submit a job which generates a large amount of output to the job log. (eg. DBDGEN) using *zos_job_submit*

