### PR TITLE
Bugfix/1661 & 1704 fix query of job for different user zos_job_submit and zos_job_action_query

### DIFF
--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -30,9 +30,8 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None):
         RuntimeError: When no job output is found
 
     Returns:
-        dict[str, list[dict]] -- The output information for a given job.
+        list[dict] -- The output information for a list of jobs matching specified criteria.
     """
-    module = AnsibleModule(argument_spec={}, check_invalid_arguments=False)
     arg_defs = dict(
         job_id=dict(arg_type="qualifier_pattern"),
         owner=dict(arg_type="qualifier_pattern"),
@@ -61,7 +60,7 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None):
     if not out:
         raise RuntimeError("Failed to retrieve job output. No job output found.")
     job_detail_json = json.loads(out, strict=False)
-    for job in job_detail_json.get("jobs"):
+    for job in job_detail_json:
         job["ret_code"] = {} if job.get("ret_code") is None else job.get("ret_code")
         job["ret_code"]["code"] = _get_return_code_num(
             job.get("ret_code").get("msg", "")
@@ -116,14 +115,14 @@ end
 
 Address SDSF "ISFEXEC ST (ALTERNATE DELAYED)"
 if rc<>0 then do
-Say '{"jobs":[]}'
+Say '[]'
 Exit 0
 end
 if isfrows == 0 then do
-Say '{"jobs":[]}'
+Say '[]'
 end
 else do
-Say '{"jobs":['
+Say '['
 do ix=1 to isfrows
     linecount = 0
     if ix<>1 then do
@@ -179,7 +178,7 @@ do ix=1 to isfrows
     end
     Say '}'
 end
-Say ']}'
+Say ']'
 end
 
 rc=isfcalls('OFF')
@@ -234,7 +233,7 @@ def job_status(job_id=None, owner=None, job_name=None):
         RuntimeError: When no job status is found.
 
     Returns:
-        list[dict] -- The status information for a given job.
+        list[dict] -- The status information for a list of jobs matching search criteria.
     """
     arg_defs = dict(
         job_id=dict(arg_type="qualifier_pattern"),

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -352,7 +352,7 @@ def run_module():
         module.fail_json(msg="Please provide a job_id or job_name or owner")
 
     try:
-        results = job_output(module, job_id, owner, job_name, ddname)
+        results = job_output(job_id, owner, job_name, ddname)
         results["changed"] = False
     except Exception as e:
         module.fail_json(msg=repr(e))

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -352,7 +352,8 @@ def run_module():
         module.fail_json(msg="Please provide a job_id or job_name or owner")
 
     try:
-        results = job_output(job_id, owner, job_name, ddname)
+        results = {}
+        results["jobs"] = job_output(job_id, owner, job_name, ddname)
         results["changed"] = False
     except Exception as e:
         module.fail_json(msg=repr(e))

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {
     "supported_by": "community",
 }
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: zos_job_query
 short_description: Query job status
@@ -44,9 +44,9 @@ options:
         with STC, JOB, TSU and are followed by 5 digits.
     type: str
     required: False
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: list zos jobs with a jobname 'IYK3ZNA1'
   zos_job_query:
     job_name: "IYK3ZNA1"
@@ -64,9 +64,9 @@ EXAMPLES = r'''
   zos_job_query:
     job_name: IYK3ZNA*
     owner: BROWNAD
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
 changed:
   description:
      True if the state was changed, otherwise False.
@@ -134,15 +134,11 @@ message:
   returned: failure
   sample:
      msg: "List FAILED! no such job been found: IYK3Z0R9"
-'''
+"""
 
-try:
-    from zoautil_py import Jobs
-except Exception:
-    Jobs = ""
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import job_status
 from ansible.module_utils.basic import AnsibleModule
 import re
-from time import sleep
 
 
 def run_module():
@@ -164,6 +160,7 @@ def run_module():
         validate_arguments(module.params)
         jobs_raw = query_jobs(module.params)
         jobs = parsing_jobs(jobs_raw)
+
     except Exception as e:
         module.fail_json(msg=e, **result)
     result["jobs"] = jobs
@@ -196,69 +193,55 @@ def validate_arguments(params):
         raise RuntimeError("Argument Error:job id can not be co-exist with owner")
 
 
-def query_jobs(params, count=0):
+def query_jobs(params):
     job_name_in = params.get("job_name")
     job_id = params.get("job_id")
     owner = params.get("owner")
     jobs = []
-    try:
-        if job_id:
-            jobs = Jobs.list(job_id=job_id)
-        elif owner:
-            jobs = Jobs.list(owner=owner, job_name=job_name_in)
-        else:
-            jobs = Jobs.list(job_name=job_name_in)
-        if not jobs:
-            raise RuntimeError(
-                "List FAILED! no such job name been found: " + job_name_in
-            )
-    except IndexError:
-        if count > 12:
-            raise
-        sleep(0.25)
-        count += 1
-        jobs = query_jobs(params, count)
+    if job_id:
+        jobs = job_status(job_id=job_id)
+    elif owner:
+        jobs = job_status(owner=owner, job_name=job_name_in)
+    else:
+        jobs = job_status(job_name=job_name_in)
+    if not jobs:
+        raise RuntimeError("List FAILED! no such job was found.")
     return jobs
 
 
 def parsing_jobs(jobs_raw):
     jobs = []
-    status = ""
     ret_code = {}
     for job in jobs_raw:
-        status_raw = job.get("status")
+        status_raw = job.get("ret_code").get("msg", "")
         if "AC" in status_raw:
             # the job is active
-            ret_code = "null"
+            ret_code = None
         elif "CC" in status_raw:
             # status = 'Completed normally'
             ret_code = {
-                "msg": status_raw + " " + job.get("return"),
-                "code": job.get("return"),
+                "msg": status_raw,
+                "code": job.get("ret_code").get("code"),
             }
-        elif status_raw == "ABEND":
+        elif "ABEND" in status_raw:
             # status = 'Ended abnormally'
             ret_code = {
-                "msg": status_raw + " " + job.get("return"),
-                "code": job.get("return"),
+                "msg": status_raw,
+                "code": job.get("ret_code").get("code"),
             }
         elif "ABENDU" in status_raw:
             # status = 'Ended abnormally'
-            if job.get("return") == "?":
-                ret_code = {"msg": status_raw, "code": status_raw[5:]}
-            else:
-                ret_code = {"msg": status_raw, "code": job.get("return")}
+            ret_code = {"msg": status_raw, "code": job.get("ret_code").get("code")}
         elif "CANCELED" or "JCLERR" in status_raw:
             # status = status_raw
-            ret_code = {"msg": status_raw, "code": "null"}
+            ret_code = {"msg": status_raw, "code": None}
         else:
             # status = 'Unknown'
-            ret_code = {"msg": status_raw, "code": job.get("return")}
+            ret_code = {"msg": status_raw, "code": job.get("ret_code").get("code")}
         job_dict = {
-            "job_name": job.get("name"),
+            "job_name": job.get("job_name"),
             "owner": job.get("owner"),
-            "job_id": job.get("id"),
-            # 'job_status':status,
+            "job_id": job.get("job_id"),
             "ret_code": ret_code,
         }
         jobs.append(job_dict)

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -506,7 +506,7 @@ def submit_pds_jcl(src):
     jobId = Jobs.submit(src)
     if jobId is None:
         raise SubmitJCLError(
-            "SUBMIT JOB FAILED: " + "NO JOB ID IS RETURNED. PLEASE CHECK THE JCL."
+            "SUBMIT JOB FAILED: NO JOB ID IS RETURNED. PLEASE CHECK THE JCL."
         )
     return jobId
 
@@ -524,7 +524,7 @@ def submit_uss_jcl(src, module):
         jobId = stdout.replace("\n", "").strip()
     else:
         raise SubmitJCLError(
-            "SUBMIT JOB FAILED: " + "NO JOB ID IS RETURNED. PLEASE CHECK THE JCL."
+            "SUBMIT JOB FAILED: NO JOB ID IS RETURNED. PLEASE CHECK THE JCL."
         )
     return jobId
 
@@ -587,10 +587,7 @@ def query_jobs_status(module, jobId):
             pass
         except Exception as e:
             raise SubmitJCLError(
-                repr(e)
-                + """
-            The output is """
-                + output
+                "{0} {1} {2}".format(repr(e), "The output is", output or "")
             )
     if not output and timeout == 0:
         raise SubmitJCLError(

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -580,8 +580,7 @@ def query_jobs_status(module, jobId):
     output = {}
     while not output.get("jobs") and timeout > 0:
         try:
-            # all_jobs = Jobs.list()
-            output = job_output(module, job_id=jobId)
+            output = job_output(job_id=jobId)
             sleep(0.5)
             timeout = timeout - 1
         except IndexError:
@@ -739,7 +738,7 @@ def run_module():
         ):
             sleep(1)
             duration = duration + 1
-            waitJob = job_output(module, job_id=jobId)
+            waitJob = job_output(job_id=jobId)
             job_msg = waitJob.get("jobs")[0].get("ret_code").get("msg")
             if re.search("^(?:{0})".format("|".join(JOB_COMPLETION_MESSAGES)), job_msg):
                 break

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -498,6 +498,8 @@ from stat import S_IEXEC, S_IREAD, S_IWRITE
 POLLING_INTERVAL = 1
 POLLING_COUNT = 60
 
+JOB_COMPLETION_MESSAGES = ["CC", "ABEND", "SEC"]
+
 
 def submit_pds_jcl(src):
     """ A wrapper around zoautil_py Jobs submit to raise exceptions on failure. """
@@ -560,11 +562,9 @@ def copy_rexx_and_run(script, src, vol, module):
 def get_job_info(module, jobId, return_output):
     result = dict()
     try:
-        output = query_jobs_status(jobId)
+        result = query_jobs_status(module, jobId)
     except SubmitJCLError:
         raise
-
-    result = job_output(module, job_id=jobId)
 
     if not return_output:
         for job in result.get("jobs", []):
@@ -575,13 +575,14 @@ def get_job_info(module, jobId, return_output):
     return result
 
 
-def query_jobs_status(jobId):
-    timeout = 10
-    output = None
-    while output is None and timeout > 0:
+def query_jobs_status(module, jobId):
+    timeout = 20
+    output = {}
+    while not output.get("jobs") and timeout > 0:
         try:
-            output = Jobs.list(job_id=jobId)
-            sleep(1)
+            # all_jobs = Jobs.list()
+            output = job_output(module, job_id=jobId)
+            sleep(0.5)
             timeout = timeout - 1
         except IndexError:
             pass
@@ -592,101 +593,16 @@ def query_jobs_status(jobId):
             The output is """
                 + output
             )
