### PR TITLE
changed behavior on failure

### DIFF
--- a/plugins/modules/zos_operator_action_query.py
+++ b/plugins/modules/zos_operator_action_query.py
@@ -168,7 +168,6 @@ actions:
 
 from ansible.module_utils.basic import AnsibleModule
 import re
-from traceback import format_exc
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
     BetterArgParser,
 )
@@ -196,11 +195,10 @@ def run_module():
         if requests:
             result["count"] = len(requests)
     except Error as e:
-        module.fail_json(msg=e.msg, **result)
+        module.fail_json(msg=repr(e), **result)
     except Exception as e:
-        trace = format_exc()
         module.fail_json(
-            msg="An unexpected error occurred: {0}".format(trace), **result
+            msg="An unexpected error occurred: {0}".format(repr(e)), **result
         )
 
     result["actions"] = requests
@@ -249,11 +247,6 @@ def find_required_request(params):
     """Find the request given the options provided."""
     merged_list = create_merge_list()
     requests = filter_requests(merged_list, params)
-    if requests:
-        pass
-    else:
-        message = "There is no such request given the condition, check your command or update your options."
-        raise OperatorCmdError(message)
     return requests
 
 

--- a/tests/functional/modules/test_zos_operator_action_query_func.py
+++ b/tests/functional/modules/test_zos_operator_action_query_func.py
@@ -21,7 +21,7 @@ def test_zos_operator_action_query_no_options(ansible_zos_module):
     except Exception:
         pass
     for result in results.contacted.values():
-        assert not result.get("actions") is None
+        assert result.get("actions")
 
 
 def test_zos_operator_action_query_option_message_id(ansible_zos_module):
@@ -35,7 +35,7 @@ def test_zos_operator_action_query_option_message_id(ansible_zos_module):
     except Exception:
         pass
     for result in results.contacted.values():
-        assert not result.get("actions") is None
+        assert result.get("actions")
 
 
 def test_zos_operator_action_query_option_message_id_invalid_abbreviation(
@@ -51,7 +51,7 @@ def test_zos_operator_action_query_option_message_id_invalid_abbreviation(
     except Exception:
         pass
     for result in results.contacted.values():
-        assert result.get("actions") is None
+        assert not result.get("actions")
 
 
 @pytest.mark.parametrize("message_id", ["IEE*", "*"])
@@ -68,7 +68,7 @@ def test_zos_operator_action_query_option_message_id_regex(
     except Exception:
         pass
     for result in results.contacted.values():
-        assert not result.get("actions") is None
+        assert result.get("actions")
 
 
 def test_zos_operator_action_query_option_system(ansible_zos_module):
@@ -79,7 +79,7 @@ def test_zos_operator_action_query_option_system(ansible_zos_module):
         system_name = result.get("stdout", "").strip()
     results = hosts.all.zos_operator_action_query(system=system_name)
     for result in results.contacted.values():
-        assert not result.get("actions") is None
+        assert result.get("actions")
 
 
 def test_zos_operator_action_query_option_system_invalid_abbreviation(
@@ -92,7 +92,7 @@ def test_zos_operator_action_query_option_system_invalid_abbreviation(
         system_name = result.get("stdout", "").strip()
     results = hosts.all.zos_operator_action_query(system=system_name[:-1])
     for result in results.contacted.values():
-        assert result.get("actions") is None
+        assert not result.get("actions")
 
 
 @pytest.mark.parametrize("message_id", ["IEE*", "IEE094D", "*"])
@@ -108,7 +108,7 @@ def test_zos_operator_action_query_option_system_and_message_id(
         system=system_name, message_id=message_id
     )
     for result in results.contacted.values():
-        assert not result.get("actions") is None
+        assert result.get("actions")
 
 
 def test_zos_operator_action_query_option_system_regex(ansible_zos_module):
@@ -126,7 +126,7 @@ def test_zos_operator_action_query_option_system_regex(ansible_zos_module):
     except Exception:
         pass
     for result in results.contacted.values():
-        assert not result.get("actions") is None
+        assert result.get("actions")
 
 
 @pytest.mark.parametrize("message_id", ["IEE*", "IEE094D", "*"])
@@ -149,7 +149,7 @@ def test_zos_operator_action_query_option_system_regex_and_message_id(
     except Exception:
         pass
     for result in results.contacted.values():
-        assert not result.get("actions") is None
+        assert result.get("actions")
 
 
 @pytest.mark.parametrize("system", ["", "OVER8CHARS", "--BADNM", "invalid-system"])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1698 in Jira. This PR changes the behavior of zos_operator_action_query to return an empty list for `actions` when no action messages are found. This differs from old behavior which would raise an exception if no messages were found. 

I also modified an exception string response to match behavior provided by other modules.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Update Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
 - plugins/modules/zos_operator_action_query.py
##### ADDITIONAL INFORMATION

![image](https://user-images.githubusercontent.com/29046916/80054865-3af11500-84d5-11ea-8ebe-ffcf90cda30e.png)

