### PR TITLE
Better ZOAU import missing messages

### DIFF
--- a/plugins/module_utils/import_handler.py
+++ b/plugins/module_utils/import_handler.py
@@ -1,0 +1,11 @@
+class MissingZOAUImport(object):
+    def __getattr__(self, name):
+        def method(*args, **kwargs):
+            raise ImportError(
+                (
+                    "ZOAU is not properly configured for Ansible. Unable to import zoautil_py. "
+                    "Ensure environment variables are properly configured in Ansible for use with ZOAU."
+                )
+            )
+
+        return method

--- a/plugins/module_utils/import_handler.py
+++ b/plugins/module_utils/import_handler.py
@@ -1,3 +1,11 @@
+# Copyright (c) IBM Corporation 2020
+# Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
 class MissingZOAUImport(object):
     def __getattr__(self, name):
         def method(*args, **kwargs):

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -381,11 +381,16 @@ from collections import OrderedDict
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.vtoc import (
     VolumeTableOfContents,
 )
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
+    MissingZOAUImport,
+)
 
 try:
     from zoautil_py import Datasets, types, MVSCmd
 except Exception:
-    Datasets = ""
+    Datasets = MissingZOAUImport()
+    types = MissingZOAUImport()
+    MVSCmd = MissingZOAUImport()
 import re
 from ansible.module_utils.basic import AnsibleModule
 

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {
     "supported_by": "community",
 }
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: zos_job_query
 short_description: Query job status
@@ -44,9 +44,9 @@ options:
         with STC, JOB, TSU and are followed by 5 digits.
     type: str
     required: False
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: list zos jobs with a jobname 'IYK3ZNA1'
   zos_job_query:
     job_name: "IYK3ZNA1"
@@ -64,9 +64,9 @@ EXAMPLES = r'''
   zos_job_query:
     job_name: IYK3ZNA*
     owner: BROWNAD
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
 changed:
   description:
      True if the state was changed, otherwise False.
@@ -134,12 +134,15 @@ message:
   returned: failure
   sample:
      msg: "List FAILED! no such job been found: IYK3Z0R9"
-'''
+"""
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
+    MissingZOAUImport,
+)
 
 try:
     from zoautil_py import Jobs
 except Exception:
-    Jobs = ""
+    Jobs = MissingZOAUImport()
 from ansible.module_utils.basic import AnsibleModule
 import re
 from time import sleep

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -479,11 +479,14 @@ EXAMPLES = r"""
 
 from ansible.module_utils.basic import AnsibleModule
 from pipes import quote
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
+    MissingZOAUImport,
+)
 
 try:
     from zoautil_py import Jobs
 except Exception:
-    Jobs = ""
+    Jobs = MissingZOAUImport()
 from time import sleep
 from os import chmod, path, remove
 from tempfile import NamedTemporaryFile