-    if output is None and timeout == 0:
+    if not output.get("jobs") and timeout == 0:
         raise SubmitJCLError(
             "THE JOB CAN NOT BE QUERIED FROM JES (TIMEOUT=10s). PLEASE CHECK THE ZOS SYSTEM. IT IS SLOW TO RESPONSE."
         )
     return output
 
 
-def parsing_job(job_raw):
-    ret_code = {}
-    status_raw = job_raw.get("status")
-    if "AC" in status_raw:
-        # the job is active
-        ret_code = {
-            "msg": "ACTIVE",
-            "code": "null",
-            "msg_detail": "Submit JCL operation succeeded.The job is still running.",
-        }
-    elif "CC" in status_raw:
-        # status = 'Completed normally'
-        ret_code = {
-            "msg": status_raw + " " + job_raw.get("return"),
-            "code": job_raw.get("return"),
-            "msg_detail": "Submit JCL operation succeeded.",
-        }
-    elif status_raw == "ABEND":
-        # status = 'Ended abnormally'
-        ret_code = {
-            "msg": status_raw + " " + job_raw.get("return"),
-            "code": job_raw.get("return"),
-            "msg_detail": "Submit JCL operation succeeded. But the job is ended abnormally.",
-        }
-    elif "ABENDU" in status_raw:
-        # status = 'Ended abnormally'
-        if job_raw.get("return") == "?":
-            ret_code = {
-                "msg": status_raw,
-                "code": status_raw[5:],
-                "msg_detail": "Submit JCL operation succeeded but the job is ended abnormally",
-            }
-        else:
-            ret_code = {
-                "msg": status_raw,
-                "code": job_raw.get("return"),
-                "msg_detail": "Submit JCL operation succeeded but the job is ended abnormally.",
-            }
-    elif "CANCELED" in status_raw:
-        # status = status_raw
-        ret_code = {
-            "msg": status_raw,
-            "code": "null",
-            "msg_detail": "Submit JCL operation succeeded but the job was canceled.",
-        }
-    elif "JCLERR" in status_raw:
-        ret_code = {
-            "msg": "JCL ERROR",
-            "code": "null",
-            "msg_detail": "Submit JCL operation succeeded but the job has a JCL ERROR.",
-        }
-    else:
-        # status = 'Unknown'
-        ret_code = {
-            "msg": status_raw,
-            "code": job_raw.get("return"),
-            "msg_detail": "Submit JCL operation succeeded. Please check the job status.",
-        }
-
-    return ret_code
-
-
 def assert_valid_return_code(max_rc, found_rc):
     if found_rc is None or max_rc < int(found_rc):
         raise SubmitJCLError("")
