### PR TITLE
remove original_message return parameter

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,24 +49,24 @@ html_context = {
 }
 
 # Not using these now but can see the doc here for them:
-# https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html and 
+# https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html and
 # https://sphinx-rtd-theme.readthedocs.io/en/stable/
-html_theme_options = {
-    # 'canonical_url': '',
-    # 'analytics_id': 'UA-XXXXXXX-1',  #  Provided by Google in your dashboard
-    # 'logo_only': False,
-    # 'display_version': True,
-    # 'prev_next_buttons_location': 'bottom',
-    # 'style_external_links': False,
-    # 'vcs_pageview_mode': '',
-    # 'style_nav_header_background': 'white',
-    # # Toc options
-    # 'collapse_navigation': True,
-    # 'sticky_navigation': True,
-    # 'navigation_depth': 4,
-    # 'includehidden': True,
-    # 'titles_only': False
- }
+# html_theme_options = {
+#      'canonical_url': '',
+#      'analytics_id': 'UA-XXXXXXX-1',
+#      'logo_only': False,
+#      'display_version': True,
+#      'prev_next_buttons_location': 'bottom',
+#      'style_external_links': False,
+#      'vcs_pageview_mode': '',
+#      'style_nav_header_background': 'white',
+#      # Toc options
+#      'collapse_navigation': True,
+#      'sticky_navigation': True,
+#      'navigation_depth': 4,
+#      'includehidden': True,
+#      'titles_only': False
+# }
 
 #####################################
 # © Copyright IBM Corporation 2020  #

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -33,7 +33,6 @@ installed in ``~/.ansible/collections``, see the sample output.
    https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html
 
 .. code-block:: sh
-   :emphasize-lines: 3
 
    Process install dependency map
    Starting collection install process

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -193,7 +193,6 @@ To build a collection from the git repository:
       In the output of collection installation, note the installation path to access the sample playbook:
 
       .. code-block:: sh
-         :emphasize-lines: 3
 
          Process install dependency map
          Starting collection install process

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -1,7 +1,7 @@
 Plugins
 =======
 
-Plugins that come with **IBM z/OS Core Collection** augment Ansible’s core
+Plugins that come with **IBM z/OS Core Collection** augment Ansible's core
 functionality. Ansible uses a plugin architecture to enable a rich, flexible
 and expandable feature set.
 

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -14,21 +14,21 @@ ANSIBLE_METADATA = {
     "supported_by": "community",
 }
 
-DOCUMENTATION =r'''
+DOCUMENTATION = r"""
 ---
 module: zos_job_output
 short_description: Display job output.
 description:
-  - Display the z/OS job output for a given criteria (Job id/Job name/owner) 
+  - Display the z/OS job output for a given criteria (Job id/Job name/owner)
     with/without a data definition name as a filter.
   - At least provide a job id/job name/owner.
-  - The job id can be specific such as "STC02560", or one that uses a pattern 
+  - The job id can be specific such as "STC02560", or one that uses a pattern
     such as "STC*" or "*".
-  - The job name can be specific such as "TCPIP", or one that uses a pattern 
+  - The job name can be specific such as "TCPIP", or one that uses a pattern
     such as "TCP*" or "*".
-  - The owner can be specific such as "IBMUSER", or one that uses a pattern 
+  - The owner can be specific such as "IBMUSER", or one that uses a pattern
     like "*".
-  - If there is no ddname, or if ddname="?", output of all the ddnames under 
+  - If there is no ddname, or if ddname="?", output of all the ddnames under
     the given job will be displayed.
 version_added: "2.9"
 author: "Jack Ho (@jacklotusho)"
@@ -54,7 +54,7 @@ options:
       - Data definition name. (e.g "JESJCL", "?")
     type: str
     required: false
-'''
+"""
 
 EXAMPLES = r"""
 - name: Job output with ddname
@@ -74,16 +74,16 @@ EXAMPLES = r"""
     ddname: "?"
 """
 