@@ -587,10 +590,7 @@ def query_jobs_status(jobId):
             pass
         except Exception as e:
             raise SubmitJCLError(
-                repr(e)
-                + """
-            The output is """
-                + output
+                "{0} {1} {2}".format(repr(e), "The output is", output or " ")
             )
     if output is None and timeout == 0:
         raise SubmitJCLError(

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -9,12 +9,12 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {
-    'metadata_version': '1.1',
-    'status': ['preview'],
-    'supported_by': 'community'
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
 }
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: zos_operator
 short_description: Execute operator command
@@ -39,9 +39,9 @@ options:
     type: bool
     required: false
     default: false
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Execute an operator command to show active jobs
   zos_operator:
     cmd: 'd u,all'
@@ -56,9 +56,9 @@ EXAMPLES = r'''
     cmd: 'd u,all'
     verbose: true
     debug: true
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
 rc:
     description:
        Return code of the operator command
@@ -86,63 +86,57 @@ changed:
        command failure has occurred.
     returned: always
     type: bool
-'''
+"""
 
 
 from ansible.module_utils.basic import AnsibleModule
 import re
 from traceback import format_exc
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
+    MissingZOAUImport,
+)
+
 try:
     from zoautil_py import OperatorCmd
 except Exception:
-    OperatorCmd = ""
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import BetterArgParser
+    OperatorCmd = MissingZOAUImport()
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
+    BetterArgParser,
+)
 
 
 def run_module():
     module_args = dict(
-        cmd=dict(type='str', required=True),
-        verbose=dict(type='bool', default=False),
-        debug=dict(type='bool', default=False),
+        cmd=dict(type="str", required=True),
+        verbose=dict(type="bool", default=False),
+        debug=dict(type="bool", default=False),
     )
 
-    result = dict(
-        changed=False
-    )
+    result = dict(changed=False)
 
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=False
-    )
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
 
     try:
         new_params = parse_params(module.params)
         rc_message = run_operator_command(new_params)
-        result['rc'] = rc_message.get('rc')
-        result['content'] = rc_message.get('message').split('\n')
+        result["rc"] = rc_message.get("rc")
+        result["content"] = rc_message.get("message").split("\n")
     except Error as e:
         module.fail_json(msg=e.msg, **result)
     except Exception as e:
         trace = format_exc()
-        module.fail_json(msg='An unexpected error occurred: {0}'.format(trace), **result)
-    result['changed'] = True
+        module.fail_json(
+            msg="An unexpected error occurred: {0}".format(trace), **result
+        )
+    result["changed"] = True
     module.exit_json(**result)
 
 
 def parse_params(params):
     arg_defs = dict(
-        cmd=dict(
-            arg_type='str',
-            required=True
-        ),
-        verbose=dict(
-            arg_type='bool',
-            required=False
-        ),
-        debug=dict(
-            arg_type='bool',
-            required=False
-        )
+        cmd=dict(arg_type="str", required=True),
+        verbose=dict(arg_type="bool", required=False),
+        debug=dict(arg_type="bool", required=False),
     )
     parser = BetterArgParser(arg_defs)
     new_params = parser.parse_args(params)
@@ -150,15 +144,15 @@ def parse_params(params):
 
 
 def run_operator_command(params):
-    command = params.get('cmd')
-    verbose = params.get('verbose')
-    debug = params.get('debug')
+    command = params.get("cmd")
+    verbose = params.get("verbose")
+    debug = params.get("debug")
     rc_message = []
     rc_message = OperatorCmd.execute(command, "", verbose, debug)
-    rc = rc_message.get('rc')
-    message = rc_message.get('message')
+    rc = rc_message.get("rc")
+    message = rc_message.get("message")
     if rc > 0:
-        raise OperatorCmdError(command, message.split('\n') if message else message)
+        raise OperatorCmdError(command, message.split("\n") if message else message)
     return rc_message
 
 
@@ -168,12 +162,14 @@ class Error(Exception):
 
 class OperatorCmdError(Error):
     def __init__(self, cmd, message):
-        self.msg = 'An error occurred executing the operator command "{0}", with response "{1}"'.format(cmd, message)
+        self.msg = 'An error occurred executing the operator command "{0}", with response "{1}"'.format(
+            cmd, message
+        )
 
 
 def main():
     run_module()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/zos_operator_action_query.py
+++ b/plugins/modules/zos_operator_action_query.py
@@ -172,11 +172,14 @@ from traceback import format_exc
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
     BetterArgParser,
 )
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
+    MissingZOAUImport,
+)
 
 try:
     from zoautil_py import OperatorCmd
 except Exception:
-    OperatorCmd = ""
+    OperatorCmd = MissingZOAUImport()
 
 
 def run_module():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR addresses #1648 in Jira. PR adds a new shared utility MissingZOAUImport to module_utils and updated modules to use the utility. Any method call on an MissingZOAUImport object will raise an ImportError with the message 

> ZOAU is not properly configured for Ansible. Unable to import zoautil_py. Ensure environment variables are properly configured in Ansible for use with ZOAU.

This is an improvement over the old method, which by comparison, set the expected ZOAU import names to an empty string when ZOAU import errors occurred. The old method has led to  confusion from users whose environment variables are not properly configured.

In addition, one error message return format was changed in zos_job_submit to prevent an ambiguous error message from being returned in place of a descriptive message.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Update Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- plugins/module_utils/import_handler.py
- All modules which use ZOAU

