### PR TITLE
Update/496/module security updates

### DIFF
--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -8,7 +8,6 @@ from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
 import os
-from tempfile import mktemp
 
 
 class ActionModule(ActionBase):

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2019, 2020 
+# Copyright (c) IBM Corporation 2019, 2020
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -8,12 +8,12 @@ from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes, to_text
 import os
+from tempfile import mktemp
 
-ZOAU_TEMP_USS = '/tmp/ansible-temp-1'
+
 class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
-
         ''' handler for file transfer operations '''
         if task_vars is None:
             task_vars = dict()
@@ -27,10 +27,16 @@ class ActionModule(ActionBase):
         if module_args['location'] == 'LOCAL':
 
             source = self._task.args.get('src', None)
-            dest = ZOAU_TEMP_USS
+
+            # Get a temporary file on the managed node
+            dest_path = self._execute_module(
+                module_name='tempfile',
+                module_args={},
+                task_vars=task_vars,
+            ).get('path')
 
             result['failed'] = True
-            if source is None or dest is None:
+            if source is None or dest_path is None:
                 result['msg'] = "src and dest are required"
             elif source is not None and source.endswith("/"):
                 result['msg'] = "src must be a file"
@@ -67,12 +73,13 @@ class ActionModule(ActionBase):
                 self._remove_tmp_path(tmp)
                 return result
 
-            if self._connection._shell.path_has_trailing_slash(dest):
-                dest_file = self._connection._shell.join_path(dest, source_rel)
-            else:
-                dest_file = self._connection._shell.join_path(dest)
+            # if self._connection._shell.path_has_trailing_slash(dest):
+            #     dest_file = self._connection._shell.join_path(dest, source_rel)
+            # else:
+            dest_file = self._connection._shell.join_path(dest_path)
 
-            dest_status = self._execute_remote_stat(dest_file, all_vars=task_vars, follow=False)
+            dest_status = self._execute_remote_stat(
+                dest_file, all_vars=task_vars, follow=False)
 
             if dest_status['exists'] and dest_status['isdir']:
                 self._remove_tmp_path(tmp)
@@ -81,7 +88,6 @@ class ActionModule(ActionBase):
                 return result
 
             tmp_src = self._connection._shell.join_path(tmp, 'source')
-
 
             remote_path = None
             remote_path = self._transfer_file(source_full, tmp_src)
@@ -92,12 +98,13 @@ class ActionModule(ActionBase):
             result = {}
             copy_module_args = {}
             module_args = self._task.args.copy()
+            module_args['temp_file'] = dest_path
 
             copy_module_args.update(
                 dict(
                     src=tmp_src,
-                    dest=dest,
-                    mode='0755',
+                    dest=dest_path,
+                    mode='0600',
                     _original_basename=source_rel,
                 )
             )
@@ -123,7 +130,5 @@ class ActionModule(ActionBase):
                     task_vars=task_vars,
                 )
             )
-
-
 
         return result

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -3,7 +3,7 @@
 
 from tempfile import NamedTemporaryFile
 from os import chmod, path, remove
-from stat import S_IEXEC, S_IREAD
+from stat import S_IEXEC, S_IREAD, S_IWRITE 
 import json
 import re
 
@@ -183,7 +183,7 @@ Return translate(string, '4040'x, '1525'x)
         tmp = NamedTemporaryFile(delete=True)
         with open(tmp.name, 'w') as f:
             f.write(get_job_detail_json_rexx)
-        chmod(tmp.name, S_IEXEC | S_IREAD)
+        chmod(tmp.name, S_IEXEC | S_IREAD | S_IWRITE)
         args = [jobid_param, owner_param,
             jobname_param, ddname_param]
 

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -565,18 +565,13 @@ def create_data_set_member(name):
     """Create a data set member if the partitioned data set exists.
     Also used to overwrite a data set member if empty replacement is desired.
     Raises DatasetNotFoundError if data set cannot be found."""