-
-
-def data_set_or_path_type(contents, resolve_dependencies):
-    if not re.fullmatch(
-        r"^(?:(?:[A-Z]{1}[A-Z0-9]{0,7})(?:[.]{1})){1,21}[A-Z]{1}[A-Z0-9]{0,7}(?:\([A-Z]{1}[A-Z0-9]{0,7}\)){0,1}$",
-        str(contents),
-        re.IGNORECASE,
-    ):
-        if not path.isabs(str(contents)):
-            raise ValueError(
-                'Invalid argument type for "{0}". expected "data_set" or "path"'.format(
-                    contents
-                )
-            )
-    return str(contents)
-
-
-def encoding_type(contents, resolve_dependencies):
-    if not re.fullmatch(r"^[A-Z0-9-]{2,}$", str(contents), re.IGNORECASE,):
-        raise ValueError(
-            'Invalid argument type for "{0}". expected "encoding"'.format(contents)
-        )
-    return str(contents)
 
 
 def run_module():
@@ -712,12 +628,12 @@ def run_module():
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
 
     arg_defs = dict(
-        src=dict(arg_type=data_set_or_path_type, required=True),
+        src=dict(arg_type="data_set_or_path", required=True),
         wait=dict(arg_type="bool", required=False),
         location=dict(
             arg_type="str", default="DATA_SET", choices=["DATA_SET", "USS", "LOCAL"],
         ),
-        encoding=dict(arg_type=encoding_type, default="UTF-8"),
+        encoding=dict(arg_type="encoding", default="UTF-8"),
         volume=dict(arg_type="volume", required=False),
         return_output=dict(arg_type="bool", default=True),
         wait_time_s=dict(arg_type="int", required=False, default=60),
@@ -750,8 +666,6 @@ def run_module():
 
     DSN_REGEX = r"^(([A-Z]{1}[A-Z0-9]{0,7})([.]{1})){1,21}[A-Z]{1}[A-Z0-9]{0,7}([(]([A-Z]{1}[A-Z0-9]{0,7})[)]){0,1}?$"
 
-    # calculate the job elapse time
-    duration = 0
     try:
         if location == "DATA_SET":
             data_set_name_pattern = re.compile(DSN_REGEX, re.IGNORECASE)
@@ -812,15 +726,22 @@ def run_module():
 
     result["job_id"] = jobId
     if wait is True:
+        # calculate the job elapse time
+        duration = 0
         try:
-            waitJob = query_jobs_status(jobId)
+            waitJob = query_jobs_status(module, jobId)
+            job_msg = waitJob.get("jobs")[0].get("ret_code").get("msg")
         except SubmitJCLError as e:
             module.fail_json(msg=repr(e), **result)
-        while waitJob[0].get("status") == "AC":  # AC means in progress
+        # while (job_msg.startswith("CC") or job_msg.startswith("ABEND")) is False:
+        while not re.search(
+            "^(?:{0})".format("|".join(JOB_COMPLETION_MESSAGES)), job_msg
+        ):
             sleep(1)
             duration = duration + 1
-            waitJob = Jobs.list(job_id=jobId)
-            if waitJob[0].get("status") == "CC":  # CC means completed
+            waitJob = job_output(module, job_id=jobId)
+            job_msg = waitJob.get("jobs")[0].get("ret_code").get("msg")
+            if re.search("^(?:{0})".format("|".join(JOB_COMPLETION_MESSAGES)), job_msg):
                 break
             if duration == wait_time_s:  # Long running task. timeout return
                 break

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -562,7 +562,7 @@ def copy_rexx_and_run(script, src, vol, module):
 def get_job_info(module, jobId, return_output):
     result = dict()
     try:
-        result = query_jobs_status(module, jobId)
+        result["jobs"] = query_jobs_status(module, jobId)
     except SubmitJCLError:
         raise
 
@@ -577,8 +577,8 @@ def get_job_info(module, jobId, return_output):
 
 def query_jobs_status(module, jobId):
     timeout = 20
-    output = {}
-    while not output.get("jobs") and timeout > 0:
+    output = []
+    while not output and timeout > 0:
         try:
             output = job_output(job_id=jobId)
             sleep(0.5)
@@ -592,7 +592,7 @@ def query_jobs_status(module, jobId):
             The output is """
                 + output
             )
-    if not output.get("jobs") and timeout == 0:
+    if not output and timeout == 0:
         raise SubmitJCLError(
             "THE JOB CAN NOT BE QUERIED FROM JES (TIMEOUT=10s). PLEASE CHECK THE ZOS SYSTEM. IT IS SLOW TO RESPONSE."
         )
@@ -729,7 +729,7 @@ def run_module():
         duration = 0
         try:
             waitJob = query_jobs_status(module, jobId)
-            job_msg = waitJob.get("jobs")[0].get("ret_code").get("msg")
+            job_msg = waitJob[0].get("ret_code").get("msg")
         except SubmitJCLError as e:
             module.fail_json(msg=repr(e), **result)
         # while (job_msg.startswith("CC") or job_msg.startswith("ABEND")) is False:
@@ -739,7 +739,7 @@ def run_module():
             sleep(1)
             duration = duration + 1
             waitJob = job_output(job_id=jobId)
-            job_msg = waitJob.get("jobs")[0].get("ret_code").get("msg")
+            job_msg = waitJob[0].get("ret_code").get("msg")
             if re.search("^(?:{0})".format("|".join(JOB_COMPLETION_MESSAGES)), job_msg):
                 break
             if duration == wait_time_s:  # Long running task. timeout return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # Copyright (c) IBM Corporation 2019, 2020
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
@@ -47,6 +47,7 @@ def ansible_zos_module(request, z_python_interpreter):
         host.vars["ansible_python_interpreter"] = interpreter
         host.vars["ansible_connection"] = "zos_ssh"
     yield adhoc
+    adhoc.all.command(cmd="opercmd '$PJ(*)'")
 
 
 # * We no longer edit sys.modules directly to add zoautil_py mock


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module fixes #1661 and #1704 in Jira, as well as fixes #62  in GitHub.
Both modules were using the ZOAU Jobs.list() method, which does not support querying on jobs by ID outside of those owned by the user. This can be done by calling Jobs.list() with no arguments then parsing, but that is excessive. 

This PR removed the use of Jobs.list() from the modules and replaces it with calls to the shared job utility in module_utils. In addition, a new function, job_status, was added to the shared job utility to simplify retrieval of basic status information for jobs without spending the effort or computationfinding,  printing and parsing all the DD output.

Other changes:

- enhanced shared job library to no longer require AnsibleModule object to be provided as an argument
- enhanced shared job library job_output function output to only return a list of jobs, instead of a dictionary with the single "jobs" key. Any requirements of adding this list to a dictionary containing "jobs" key has been moved to the modules.
- updated relevant portions of zos_job_submit and zos_job_query to maintain consistent behavior after switching from ZOAU to shared utility.
- updated zos_job_output due to changes in job_output function parameters
- added small job clean up task in functional test pytest fixture to clean up job logs after each test

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- plugins/modules/zos_job_submit.py
- plugins/modules/zos_job_query.py
- plugins/modules/zos_job_output.py
- plugins/module_utils/job.py
- tests/conftest.py