### PR TITLE
Update/973/add new supported data set characters betterargparser

### DIFF
--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -125,8 +125,8 @@ class BetterArgHandler(object):
             "qualifier": self._qualifier_type,
             "qualifier_pattern": self._qualifier_pattern_type,
             "volume": self._volume_type,
-            "data_set_or_path_type": self._data_set_or_path_type,
-            "encoding_type": self._encoding_type,
+            "data_set_or_path": self._data_set_or_path_type,
+            "encoding": self._encoding_type,
         }
 
     def handle_arg(self):
@@ -279,6 +279,26 @@ class BetterArgHandler(object):
             )
         return str(contents)
 
+    # ---------------------------------------------------------------------------- #
+    #                             DATA SET NAMING RULES                            #
+    # ---------------------------------------------------------------------------- #
+    # A data set name consists of one or more parts connected by periods. Each part is called a qualifier.
+    # Each qualifier must begin with an alphabetic character (A-Z) or the special characters $, #, @.
+    # The remaining characters in each qualifier can be alphabetic characters, digits (0-9), a hyphen (-),
+    #  or the special characters $, #, @.
+    # Each qualifier must be one to eight characters long.
+    # The maximum length of a complete data set name before specifying a member name is 44 characters,
+    # including the periods.
+
+    # ---------------------------------------------------------------------------- #
+    #                            PDS member naming rules                           #
+    # ---------------------------------------------------------------------------- #
+    # A member name cannot be longer than eight characters.
+    # The first member character must be either a letter or one of the following three special characters: #, @, $.
+    # The remaining seven characters can be letters, numbers, or one of the following special characters: #, @, or $.
+    # A PDS member name cannot contain a hyphen (-).
+    # A PDS member name cannot contain accented characters (à, é, è, and so on).
+
     def _data_set_type(self, contents, resolve_dependencies):
         """Resolver for data_set type arguments.
 
@@ -294,7 +314,7 @@ class BetterArgHandler(object):
             str -- The arguments contents after any necessary operations.
         """
         if not re.fullmatch(
-            r"^(?:(?:[A-Z]{1}[A-Z0-9]{0,7})(?:[.]{1})){1,21}[A-Z]{1}[A-Z0-9]{0,7}(?:\([A-Z]{1}[A-Z0-9]{0,7}\)){0,1}$",
+            r"^(?:(?:[A-Z$#@]{1}[A-Z0-9$#@-]{0,7})(?:[.]{1})){1,21}[A-Z$#@]{1}[A-Z0-9$#@-]{0,7}(?:\([A-Z$#@]{1}[A-Z0-9$#@]{0,7}\)){0,1}$",
             str(contents),
             re.IGNORECASE,
         ):
@@ -318,7 +338,7 @@ class BetterArgHandler(object):
             str -- The arguments contents after any necessary operations.
         """
         if not re.fullmatch(
-            r"^(?:(?:[A-Z]{1}[A-Z0-9]{0,7})(?:[.]{1})){1,21}[A-Z]{1}[A-Z0-9]{0,7}$",
+            r"^(?:(?:[A-Z$#@]{1}[A-Z0-9$#@-]{0,7})(?:[.]{1})){1,21}[A-Z$#@]{1}[A-Z0-9$#@-]{0,7}$",
             str(contents),
             re.IGNORECASE,
         ):
@@ -344,7 +364,7 @@ class BetterArgHandler(object):
             str -- The arguments contents after any necessary operations.
         """
         if not re.fullmatch(
-            r"^(?:(?:[A-Z]{1}[A-Z0-9]{0,7})(?:[.]{1})){1,21}[A-Z]{1}[A-Z0-9]{0,7}\([A-Z]{1}[A-Z0-9]{0,7}\)$",
+            r"^(?:(?:[A-Z$#@]{1}[A-Z0-9$#@-]{0,7})(?:[.]{1})){1,21}[A-Z$#@]{1}[A-Z0-9$#@-]{0,7}\([A-Z$#@]{1}[A-Z0-9$#@]{0,7}\)$",
             str(contents),
             re.IGNORECASE,
         ):