-    try:
-        base_dsname = name.split('(')[0]
-        if not base_dsname or not data_set_exists(base_dsname):
-            raise DatasetNotFoundError(name)
-        tmp_file = tempfile.NamedTemporaryFile(delete=False)
-        rc, stdout, stderr = run_command('cp {} "//\'{}\'"'.format(tmp_file.name, name))
-        if rc != 0:
-            raise DatasetMemberCreateError(name, rc)
-    except Exception:
-        raise
-    finally:
-        os.remove(tmp_file.name)
+    base_dsname = name.split('(')[0]
+    if not base_dsname or not data_set_exists(base_dsname):
+        raise DatasetNotFoundError(name)
+    tmp_file = tempfile.NamedTemporaryFile(delete=True)
+    rc, stdout, stderr = run_command('cp {} "//\'{}\'"'.format(tmp_file.name, name))
+    if rc != 0:
+        raise DatasetMemberCreateError(name, rc)
     return
 
 def delete_data_set_member(name):

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -322,15 +322,14 @@ EXAMPLE RESULTS:
 '''
 
 from ansible.module_utils.basic import *
+from pipes import quote
 from zoautil_py import Jobs
 from time import sleep
 from os import chmod, path
 from tempfile import NamedTemporaryFile
 import re
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import job_output
-
-ZOAUTIL_TEMP_USS = "/tmp/ansible-temp-1"
-ZOAUTIL_TEMP_USS2 = "/tmp/ansible-temp-2"
+from stat import S_IEXEC, S_IREAD
 
 """time between job query checks to see if a job has completed, default 1 second"""
 POLLING_INTERVAL = 1
@@ -382,7 +381,7 @@ def copy_rexx_and_run(script,src,vol,module):
     tmp_file = NamedTemporaryFile(delete=delete_on_close)
     with open(tmp_file.name, 'w') as f:
         f.write(script)
-    chmod(tmp_file.name, 0o755)
+    chmod(tmp_file.name, stat.S_IEXEC | stat.S_IREAD)
     pathName = path.dirname(tmp_file.name)
     scriptName = path.basename(tmp_file.name)
     rc, stdout, stderr = module.run_command(['./' + scriptName, src, vol], cwd=pathName)
@@ -499,7 +498,8 @@ def run_module():
         volume=dict(type='str', required=False),
         return_output=dict(type='bool', required=False, default=True),
         wait_time_s=dict(type='int', required=False),
-        max_rc=dict(type='int', required=False)
+        max_rc=dict(type='int', required=False),
+        temp_file=dict(type='path', required=False)
     )
 
     module = AnsibleModule(
@@ -528,7 +528,11 @@ def run_module():
     return_output = module.params.get('return_output')
     wait_time_s = module.params.get('wait_time_s')
     max_rc = module.params.get('max_rc')
-    
+    # get temporary file names for copied files
+    temp_file = module.params.get('temp_file')
+    if temp_file:
+        temp_file_2 = NamedTemporaryFile(delete=True)
+        
     if wait_time_s is None:
         wait_time_s = POLLING_THRESHOLD
     else:
@@ -558,12 +562,12 @@ def run_module():
                 # For local file, it has been copied to the temp directory in action plugin.
                 encoding = module.params.get('encoding')
                 if encoding == 'EBCDIC' or encoding == 'IBM-037' or encoding == 'IBM-1047':
-                    jobId = submit_uss_jcl(ZOAUTIL_TEMP_USS, module)
+                    jobId = submit_uss_jcl(temp_file, module)
                 elif encoding == 'UTF-8' or encoding == 'ISO-8859-1' or encoding == 'ASCII' or encoding == None:  ## 'UTF-8' 'ASCII' encoding will be converted.
-                    (conv_rc, stdout, stderr) = module.run_command('iconv -f ISO8859-1 -t IBM-1047 %s > %s' % (ZOAUTIL_TEMP_USS, ZOAUTIL_TEMP_USS2),
+                    (conv_rc, stdout, stderr) = module.run_command('iconv -f ISO8859-1 -t IBM-1047 %s > %s' % (quote(temp_file), quote(temp_file_2.name)),
                                                                use_unsafe_shell=True)
                     if conv_rc == 0:
-                        jobId = submit_uss_jcl(ZOAUTIL_TEMP_USS2, module)
+                        jobId = submit_uss_jcl(temp_file_2.name, module)
                     else:
                         module.fail_json(msg='The Local file encoding conversion failed. Please check the source file.'+ stderr, **result)
                 else:
@@ -600,6 +604,9 @@ def run_module():
         module.fail_json(msg=str(e), **result)
     except Exception as e:
         module.fail_json(msg=str(e), **result)
+    finally:
+        if temp_file:
+            os.remove(temp_file)
     result['duration'] = duration
     if duration == wait_time_s:
         result['message'] = {'stdout': 'Submit JCL operation succeeded but it is a long running job. Timeout is '+ str(wait_time_s)+' seconds.'}

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -329,7 +329,7 @@ from os import chmod, path
 from tempfile import NamedTemporaryFile
 import re
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import job_output
-from stat import S_IEXEC, S_IREAD
+from stat import S_IEXEC, S_IREAD, S_IWRITE
 
 """time between job query checks to see if a job has completed, default 1 second"""
 POLLING_INTERVAL = 1
@@ -381,7 +381,7 @@ def copy_rexx_and_run(script,src,vol,module):
     tmp_file = NamedTemporaryFile(delete=delete_on_close)
     with open(tmp_file.name, 'w') as f:
         f.write(script)
-    chmod(tmp_file.name, stat.S_IEXEC | stat.S_IREAD)
+    chmod(tmp_file.name, stat.S_IEXEC | stat.S_IREAD | S_IWRITE)
     pathName = path.dirname(tmp_file.name)
     scriptName = path.basename(tmp_file.name)
     rc, stdout, stderr = module.run_command(['./' + scriptName, src, vol], cwd=pathName)

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -29,7 +29,7 @@ def test_zos_job_output_no_job_id(ansible_zos_module):
     for result in results.contacted.values():
         print(result)
         assert result.get('changed') is False
-        assert result.get('zos_job_output') is not None
+        assert result.get('jobs') is not None
 
 
 def test_zos_job_output_no_job_name(ansible_zos_module):
@@ -38,7 +38,7 @@ def test_zos_job_output_no_job_name(ansible_zos_module):
     for result in results.contacted.values():
         print(result)
         assert result.get('changed') is False
-        assert result.get('zos_job_output') is not None
+        assert result.get('jobs') is not None
 
 
 def test_zos_job_output_no_owner(ansible_zos_module):
@@ -47,7 +47,7 @@ def test_zos_job_output_no_owner(ansible_zos_module):
     for result in results.contacted.values():
         print(result)
         assert result.get('changed') is False
-        assert result.get('zos_job_output') is not None
+        assert result.get('jobs') is not None
 
 
 def test_zos_job_output_reject(ansible_zos_module):
@@ -68,4 +68,4 @@ def test_zos_job_output_job_exists(ansible_zos_module):
     results = hosts.all.zos_job_output(job_name='SAMPLE')
     for result in results.contacted.values():
         assert result.get('changed') is False
-        assert result.get('zos_job_output') is not None
+        assert result.get('jobs') is not None

--- a/tests/units/modules/test_zos_job_output_unit.py
+++ b/tests/units/modules/test_zos_job_output_unit.py
@@ -6,7 +6,7 @@
 import pytest
 from unittest.mock import MagicMock, Mock
 
-IMPORT_NAME = 'ibm_zos_core.plugins.modules.zos_job_output'
+IMPORT_NAME = 'ibm_zos_core.plugins.module_utils.job'
 
 dummy_return_dict = (
     0, '{"jobs":[{"changed":"false","class":"","content-type":"STC","ddnames":[],"failed":"false","job_id":"STC02502","job_name":"TCPIP","owner":"TCPIP","ret_code":{"msg":"CC 0000"},"subsystem":"S0W1"}]}', '')
@@ -26,7 +26,7 @@ def test_job_out(zos_import_mocker, job_id, job_name, owner, ddname, zoau_return
     module = MagicMock()
     module.run_command = Mock(return_value=zoau_return_value)
     try:
-        jobs.get_job_json(job_id, job_name, owner, ddname, module)
+        jobs._get_job_json_str(module, job_id, job_name, owner, ddname)
     except RuntimeError:
         passed = False
     assert passed == expected

--- a/tests/units/modules/test_zos_job_submit_unit.py
+++ b/tests/units/modules/test_zos_job_submit_unit.py
@@ -90,32 +90,32 @@ def test_submit_jcl_in_volume(zos_import_mocker, src, volume, return_value, expe
         passed = False
     assert passed == expected
 
-
-list_return_dict = [
-    {'owner': 'TESTER', 'name': 'TEST', 'id': 'JOB12345', 'status': 'AC', 'return': '0'}
-]
-listDD_return_dict = [
-    {'stepname': 'JES2', 'dataset': 'JESMSGLG', 'format': 'VB' },
-]
-output_dict = [
-    {'stepname': 'JES2',
-     'dataset': 'JESMSGLG',
-     'DDoutput': 'ICH70001I BJMAXY   LAST ACCESS AT 08:35:35 ON FRIDAY, DECEMBER 6, 2019 IEFA111I TEST IS USING THE FOLLOWING JOB RELATED SETTINGS:',}
-]
-test_data_get_info = [
-    ('JOB12345', list_return_dict, listDD_return_dict ,output_dict, True),
-    (None, None, [], [], False)
-]
-@pytest.mark.parametrize("jobid,  zoau_list_return_value, zoau_listDD_returned_value, zoau_output_dict, expected", test_data_get_info)
-def test_get_job_info(zos_import_mocker,jobid,  zoau_list_return_value, zoau_listDD_returned_value, zoau_output_dict, expected):
-    mocker, importer = zos_import_mocker
-    jobs = importer(IMPORT_NAME)
-    passed = True
-    mocker.patch('zoautil_py.Jobs.list_dds', create=True, return_value=zoau_listDD_returned_value)
-    mocker.patch('zoautil_py.Jobs.list', create=True, return_value=zoau_list_return_value)
-    mocker.patch('zoautil_py.Jobs.read_output',create=True, return_value= zoau_output_dict)
-    try:
-        jobs.get_job_info(jobid, True)
-    except jobs.SubmitJCLError:
-        passed = False
-    assert passed == expected
+# * no longer valid after restructuring of job output for module
+# list_return_dict = [
+#     {'owner': 'TESTER', 'name': 'TEST', 'id': 'JOB12345', 'status': 'AC', 'return': '0'}
+# ]
+# listDD_return_dict = [
+#     {'stepname': 'JES2', 'dataset': 'JESMSGLG', 'format': 'VB' },
+# ]
+# output_dict = [
+#     {'stepname': 'JES2',
+#      'dataset': 'JESMSGLG',
+#      'DDoutput': 'ICH70001I BJMAXY   LAST ACCESS AT 08:35:35 ON FRIDAY, DECEMBER 6, 2019 IEFA111I TEST IS USING THE FOLLOWING JOB RELATED SETTINGS:',}
+# ]
+# test_data_get_info = [
+#     ('JOB12345', list_return_dict, listDD_return_dict ,output_dict, True),
+#     (None, None, [], [], False)
+# ]
+# @pytest.mark.parametrize("jobid,  zoau_list_return_value, zoau_listDD_returned_value, zoau_output_dict, expected", test_data_get_info)
+# def test_get_job_info(zos_import_mocker,jobid,  zoau_list_return_value, zoau_listDD_returned_value, zoau_output_dict, expected):
+#     mocker, importer = zos_import_mocker
+#     jobs = importer(IMPORT_NAME)
+#     passed = True
+#     mocker.patch('zoautil_py.Jobs.list_dds', create=True, return_value=zoau_listDD_returned_value)
+#     mocker.patch('zoautil_py.Jobs.list', create=True, return_value=zoau_list_return_value)
+#     mocker.patch('zoautil_py.Jobs.read_output',create=True, return_value= zoau_output_dict)
+#     try:
+#         jobs.get_job_info(jobid, True, True)
+#     except jobs.SubmitJCLError:
+#         passed = False
+#     assert passed == expected


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes [#496](https://jsw.ibm.com/browse/NAZARE-496) . potential security holes in the zos_job_submit module & action plugin and the shared job module_utility.  I also updated unit and functional tests for any related modules to ensure none of the security updates impacted desired module behavior.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Update Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Modules:

- zos_job_submit.py

Action Plugins:

- zos_job_submit.py

Module Utilities:

- job.py

Test Cases:

- test_zos_job_output_unit.py
- test_zos_job_output_func.py
- test_zos_job_submit_unit.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Running the tool [bandit](https://pypi.org/project/bandit/) in the collection's *plugins/* directory will now only show warnings in the zos_ssh.py connection plugin. All warnings returned are from the original Ansible source for ssh.py. If the same command is run against current dev branch multiple warnings will be returned from our source.
<!--- Paste verbatim command output below, e.g. before and after your change -->

