### PR TITLE
Add two additional arg types to BetterArgHandler

### DIFF
--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -439,7 +439,7 @@ class BetterArgHandler(object):
             str(contents),
             re.IGNORECASE
         ):
-            if not os.path.isabs(str(contents)):
+            if not path.isabs(str(contents)):
                 raise ValueError('Invalid argument type for source. expected "data_set" or "path"')
         return str(contents)
 

--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -125,6 +125,8 @@ class BetterArgHandler(object):
             "qualifier": self._qualifier_type,
             "qualifier_pattern": self._qualifier_pattern_type,
             "volume": self._volume_type,
+            "data_set_or_path_type": self._data_set_or_path_type,
+            "encoding_type": self._encoding_type
         }
 
     def handle_arg(self):
@@ -415,6 +417,49 @@ class BetterArgHandler(object):
         if not re.fullmatch(r"^[A-Z0-9]{1,6}$", str(contents), re.IGNORECASE,):
             raise ValueError(
                 'Invalid argument type for "{0}". expected "volume"'.format(contents)
+            )
+        return str(contents)
+
+    def _data_set_or_path_type(self, contents, resolve_dependencies):
+        """Resolver for data_set_or_path type arguments
+
+        Arguments:
+            contents {bool} -- The contents of the argument.
+            resolved_dependencies {dict} -- Contains all of the dependencies and their contents,
+            which have already been handled,
+            for use during current arguments handling operations.
+
+        Raises:
+            ValueError: When contents is invalid argument type
+        Returns:
+            str -- The arguments contents after any necessary operations.
+        """
+        if not re.fullmatch(
+            r"^(?:(?:[A-Z]{1}[A-Z0-9]{0,7})(?:[.]{1})){1,21}[A-Z]{1}[A-Z0-9]{0,7}(?:\([A-Z]{1}[A-Z0-9]{0,7}\)){0,1}$",
+            str(contents),
+            re.IGNORECASE
+        ):
+            if not os.path.isabs(str(contents)):
+                raise ValueError('Invalid argument type for source. expected "data_set" or "path"')
+        return str(contents)
+
+    def _encoding_type(self, contents, resolve_dependencies):
+        """Resolver for encoding type arguments
+
+        Arguments:
+            contents {bool} -- The contents of the argument.
+            resolved_dependencies {dict} -- Contains all of the dependencies and their contents,
+            which have already been handled,
+            for use during current arguments handling operations.
+
+        Raises:
+            ValueError: When contents is invalid argument type
+        Returns:
+            str -- The arguments contents after any necessary operations.
+        """
+        if not re.fullmatch(r"^[A-Z0-9-]{2,}$", str(contents), re.IGNORECASE):
+            raise ValueError(
+                'Invalid argument type for "{0}". expected "encoding"'.format(contents)
             )
         return str(contents)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add the following two arg types to BetterArgHandler::
- data_set_or_path_type
- encoding_type
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
_data_set_or_path_type_: A handler for arguments that can be either data sets or paths, (e.g. `USER.PROCLIB` and `/etc/profile` are both valid

_encoding_type_: A handler for arguments that specify encoding, (e.g. `IBM-037`, `ISO-88559-1`)