@@ -415,7 +435,7 @@ class BetterArgHandler(object):
         Returns:
             str -- The arguments contents after any necessary operations.
         """
-        if not re.fullmatch(r"^[A-Z0-9]{1,6}$", str(contents), re.IGNORECASE,):
+        if not re.fullmatch(r"^[A-Z0-9@#$]{1,6}$", str(contents), re.IGNORECASE,):
             raise ValueError(
                 'Invalid argument type for "{0}". expected "volume"'.format(contents)
             )
@@ -436,7 +456,7 @@ class BetterArgHandler(object):
             str -- The arguments contents after any necessary operations.
         """
         if not re.fullmatch(
-            r"^(?:(?:[A-Z]{1}[A-Z0-9]{0,7})(?:[.]{1})){1,21}[A-Z]{1}[A-Z0-9]{0,7}(?:\([A-Z]{1}[A-Z0-9]{0,7}\)){0,1}$",
+            r"^(?:(?:[A-Z$#@]{1}[A-Z0-9$#@-]{0,7})(?:[.]{1})){1,21}[A-Z$#@]{1}[A-Z0-9$#@-]{0,7}(?:\([A-Z$#@]{1}[A-Z0-9$#@]{0,7}\)){0,1}$",
             str(contents),
             re.IGNORECASE,
         ):

--- a/tests/functional/module_utils/test_arg_parser.py
+++ b/tests/functional/module_utils/test_arg_parser.py
@@ -617,3 +617,63 @@ def test_custom_defined_values_second_level():
         }
     )
     assert result.get("person").get("name") == "john"
+
+
+@pytest.mark.parametrize(
+    ("arg_type", "name"),
+    [
+        ("data_set", "easy.data.set"),
+        ("data_set", "$asy.d@ta.$et"),
+        ("data_set", "easy.dat@.s$t"),
+        ("data_set", "e##@y.dat#@.set(h$ll0)"),
+        ("data_set", "easy.da-a.set(######)"),
+        ("data_set_base", "easy.data.set"),
+        ("data_set_base", "$asy.d@ta.$et"),
+        ("data_set_base", "easy.dat@.s$t"),
+        ("data_set_member", "e##@y.dat#@.set(h$ll0)"),
+        ("data_set_member", "ea-y.data.set(######)"),
+        ("data_set_or_path", "easy.data.set"),
+        ("data_set_or_path", "$asy.d@ta.$et"),
+        ("data_set_or_path", "easy.dat@.s$t"),
+        ("data_set_or_path", "e##@y.d-t#@.s-t(h$ll0)"),
+        ("data_set_or_path", "easy.data.set(######)"),
+        ("data_set_or_path", "e##@y.dat#@.set(hello)"),
+        ("data_set_or_path", "easy.data.set(helloo)"),
+        ("data_set_or_path", "/usr/lpp/rsusr"),
+    ],
+)
+def test_data_set_type_no_invalid(arg_type, name):
+    arg_defs = dict(dsname=dict(arg_type=arg_type))
+    parser = BetterArgParser(arg_defs)
+    result = parser.parse_args({"dsname": name})
+    assert result.get("dsname") == name
+
+
+@pytest.mark.parametrize(
+    ("arg_type", "name"),
+    [
+        ("data_set", "easy.data.set(helloworld)"),
+        ("data_set", "$asy.d@ta.$et(--helo)"),
+        ("data_set", "easy.dat@.s$t(@$%@)"),
+        ("data_set", "$asy.d@ta.$et(0helo)"),
+        ("data_set", "-##@y.dat#@.set(h$ll0)"),
+        ("data_set", "1asy.da-a.set(######)"),
+        ("data_set_base", "-asy.data.set"),
+        ("data_set_base", "$asy.d@ta.$etdafsfsdfad"),
+        ("data_set_member", "e##@y.dat#@.set(h$l-l0)"),
+        ("data_set_member", "ea-y.data.set(#########)"),
+        ("data_set_or_path", "easy.data.seeeeeeeeeet"),
+        ("data_set_or_path", "-asy.d@ta.$et"),
+        ("data_set_or_path", "easy.dat@.s$t(-)"),
+        ("data_set_or_path", "e##@y.d-t#@.s-t(h$dddll00)"),
+        ("data_set_or_path", "3asy.data.set(######)"),
+        ("data_set_or_path", "e#^#@y.dat#@.set(hello)"),
+        ("data_set_or_path", "easy.5at@@a.set(helloo)"),
+        ("data_set_or_path", "../lpp/rsusr"),
+    ],
+)
+def test_data_set_type_invalid(arg_type, name):
+    arg_defs = dict(dsname=dict(arg_type=arg_type))
+    parser = BetterArgParser(arg_defs)
+    with pytest.raises(ValueError):
+        parser.parse_args({"dsname": name})


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #973 in Jira. This PR adds correct support for the characters "@", "#", "$", and "-" when they are valid in a data set, PDS member, or volume serial. In addition, PR also fixes some built-in type naming errors that were overlooked in previous PR (my fault). Supporting test cases are also included.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Update Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/module_utils/better_arg_parser.py
tests/functional/module_utils/test_arg_parser.py