-RETURN =r'''
+RETURN = r"""
 jobs:
-  description: 
+  description:
       List of jobs output
   returned: success
   type: list
   elements: dict
   contains:
     job_id:
-      description: 
+      description:
          The z/OS job ID of the job containing the spool file.
       type: str
       sample: JOB00134
@@ -92,29 +92,29 @@ jobs:
          The name of the batch job.
       type: str
       sample: HELLO
-    subsystem: 
+    subsystem:
       description:
-         The job entry subsystem that MVS uses to do work. 
+         The job entry subsystem that MVS uses to do work.
       type: str
       sample: STL1
     class:
-      description: 
+      description:
          Identifies the data set used in a system output data set, usually called a sysout data set.
       type: str
       sample:
     content_type:
-      description: 
+      description:
          Type of address space.
       type: str
       sample: JOB
     ddnames:
-      description: 
+      description:
          Data definition names.
       type: list
       elements: dict
       contains:
         ddname:
-          description: 
+          description:
              Data definition name.
           type: str
           sample: JESMSGLG
@@ -124,19 +124,19 @@ jobs:
           type: int
           sample: 17
         id:
-          description: 
+          description:
              Unique job id assigned to the job by JES
           type: str
           sample: 2
         stepname:
-          description: 
-              A step name is name that identifies the job step so that other 
-              JCL statements or the operating system can refer to it. 
+          description:
+              A step name is name that identifies the job step so that other
+              JCL statements or the operating system can refer to it.
           type: str
           sample: JES2
         procstep:
           description:
-             Identifies the set of statements inside JCL grouped together to 
+             Identifies the set of statements inside JCL grouped together to
              perform a particular function.
           type: str
           sample: PROC1
@@ -171,23 +171,23 @@ jobs:
       type: dict
       contains:
         msg:
-          description: 
+          description:
             Return code or abend resulting from the job submission.
           type: str
           sample: CC 0000
         msg_code:
-          description: 
+          description:
             Return code extracted from the `msg` so that it can better
             evaluated. For example , ABEND(S0C4) would yield ""S0C4".
           type: str
           sample: S0C4
         msg_txt:
-          description: 
+          description:
              Returns additional information related to the job.
           type: str
           sample: "No job can be located with this job name: HELLO"
         code:
-          description: 
+          description:
              Return code converted to integer value (when possible)
           type: int
           sample: 00
@@ -321,11 +321,11 @@ jobs:
       }
   ]
 changed:
-    description: 
+    description:
       Indicates if any changes were made during module operation
     type: bool
     returned: on success
-'''
+"""
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {
     "supported_by": "community",
 }
 
-DOCUMENTATION =r'''
+DOCUMENTATION = r'''
 ---
 module: zos_job_query
 short_description: Query job(s) and status.
@@ -26,7 +26,7 @@ description:
 author: "Ping Xiao (@xiaopingBJ)"
 options:
   job_name:
-    description: 
+    description:
        - The job name to query.
     type: str
     required: False
@@ -36,16 +36,16 @@ options:
       - Identifies the owner of the job.
     type: str
     required: False
-    deafault: Current user
+    deafault: "$USER"
   job_id:
     description:
-      - The job number that has been assigned to the job. These normally begin 
+      - The job number that has been assigned to the job. These normally begin
         with STC, JOB, TSU and are followed by 5 digits.
     type: str
     required: False
 '''
 
-EXAMPLES =r'''
+EXAMPLES = r'''
 - name: list zos jobs with a jobname 'IYK3ZNA1'
   zos_job_query:
     job_name: "IYK3ZNA1"
@@ -65,14 +65,14 @@ EXAMPLES =r'''
     owner: BROWNAD
 '''
 
-RETURN =r'''
+RETURN = r'''
 changed:
-  description: 
+  description:
      True if the state was changed, otherwise False.
   returned: always
   type: bool
 jobs:
-  description: 
+  description:
      The list of z/OS job(s) and status.
   returned: success
   type: list
@@ -99,12 +99,12 @@ jobs:
       type: dict
       contains:
         msg:
-          description: 
+          description:
             Return code or abend resulting from the job submission.
           type: str
           sample: CC 0000
         code:
-          description: 
+          description:
              Return code converted to integer value (when possible)
           type: int
           sample: 00
@@ -127,7 +127,7 @@ jobs:
         },
     ]
 message:
-  description: 
+  description:
      Message returned on failure.
   type: str
   returned: failure

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -36,7 +36,7 @@ options:
       - Identifies the owner of the job.
     type: str
     required: False
-    deafault: "$USER"
+    default: "$USER"
   job_id:
     description:
       - The job number that has been assigned to the job. These normally begin

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -152,7 +152,7 @@ def run_module():
         job_id=dict(type="str", required=False),
     )
 
-    result = dict(changed=False, original_message="", message="")
+    result = dict(changed=False, message="")
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
 
@@ -165,7 +165,6 @@ def run_module():
         jobs = parsing_jobs(jobs_raw)
     except Exception as e:
         module.fail_json(msg=e, **result)
-    result["original_message"] = module.params["job_name"]
     result["jobs"] = jobs
     module.exit_json(**result)
 

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -34,9 +34,10 @@ options:
   owner:
     description:
       - Identifies the owner of the job.
+      - If no owner is set, the default set is 'none' and all jobs will be
+        queried.
     type: str
     required: False
-    default: "$USER"
   job_id:
     description:
       - The job number that has been assigned to the job. These normally begin


### PR DESCRIPTION
##### SUMMARY
This update removes the unnecessary return value "original_message". There is no need to return the original options , there are other ways to access this and don't see any need to parse this value out from a response.  

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Module: zos_job_query

