### PR TITLE
Corrected README to point to MD, and long tag removed

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ name: ibm_zos_core
 version: 1.0.0
 
 # Collection README file
-readme: README.rst
+readme: README.md
 
 # Contributors
 authors:
@@ -40,7 +40,6 @@ tags:
     core,
     zos_core,
     ibm_zos_core,
-    red_hat_ansible_certified_content_for_ibm_z,
     data_set,
     jcl,
     uss,


### PR DESCRIPTION
##### SUMMARY
Fixes README to point to .md instead of .rst
Fixes the long tag

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION
Contributed by @thedoubl3j 
