### PR TITLE
bugfix for job name capture group

### DIFF
--- a/plugins/modules/zos_operator_action_query.py
+++ b/plugins/modules/zos_operator_action_query.py
@@ -365,7 +365,7 @@ def parse_result_b(result):
     for index, line in enumerate(lines):
         line = line.strip()
         pattern_with_job_name = re.compile(
-            r"\s*([0-9]{2,})\s([A-Z]{1})\s+(?:[A-Z0-9]{1,8})?\s*[&*]?[0-9]+\s([A-Z0-9]+)"
+            r"\s*([0-9]{2,})\s[A-Z]{1}\s+([A-Z0-9]{1,8})?\s*[&*]?[0-9]+\s([A-Z0-9]+)"
         )
         m = pattern_with_job_name.search(line)
         if m:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1160 in Jira. In zos_operator_action_query, capture group for job name was set to noncapture group, as well as another capture group that should not have been present, was causing incorrect capture of text unrelated to job name.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- /plugins/modules/zos_operator_action_query.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
