### PR TITLE
Content/58/update documentation for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@ IBM z/OS core collection
 The **IBM z/OS core collection**, also represented as **ibm\_zos\_core**
 in this document, is part of the broader offering **Red Hat® Ansible
 Certified Content for IBM Z**. IBM z/OS core collection supports tasks
-such as creating data sets, submitting jobs, querying jobs, and
-retrieving job output.
+such as creating data sets, submitting jobs, querying jobs,
+retrieving job output, encoding data sets, fetching data sets, operator
+commands, TSO commands, ping and querying operator actions.
+
+The **IBM z/OS core collection** serves as a dependency for other collections
+under the **Red Hat® Ansible Certified Content for IBM Z** umbrella and
+works closely with offerings such as [IBM z/OS IMS collection]
+(https://github.com/ansible-collections/ibm_zos_ims) to deliver
+a solution that will enable you to automate tasks on z/OS subsystems such
+as IMS.
 
 Red Hat Ansible Certified Content for IBM Z
 ===========================================
@@ -18,8 +26,8 @@ orchestration with configuration management, provisioning, and
 application deployment in one easy-to-use platform.
 
 IBM z/OS core collection, as part of the broader offering **Red Hat®
-Ansible Certified Content for IBM Z**, will be available on both, Galaxy
-as community supported and Automation Hub with enterprise support.
+Ansible Certified Content for IBM Z**, is available on both, **Galaxy**
+as community supported and **Automation Hub** with enterprise support.
 
 For **guides** and **reference**, please visit [the documentation
 site](https://ansible-collections.github.io/ibm_zos_core/).
@@ -27,13 +35,17 @@ site](https://ansible-collections.github.io/ibm_zos_core/).
 Features
 ========
 
-The IBM z/OS core collection includes [connection
-plugins](https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/connection/),
-[action
-plugins](https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/action/),
-[modules](https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/modules/),
-[sample
-playbooks](https://github.com/ansible-collections/ibm_zos_core/tree/master/playbooks/)
+The IBM z/OS core collection includes
+[connection plugins]
+(https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/connection/),
+[action plugins]
+(https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/action/),
+[modules]
+(https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/modules/),
+[sample playbooks]
+(https://github.com/ansible-collections/ibm_zos_core/tree/master/playbooks/),
+[filters]
+(https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/filter/),
 and ansible-doc to automate tasks on z/OS.
 
 Copyright

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ commands, TSO commands, ping and querying operator actions.
 
 The **IBM z/OS core collection** serves as a dependency for other collections
 under the **Red Hat® Ansible Certified Content for IBM Z** umbrella and
-works closely with offerings such as [IBM z/OS IMS collection]
-(https://github.com/ansible-collections/ibm_zos_ims) to deliver
-a solution that will enable you to automate tasks on z/OS subsystems such
-as IMS.
+works closely with offerings such as
+[IBM z/OS IMS collection](https://github.com/ansible-collections/ibm_zos_ims) 
+to deliver a solution that will enable you to automate tasks on z/OS subsystems
+such as IMS.
 
 Red Hat Ansible Certified Content for IBM Z
 ===========================================

--- a/README.md
+++ b/README.md
@@ -36,16 +36,11 @@ Features
 ========
 
 The IBM z/OS core collection includes
-[connection plugins]
-(https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/connection/),
-[action plugins]
-(https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/action/),
-[modules]
-(https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/modules/),
-[sample playbooks]
-(https://github.com/ansible-collections/ibm_zos_core/tree/master/playbooks/),
-[filters]
-(https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/filter/),
+[connection plugins](https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/connection/),
+[action plugins](https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/action/),
+[modules](https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/modules/),
+[sample playbooks](https://github.com/ansible-collections/ibm_zos_core/tree/master/playbooks/),
+[filters](https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/filter/),
 and ansible-doc to automate tasks on z/OS.
 
 Copyright

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,14 +18,14 @@ help:
 
 .PHONY: help Makefile
 
-clean: 
+clean:
 	rm -rf build
 	echo "Deleted directory build/"
 
 	rm -rf source/modules
 	echo "Deleted directory source/modules"
-	echo "Completed HTML text generation, run 'make ibm_zos_core'"
-ibm_zos_core: 
+	echo "Completed HTML text generation, run 'make ibm_zos_doc'"
+ibm_zos_doc:
 	mkdir build
 	mkdir -p source/modules
 	mv ../plugins/modules/__init__.py ../plugins/modules/__init__.py.skip

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -1,0 +1,40 @@
+.. ...........................................................................
+.. © Copyright IBM Corporation 2020                                          .
+.. ...........................................................................
+
+Filters
+=======
+
+Filters in Ansible are from Jinja2, and are used for transforming data inside
+a template expression. Jinja2 ships with many filters as does Ansible and also
+allows users to add their own custom filters.
+
+It should be noted that templates operate on the Ansible controller, not on the
+target host, so filters execute on the controller as they augment the data
+locally.
+
+The **IBM z/OS core collection** includes filters and their usage in sample
+playbooks.
+
+Unlike collections that can be identified at the top level using the
+collections keyword and then simply accessing modules using module names,
+filters even when included in a collection must always be specified in the
+playbook with their fully qualified name.
+
+Filters usage follows this pattern:
+
+   .. note::
+         * <namespace>.<collection>.<filter>
+         * ibm.ibm_zos_core.filter_wtor_messages('IEE094D SPECIFY OPERAND')
+
+For more details on filters, review the filters and documentation under
+the `filter`_ directory included in the collection.
+
+.. _filter:
+   https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/filter/
+
+
+
+
+
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,11 +5,19 @@
 IBM z/OS core collection
 ========================
 
-The **IBM z/OS core collection**, also represented as **ibm_zos_core** in this 
-document, is part of the broader offering
-**Red Hat® Ansible Certified Content for IBM Z**. IBM z/OS core collection 
-supports tasks such as creating data sets, submitting jobs, querying jobs, and
-retrieving job output.
+The **IBM z/OS core collection**, also represented as **ibm\_zos\_core**
+in this document, is part of the broader offering **Red Hat® Ansible
+Certified Content for IBM Z**. IBM z/OS core collection supports tasks
+such as creating data sets, submitting jobs, querying jobs,
+retrieving job output, encoding data sets, fetching data sets, operator
+commands, TSO commands, ping and querying operator actions.
+
+The **IBM z/OS core collection** serves as a dependency for other collections
+under the **Red Hat® Ansible Certified Content for IBM Z** umbrella and
+works closely with offerings such as [IBM z/OS IMS collection]
+(https://github.com/ansible-collections/ibm_zos_ims) to deliver
+a solution that will enable you to automate tasks on z/OS subsystems such
+as IMS.
 
 Red Hat Ansible Certified Content for IBM Z
 ===========================================
@@ -23,14 +31,14 @@ easy-to-use platform.
 
 IBM z/OS core collection, as part of the broader offering
 **Red Hat® Ansible Certified Content for IBM Z**, will be available on both,
-Galaxy as community supported and Automation Hub with enterprise support. 
+Galaxy as community supported and Automation Hub with enterprise support.
 
 Features
 ========
 
 The IBM z/OS core collection includes `connection plugins`_,
-`action plugins`_, `modules`_, `sample playbooks`_ and ansible-doc to automate
-tasks on z/OS.
+`action plugins`_, `modules`_, `sample playbooks`_, `filters`_ and 
+ansible-doc to automate tasks on z/OS.
 
 .. _connection plugins:
    https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/connection/
@@ -40,6 +48,8 @@ tasks on z/OS.
     https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/modules/
 .. _sample playbooks:
     https://github.com/ansible-collections/ibm_zos_core/tree/master/playbooks/
+.. _filters:
+   https://github.com/ansible-collections/ibm_zos_core/tree/master/plugins/filter/
 
 
 Copyright

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ as IMS.
 
 .. _IBM z/OS IMS collection:
    https://github.com/ansible-collections/ibm_zos_ims
+
 Red Hat Ansible Certified Content for IBM Z
 ===========================================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,11 +14,12 @@ commands, TSO commands, ping and querying operator actions.
 
 The **IBM z/OS core collection** serves as a dependency for other collections
 under the **Red Hat® Ansible Certified Content for IBM Z** umbrella and
-works closely with offerings such as [IBM z/OS IMS collection]
-(https://github.com/ansible-collections/ibm_zos_ims) to deliver
+works closely with offerings such as `IBM z/OS IMS collection`_ to deliver
 a solution that will enable you to automate tasks on z/OS subsystems such
 as IMS.
 
+.. _IBM z/OS IMS collection:
+   https://github.com/ansible-collections/ibm_zos_ims
 Red Hat Ansible Certified Content for IBM Z
 ===========================================
 
@@ -37,7 +38,7 @@ Features
 ========
 
 The IBM z/OS core collection includes `connection plugins`_,
-`action plugins`_, `modules`_, `sample playbooks`_, `filters`_ and 
+`action plugins`_, `modules`_, `sample playbooks`_, `filters`_ and
 ansible-doc to automate tasks on z/OS.
 
 .. _connection plugins:

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -75,7 +75,7 @@ After installation, the collection content will resemble this hierarchy: :
    │                  ├── action/
    │                  ├── connection/
    │                  ├── module_utils/
-   │                  └── modules/
+   │                  ├── modules/
    │                  └── filter/
 
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -6,7 +6,7 @@ Installation
 ============
 
 You have several options you may use to install the
-**IBM z/OS Core Collection**. These are Ansible Galaxy, 
+**IBM z/OS Core Collection**. These are Ansible Galaxy,
 Ansible Automation Hub, and a local build.
 
 For more information on installing collections, see `using collections`_.
@@ -17,18 +17,35 @@ For more information on installing collections, see `using collections`_.
 Ansible Galaxy
 --------------
 
-You can use the `ansible-galaxy`_ command with the option ``install`` to 
+You can use the `ansible-galaxy`_ command with the option ``install`` to
 install a collection on your system (control node) hosted in Galaxy.
 
 Galaxy enables you to quickly configure your automation project with content
 from the Ansible community. Galaxy provides prepackaged units of work known as
-collections.
+collections. If you have installed a prior version you may need to force
+overwriting an existing collection with the ``--force`` option.
 
-Here's an example command for installing the **IBM z/OS core collection**:
+Here are examples for installing the **IBM z/OS core collection**:
 
 .. code-block:: sh
 
-   $ ansible-galaxy collection install ibm.ibm_zos_core
+   $ ansible-galaxy collection install ibm.ibm_zos_core\
+   $ ansible-galaxy collection install -f ibm.ibm_zos_core
+   $ ansible-galaxy collection install --force ibm.ibm_zos_core
+
+
+By default, ansible-galaxy installs the latest collection that is available but
+you can add a version identifier to install a specific version. When installing
+a collection from Galaxy, it would be good to review the versions available as
+there can be point releases, mods and beta versions available and you may be
+interested in features in a particular version.
+
+Here's an example command for installing the **IBM z/OS core collection** for
+a specific version.
+
+.. code-block:: sh
+
+   $ ansible-galaxy collection install ibm.ibm_zos_core::1.0.0
 
 The collection installation progress will be output to the console. Note the
 location of the installation so that you can review other content included with
@@ -59,6 +76,7 @@ After installation, the collection content will resemble this hierarchy: :
    │                  ├── connection/
    │                  ├── module_utils/
    │                  └── modules/
+   │                  └── plugin/
 
 
 You can use the `-p` option with `ansible-galaxy` to specify the installation
@@ -74,19 +92,19 @@ see `installing collections`_.
 .. _installing collections:
    https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#installing-collections-with-ansible-galaxy
 
-Private Galaxy server
----------------------
+Automaton Hub and Private Galaxy server
+---------------------------------------
 Configuring access to a private Galaxy server follows the same instructions
 that you would use to configure your client to point to Automation Hub. When
 hosting a private Galaxy server or pointing to Hub, available content is not
 always consistent with what is available on the community Galaxy server.
 
-You can use the `ansible-galaxy`_ command with the option ``install`` to 
-install a collection on your system (control node) hosted in Automation Hub 
+You can use the `ansible-galaxy`_ command with the option ``install`` to
+install a collection on your system (control node) hosted in Automation Hub
 or a private Galaxy server.
 
 By default, the ``ansible-galaxy`` command is configured to access
-``https://galaxy.ansible.com`` as the Galaxy server when you install a
+``https://galaxy.ansible.com`` as the server when you install a
 collection. The `ansible-galaxy` client can be configured to point to Hub or
 other servers, such as a privately running Galaxy server, by configuring the
 server list in the ``ansible.cfg`` file.
@@ -100,14 +118,16 @@ Ansible searches for ``ansible.cfg`` in these locations in this order:
 
 To configure a Galaxy server list in the ansible.cfg file:
 
-  * Add the server_list option under the [galaxy] section to one or more server names.
+  * Add the server_list option under the [galaxy] section to one or more
+    server names.
   * Create a new section for each server name.
   * Set the url option for each server name.
 
 For Automation Hub, you additionally need to:
 
   * Set the auth_url option for each server name.
-  * Set the API token for each server name. For more information on API tokens, see `Get API token from the version dropdown to copy your API token`_.
+  * Set the API token for each server name. For more information on API tokens,
+    see `Get API token from the version dropdown to copy your API token`_.
 
 .. _Get API token from the version dropdown to copy your API token:
    https://cloud.redhat.com/ansible/automation-hub/token/
@@ -118,20 +138,19 @@ running Galaxy server, and Galaxy:
 .. code-block:: yaml
 
    [galaxy]
-   server_list = automation_hub, release_galaxy, private_galaxy
+   server_list = automation_hub, galaxy, private_galaxy
 
    [galaxy_server.automation_hub]
    url=https://cloud.redhat.com/api/automation-hub/
    auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
-   token=hub_token
+   token=<hub_token>
 
-   [galaxy_server.release_galaxy]
+   [galaxy_server.galaxy]
    url=https://galaxy.ansible.com/
-   token=release_token
 
    [galaxy_server.private_galaxy]
    url=https://galaxy-dev.ansible.com/
-   token=private_token
+   token=<private_token>
 
 For more configuration information, see
 `configuring the ansible-galaxy client`_ and `Ansible Configuration Settings`_.
@@ -156,10 +175,6 @@ Galaxy.
 To build a collection from the git repository:
 
    1. Clone the sample repository:
-
-      .. code-block:: sh
-
-         $ git clone git@github.com:ansible-collections/ibm_zos_core.git
 
       .. note::
          * Collection archive names will change depending on the release version.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -76,7 +76,7 @@ After installation, the collection content will resemble this hierarchy: :
    │                  ├── connection/
    │                  ├── module_utils/
    │                  └── modules/
-   │                  └── plugin/
+   │                  └── filter/
 
 
 You can use the `-p` option with `ansible-galaxy` to specify the installation

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -6,7 +6,7 @@ Modules
 =======
 
 Modules can be used from the command line or in a playbook task. Ansible
-executes each module, usually on the remote target node, and collects return
+executes each module on the remote target node, and collects return
 values.
 
 While different modules perform different tasks, their interfaces and responses

--- a/docs/source/playbooks.rst
+++ b/docs/source/playbooks.rst
@@ -33,23 +33,44 @@ refer to the installation path as ``~/.ansible/collections/ibm/ibm_zos_core``.
 
 
 Sample Configuration and Setup
----------------------------------------
+------------------------------
+Each release of Ansible provides options beyond the options identified in the
+sample configurations that are included with this collection. These options
+allow you to customize how Ansible operates. Ansible supports several sources
+to configure its behavior, they follow the Ansible `precedence rules`_.
 
-Ansible config file `ansible.cfg` can override nearly all
-``ansible-playbook`` configurations. Also included in the
-`playbooks directory`_ is a sample `ansible.cfg`_ that with little
-modification can supplement ``ansible-playbook``.
+Ansible config file `ansible.cfg` can override nearly all ``ansible-playbook``
+configurations. Included in the `playbooks directory`_ is a sample
+`ansible.cfg`_ that with little modification can supplement
+``ansible-playbook``.
 
-In the sample `ansible.cfg`_, the only required configuration is:
+In the sample `ansible.cfg`_, the only required configuration is
 ``pipelining = True``
+
+We often see users who specify the SSH port used by Ansible and instruct
+Ansible where to write temporary files on the target. This can easily be done
+by adding a these options to your inventory or `ansible.cfg`.
+
+An example of adding these options to `ansible.cfg` is shown below, see the
+sample `ansible.cfg`_ notes for more details.
+
+.. code-block:: yaml
+
+   [defaults]
+   forks = 25
+   remote_tmp = /u/ansible/tmp
+   remote_port = 2022
 
 For more information about available configurations for ``ansible.cfg``, read
 the Ansible documentation on `Ansible configuration settings`_.
+
 
 .. _ansible.cfg:
    https://github.com/ansible-collections/ibm_zos_core/blob/master/playbooks/ansible.cfg
 .. _Ansible configuration settings:
    https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-configuration-settings-locations
+.. _precedence rules:
+   https://docs.ansible.com/ansible/latest/reference_appendices/general_precedence.html#general-precedence-rules
 
 Inventory
 ---------
@@ -84,8 +105,13 @@ path. This is useful for systems with more than one Python installation, or
 when Python is not located at in the default location **/usr/bin/python**, for
 example, ``ansible_python_interpreter: /usr/lpp/rsusr/python36/bin/python``
 
+
 For more information on python configuration requirements on z/OS, refer to
 Ansible `FAQ`_.
+
+For behavioral inventory parameters such as ``ansible_port`` which allows you
+to set the port for a host can be reviewed in the
+`behavioral inventory parameters`_.
 
 .. _inventory:
    https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html
@@ -95,6 +121,8 @@ Ansible `FAQ`_.
    https://github.com/ansible-collections/ibm_zos_core/blob/master/playbooks/inventory
 .. _FAQ:
    https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#running-on-z-os
+.. behavioral inventory parameters:
+   https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#connecting-to-hosts-behavioral-inventory-parameters
 
 
 Group_vars
@@ -140,6 +168,7 @@ interpreter path, for example,
 
 .. _all.yml:
    https://github.com/ansible-collections/ibm_zos_core/blob/master/playbooks/group_vars/all.yml
+
 
 
 Run the playbook

--- a/docs/source/playbooks.rst
+++ b/docs/source/playbooks.rst
@@ -121,7 +121,7 @@ to set the port for a host can be reviewed in the
    https://github.com/ansible-collections/ibm_zos_core/blob/master/playbooks/inventory
 .. _FAQ:
    https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#running-on-z-os
-.. behavioral inventory parameters:
+.. _behavioral inventory parameters:
    https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#connecting-to-hosts-behavioral-inventory-parameters
 
 

--- a/docs/source/playbooks.rst
+++ b/docs/source/playbooks.rst
@@ -181,10 +181,20 @@ levels INFO, WARN, ERROR, DEBUG.
    and artifacts will be created and cleaned up. Although samples are always
    written to operate without the need for users configuration, flexibility is
    written into the samples because it can't always be determined if a sample
-   has access to the hosts resources.
+   has access to the hosts resources. Review the playbook notes sections for
+   additional details and configuration.
+
+   Sample playbooks often submit JCL that is included with this collection
+   under the `files directory`_. Review the sample JCL for necessary edits to
+   allow for submission on the target system. The most common changes are to
+   add a CLASS parameter and change the NOTIFY user parameter. For more details
+   see the JCL notes section included in the collection.
 
 .. _ask-pass documentation:
    https://linux.die.net/man/1/sshpass
+
+.. _files directory:
+   https://github.com/ansible-collections/ibm_zos_core/tree/dev/playbooks/files
 
 
 

--- a/docs/source/playbooks.rst
+++ b/docs/source/playbooks.rst
@@ -107,7 +107,7 @@ file `all.yml`_.
 
 The value for property **BPXK_AUTOCVT** must be configured to ``ON``.
 
-The value for property **ZOAU_ROOT** is the ZOA Utilities install root path,
+The value for property **ZOAU_HOME** is the ZOA Utilities install root path,
 for example, ``/usr/lpp/IBM/zoautil``.
 
 The value for property **PYTHONPATH** is the ZOA Utilities Python library path,
@@ -126,10 +126,17 @@ interpreter path, for example,
 
    environment_vars:
       _BPXK_AUTOCVT: ON
-      ZOAU_ROOT: '/usr/lpp/IBM/zoautil'
+      ZOAU_HOME: '/usr/lpp/IBM/zoautil'
       PYTHONPATH: '/usr/lpp/IBM/zoautil/lib'
       LIBPATH: '/usr/lpp/IBM/zoautil/lib/:/usr/lpp/rsusr/python36/lib:/usr/lib:/lib:.'
-      PATH: '/usr/lpp/IBM/zoautil/bin;/usr/lpp/rsusr/python36/bin/python'
+      PATH: '/usr/lpp/IBM/zoautil/bin:/usr/lpp/rsusr/python36/bin/python:/bin'
+
+.. note::
+   In ZOAU 1.0.2 and later, the property **ZOAU_ROOT** is no longer supported
+   and can be replaced with property **ZOAU_HOME**. If you are using ZOAU less
+   than or equal to version 1.0.1, you must continue to use property
+   **ZOAU_ROOT** which is the ZOA Utilities install root path required for
+   ZOAU, for example, ``/usr/lpp/IBM/zoautil``.
 
 .. _all.yml:
    https://github.com/ansible-collections/ibm_zos_core/blob/master/playbooks/group_vars/all.yml
@@ -167,6 +174,14 @@ for example, `-v`, `-vv`, `-vvv`, or `-vvvv`.
 
 Each letter `v` increases logging verbosity similar to traditional logging
 levels INFO, WARN, ERROR, DEBUG.
+
+.. note::
+   It is a good practice to review the playbook samples before executing them
+   to understand what requirements in terms of space, location, names, authority
+   and artifacts will be created and cleaned up. Although samples are always
+   written to operate without the need for users configuration, flexibility is
+   written into the samples because it can't always be determined if a sample
+   has access to the hosts resources.
 
 .. _ask-pass documentation:
    https://linux.die.net/man/1/sshpass

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,8 +5,8 @@
 Releases
 ========
 
-Version 1.1.0-beta
-------------------
+Version 1.1.0-beta1
+-------------------
 
 Notes
    * Update recommended

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@ Releases
 ========
 
 Version 1.1.0-beta
--------------
+------------------
 
 Notes
    * Update recommended

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,28 @@
 Releases
 ========
 
+Version 1.1.0-beta
+-------------
+
+Notes
+   * Update recommended
+   * New modules
+
+     * zos_fetch, zos_encode, zos_operator_action_query, zos_operator,
+       zos_tso_command, zos_ping
+   * New filter
+   * Improved error handling and messages
+   * Bug fixes
+   * Documentation updates
+   * New samples
+
+Availability
+  * Galaxy
+  * github
+
+Reference
+  * Supported by IBM Z Open Automation Utilities: 1.0.2 or later
+
 Version 1.0.0
 -------------
 Notes
@@ -80,6 +102,3 @@ Availability
 
 Reference
   * Supported by IBM Z Open Automation Utilities: 1.0.1 (PTF UI66957 or later)
-
-
-

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -10,8 +10,8 @@ you can run commands and playbooks from a laptop, desktop, or server machine.
 However, you cannot run **IBM z/OS core collection** on a Windows machine.
 
 A managed node is often referred to as a target node, or host, and is the node
-that is managed by Ansible. Ansible does not need not need to be installed on
-a managed node, but SSH must be enabled.
+that is managed by Ansible. Ansible does not need to be installed on a managed
+node, but SSH must be enabled.
 
 The following nodes require specific versions of software:
 
@@ -36,10 +36,14 @@ Managed node
 * `Python on z/OS`_: 3.6 or later
 * `z/OS`_: V02.02.00 or later
 * `IBM Z Open Automation Utilities`_ (ZOAU)
+
+   * IBM z/OS core collections are dependent on specific versions of ZOAU,
+     review the `release notes`_ to see which version of ZOAU is required.
 * `z/OS OpenSSH`_
 
 .. _Python on z/OS:
    requirements.html#id1
+
 .. _z/OS:
    https://www.ibm.com/support/knowledgecenter/SSLTBW_2.2.0/com.ibm.zos.v2r2/zos-v2r2-home.html
 
@@ -48,6 +52,9 @@ Managed node
 
 .. _z/OS OpenSSH:
    https://www.ibm.com/support/knowledgecenter/SSLTBW_2.2.0/com.ibm.zos.v2r2.e0za100/ch1openssh.htm
+
+.. _release notes:
+   release_notes.html
 
 Python on z/OS
 --------------

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -3,12 +3,25 @@
 ################################################################################
 
 ################################################################################
-# For for on ansible.cfg optons see:
-# https://docs.ansible.com/ansible/latest/reference_appendices/config.html
+# For for on ansible.cfg options see:
+#   https://docs.ansible.com/ansible/latest/reference_appendices/config.html
+#
+# For a full sample see:
+#   https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg
+#
+# Note:
+#   Some of the common options configured are `remote_temp` and `ansible_port`.
+#   remote_temp - The temporary directory Ansible uses to transfer files onto
+#                  the controller. Default is `/.ansible/tmp`
+#   ansible_port - The connection port number Ansible uses to connect to the
+#                  target; configure the target if is not using default SSH
+#                  port 22
 ################################################################################
 
 [defaults]
 forks = 25
+# remote_tmp = /u/ansible/tmp
+# remote_port = 2022
 
 [ssh_connection]
 pipelining = True

--- a/playbooks/files/HELLO.jcl
+++ b/playbooks/files/HELLO.jcl
@@ -1,5 +1,21 @@
-//HELLO    JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,
-//             MSGCLASS=X,MSGLEVEL=1,NOTIFY=S0JM
+//******************************************************************************
+//* Copyright (c) IBM Corporation 2020
+//******************************************************************************
+//******************************************************************************
+//* Configure the job card as needed, most common keyword parameters often
+//* needing editing are:
+//* CLASS: Used to achieve a balance between different types of jobs and avoid
+//*        contention between jobs that use the same resources.
+//* MSGLEVEL: controls hpw the allocation messages and termination messages are
+//*           printed in the job's output listing (SYSOUT).
+//* MSGCLASS: assign an output class for your output listing (SYSOUT)
+//*
+//* Notes:
+//*   If you change the job name, you must update the playbook job name
+//*   references.
+//******************************************************************************
+//HELLO    JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',
+//             MSGCLASS=X,MSGLEVEL=1,NOTIFY=&SYSUID
 //*
 //* PRINT "HELLO WORLD" ON JOB OUTPUT
 //*

--- a/playbooks/group_vars/all.yml
+++ b/playbooks/group_vars/all.yml
@@ -3,16 +3,28 @@
 ################################################################################
 
 ################################################################################
-# The value for property BPXK_AUTOCVT must be configured to ON.
-# The value for property ZOAU_ROOT is the ZOA Utilities install root path, for example: /usr/lpp/IBM/zoautil.
-# The value for property PYTHONPATH is the ZOA Utilities Python library path, for example: /usr/lpp/IBM/zoautil/lib/.
-# The value for property LIBPATH is both the path to the python libraries on the target and the ZOA Utilities Python library path separated by semi-colons,
+# - The value for property BPXK_AUTOCVT must be configured to ON.
+# - The value for property ZOAU_HOME is the ZOA Utilities install root path,
+# for example: /usr/lpp/IBM/zoautil.
+# - The value for property ZOAU_ROOT is the ZOA Utilities install root path,
+# for example: /usr/lpp/IBM/zoautil.
+# - The value for property PYTHONPATH is the ZOA Utilities Python library path,
+# for example: /usr/lpp/IBM/zoautil/lib/.
+# - The value for property LIBPATH is both the path to the python libraries on
+# the target and the ZOA Utilities Python library path separated by semi-colons,
 # for example: /usr/lpp/IBM/zoautil/lib/:/usr/lpp/rsusr/python36/lib:/lib:/usr/lib:..
-# The value for property PATH is the ZOA utilities BIN path and Python interpreter path, for example: /usr/lpp/IBM/zoautil/bin;/usr/bin/python.
+# - The value for property PATH is the ZOA utilities BIN path and Python
+# interpreter path, for example: /usr/lpp/IBM/zoautil/bin:/usr/bin/python:/bin
+#
+# Note:
+#   In the configuration below, both `ZOAU_HOME` and `ZOAU_ROOT` are included.
+#   In ZOAU 1.0.1 and lesser, property `ZOAU_ROOT` is required, for versions
+#   ZOAU 1.0.2 and later, property `ZOAU_HOME` replaces `ZOAU_ROOT`
 ################################################################################
 
 environment_vars:
   _BPXK_AUTOCVT: ON
+  ZOAU_HOME: "/usr/lpp/IBM/zoautil"
   ZOAU_ROOT: "/usr/lpp/IBM/zoautil"
   PYTHONPATH: "/usr/lpp/IBM/zoautil/lib"
   LIBPATH: "/usr/lpp/IBM/zoautil/lib/:/usr/lpp/rsusr/python36/lib:/usr/lib:/lib:."

--- a/playbooks/inventory
+++ b/playbooks/inventory
@@ -4,3 +4,4 @@ zsystem:
       ansible_host: zos_target_address
       ansible_user: zos_target_username
       ansible_python_interpreter: path_to_python_interpreter_binary_on_zos_target
+

--- a/playbooks/zos-collection-sample-v2.yaml
+++ b/playbooks/zos-collection-sample-v2.yaml
@@ -14,13 +14,38 @@
 #
 # Notes:
 #  This sample demonstrates various ways to perform tasks using Ansible z/OS
-#  core modules. Each module has options available to customize how
-#  automation can be controlled. This sample does not demonstrate all options,
-#  refer to documentation or ansible-doc for those options.
+#  core modules. Each module has options available on how automation can be
+#  controlled. This sample does not demonstrate all options, refer to
+#  documentation or ansible-doc for those options.
+#
+#  When running this playbook, review the comments on how ths sample will
+#  interact with your target, ensure you have the required authority and
+#  permissions such as writing the the target directories or creating data sets.
+#
+#  Data sets created for this sample will follow this pattern
+#  <USER<.SOME.DATA.SET where USER will be the user who submits the playbook.
+# The user is identified by the Ansible variable `ansible_user`.
+#
+#  Additional facts for this playbook can be configured to override the defaults
+#  by reviewing the "Fact setting" section of this playbook, for example,
+#  `data_set_name` and `system_name`.
 #
 # Requirements:
-#   IBM z/OS core collection 1.0.1 or later
-#   ZOAU 1.0.2 or later
+#   IBM z/OS core collection 1.1.0-beta1 or later
+#   ZOAU 1.0.1 or later
+#
+# Configure:
+#   tgt_tmp_dir - this is the USS directory on the target which will be written
+#                 to for this example.
+#   ctl_tmp_dir - this is the directory on the controller which will be written
+#                 to for this example.
+# Optional:
+#   data_set_name - this is the data set name that will be created during
+#                   execution of this sample.
+#   system_name - this is the system name that will be used during this example,
+#                 determined by executing `uname -n` on the target.
+#   job_name - this is the job name what will be used in this sample, if you
+#              change the HELLO.JCL job name, you must update this variable
 ###############################################################################
 
 ---
@@ -29,23 +54,13 @@
     - ibm.ibm_zos_core
   gather_facts: no
   vars:
-    tgt_tmp_dir: "/tmp" # Scratch target directory in USS
-    ctl_tmp_dir: "/tmp" # scratch controller directory
+    tgt_tmp_dir: "/tmp"
+    ctl_tmp_dir: "/tmp"
+    job_name: "HELLO"
   environment: "{{ environment_vars }}"
   connection: ibm.ibm_zos_core.zos_ssh
 
   tasks:
-    # ##########################################################################
-    # Check requirements, iconv, z/OS Web Client Enablement toolkit, python
-    # ##########################################################################
-    - name: Ping the z/OS host {{ inventory_hostname }} and perform resource checks
-      zos_ping:
-      register: result
-
-    - name: Response
-      debug:
-        msg: "{{ result }}"
-
     # ##########################################################################
     # Fact setting for use by this playbook
     # ##########################################################################
@@ -58,7 +73,8 @@
         msg: "{{ data_set_name }}"
 
     - name: Detecting system name
-      shell: "uname -a |awk '{print $2}'"
+      #shell: "uname -a |awk '{print $2}'"
+      command: uname -n
       register: result
 
     - name: Setting fact `system_name` for use by this sample
@@ -68,6 +84,17 @@
     - name: Fact `system_name` set with value
       debug:
         msg: "{{ system_name }}"
+
+    # ##########################################################################
+    # Check requirements, iconv, z/OS Web Client Enablement toolkit, python
+    # ##########################################################################
+    - name: Ping the z/OS host {{ inventory_hostname }} and perform resource checks
+      zos_ping:
+      register: result
+
+    - name: Response
+      debug:
+        msg: "{{ result }}"
 
     # ##########################################################################
     # Modules zos_operator_action_query, zos_operator
@@ -288,7 +315,7 @@
     # Modules zos_encode
     # ##########################################################################
     # +-------------------------------------------------------------------------
-    # | Create script on target, encode with the targets charset, execute
+    # | Create shell script on target, encode with the targets charset, execute
     # | script if mode == 755, else fail
     # +-------------------------------------------------------------------------
     - name: Create shell script {{ tgt_tmp_dir }}/date.sh on
@@ -370,7 +397,7 @@
         msg: "{{ result }}"
 
     # +-------------------------------------------------------------------------
-    # | Create 4 USS files, encode, delete
+    # | Create 4 files on USS target, encode them and and delete them
     # +-------------------------------------------------------------------------
 
     - name: Detecting the character set for the locale on the target
@@ -450,8 +477,14 @@
         msg: "{{ result }}"
 
     ############################################################################
-    # List user OMVSADM
+    # Modules zos_data_set, zos_tso_command, zos_job_submit, zos_job_query,
+    # zos_job_output
     ############################################################################
+    # +-------------------------------------------------------------------------
+    # | Create a data set, create JCL on USS target, copy USS JCL to data set,
+    # | rename data set using TSO commands, submit JCL in data set, query job,
+    # | get job output, delete data set using TSO command
+    # +-------------------------------------------------------------------------
     - name: Create a PDS data set {{ data_set_name }}
       zos_data_set:
         name: "{{ data_set_name }}"
@@ -561,75 +594,113 @@
       debug:
         msg: "{{ result }}"
 
-    - name: Remove files on target in {{ tgt_tmp_dir }}/encode
+    - name: Remove files on target in {{ tgt_tmp_dir }}/ansible
       file:
         path: "{{ tgt_tmp_dir }}/ansible"
         state: absent
       register: result
 
-    - name: Response for remove files on target in {{ tgt_tmp_dir }}/encode
+    - name: Response for remove files on target in {{ tgt_tmp_dir }}/ansible
       debug:
         msg: "{{ result }}"
 
-    ############################################################################
-    # Crete location for JCL in USS
-    ############################################################################
+    # ##########################################################################
+    # Modules zos_job_submit, zos_job_query, zos_job_output, zos_data_set
+    # ##########################################################################
+    # +-------------------------------------------------------------------------
+    # | Create a directory in USS on the target, write sample JCL on target,
+    # | submit the target JCL, query for the submitted job and obtain the
+    # | job output, demonstrate creating and deleting data sets
+    # +-------------------------------------------------------------------------
 
-    - name: Ensure JCL folder exists in USS to manage JCL
+    - name: Create directory {{ tgt_tmp_dir }}/ansible/jcl on USS
+            target {{ system_name }}
       file:
         path: "{{ tgt_tmp_dir }}/ansible/jcl"
         state: directory
 
-    - name: Write HELLO JCL to USS in {{ tgt_tmp_dir }}/ansible/jcl/HELLO"
-        on target {{ inventory_hostname }}
-      shell: "echo {{ lookup('file', playbook_dir + '/files/HELLO.jcl') | quote }} > {{ tgt_tmp_dir }}/ansible/jcl/HELLO"
+    - name: Write sample {{ job_name }} JCL in {{ tgt_tmp_dir }}/ansible/jcl
+            on USS
+            target {{ system_name }}
+      shell: "echo {{ lookup('file', playbook_dir + '/files/{{job_name}}.jcl') | quote }} > {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}"
       changed_when: true
       register: result
 
-    - name: Response for ensure JCL folder exists in USS to manage JCL
+    - name: Response for write sample {{job_name}} JCL in {{ tgt_tmp_dir }}/ansible/jcl
+            on USS target {{ system_name }}
       debug:
         msg: "{{ result }}"
 
-    - name: Submit HELLO jcl on on target in {{ tgt_tmp_dir }}/ansible/jcl/HELLO
+    - name: Submit {{job_name}} jcl located on target
+            in {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}
       zos_job_submit:
-        src: "{{ tgt_tmp_dir }}/ansible/jcl/HELLO"
+        src: "{{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}"
         location: USS
         wait: True
 
-    - name: Response for submit HELLO jcl on on target
-        in {{ tgt_tmp_dir }}/ansible/jcl/HELLO
+    - name: Response for submit {{job_name}} jcl located on target
+            in {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}
       debug:
         msg: "{{ result }}"
 
-    - name: Query submitted job 'HELLO'
+    - name: Query the submitted job {{job_name}} on USS target {{ system_name }}
       zos_job_query:
-        job_name: HELLO
+        job_name: "{{job_name}}"
       register: result
 
-    - name: Response for query submitted job 'HELLO'
+    - name: Response for Query the submitted job {{job_name}}
+            on USS target {{ system_name }}
       debug:
         msg: "{{ result }}"
 
-    - name: Get HELLO job output
+    - name: Get {{job_name}} job output on USS target {{ system_name }}
       zos_job_output:
-        job_name: HELLO
+        job_name: "{{job_name}}"
       register: result
 
-    - name: Response for get HELLO job output
+    - name: Response for Get {{job_name}} job output on USS target {{ system_name }}
       debug:
         msg: "{{ result }}"
 
-    - name: Remove HELLO JCL and folder from z/OS target node
+    - name: Remove {{job_name}} JCL and folder on USS target {{ system_name }}
       file:
         path: "{{ tgt_tmp_dir }}/ansible"
         state: absent
 
-    - name: Delete data set 'USER.PRIVATE.TEST'
+    - name: Response for remove {{job_name}} JCL and folder on
+            USS target {{ system_name }}
+      debug:
+        msg: "{{ result }}"
+
+    - name: Create a PDS data set {{ data_set_name }}
       zos_data_set:
-        name: USER.PRIVATE.TEST
+        name: "{{ data_set_name }}"
+        type: pds
+        size: 5M
+        format: fb
+        record_length: 25
+        replace: yes
+      register: result
+
+    - name: Response create a PDS data set {{ data_set_name }}
+      debug:
+        msg: "{{ result }}"
+
+    - name: Check if data set {{ data_set_name }} was created
+      command: "dls {{ data_set_name }}"
+      register: result
+      changed_when: true
+
+    - name: Response for check if data set {{ data_set_name }} was created
+      debug:
+        msg: "{{ result }}"
+
+    - name: Delete data set {{ data_set_name }}
+      zos_data_set:
+        name: "{{ data_set_name }}"
         state: absent
       register: result
 
-    - name: Response for delete data set 'USER.PRIVATE.TEST'
+    - name: Response for delete data set {{ data_set_name }}
       debug:
         msg: "{{ result }}"

--- a/playbooks/zos-collection-sample.yaml
+++ b/playbooks/zos-collection-sample.yaml
@@ -12,6 +12,40 @@
 # Example:
 #  ansible-playbook -i inventory zos-collection-sample.yaml
 #
+# Notes:
+#  This sample demonstrates various ways to perform tasks using Ansible z/OS
+#  core modules. Each module has options available on how automation can be
+#  controlled. This sample does not demonstrate all options, refer to
+#  documentation or ansible-doc for those options.
+#
+#  When running this playbook, review the comments on how ths sample will
+#  interact with your target, ensure you have the required authority and
+#  permissions such as writing the the target directories or creating data sets.
+#
+#  Data sets created for this sample will follow this pattern
+#  <USER<.SOME.DATA.SET where USER will be the user who submits the playbook.
+#  The user is identified by the Ansible variable `ansible_user`.
+#
+#  Additional facts for this playbook can be configured to override the defaults
+#  by reviewing the "Fact setting" section of this playbook, for example,
+#  `data_set_name` and `system_name`.
+#
+# Requirements:
+#   IBM z/OS core collection 1.0.0 or later
+#   ZOAU 1.0.1 or later
+#
+# Configure:
+#   tgt_tmp_dir - this is the USS directory on the target which will be written
+#                 to for this example.
+#   ctl_tmp_dir - this is the directory on the controller which will be written
+#                 to for this example.
+# Optional:
+#   data_set_name - this is the data set name that will be created during
+#                   execution of this sample.
+#   system_name - this is the system name that will be used during this example,
+#                 determined by executing `uname -n` on the target.
+#   job_name - this is the job name what will be used in this sample, if you
+#              change the HELLO.JCL job name, you must update this variable
 ###############################################################################
 
 ---
@@ -19,61 +53,119 @@
   collections:
     - ibm.ibm_zos_core
   gather_facts: no
+  vars:
+    tgt_tmp_dir: "/tmp"
+    ctl_tmp_dir: "/tmp"
+    job_name: "HELLO"
 
   environment: "{{ environment_vars }}"
 
   tasks:
-    # Ping the host
+    # ##########################################################################
+    # Fact setting for use by this playbook
+    # ##########################################################################
+    - name: Setting fact `data_set_name` for use by this sample
+      set_fact:
+        data_set_name: "{{ ansible_user | upper }}.SOME.DATA.SET"
+
+    - name: Fact `data_set_name` set with value
+      debug:
+        msg: "{{ data_set_name }}"
+
+    - name: Detecting system name
+      command: uname -n
+      register: result
+
+    - name: Setting fact `system_name` for use by this sample
+      set_fact:
+        system_name: "{{ result.stdout }}"
+
+    - name: Fact `system_name` set with value
+      debug:
+        msg: "{{ system_name }}"
+
+    # ##########################################################################
+    # Ping the host with Ansible ping module to see if the target is available
+    # ##########################################################################
     - name: Ping host - {{ inventory_hostname }}
       ping:
       register: result
 
     - name: Response
       debug:
-        msg: "Ping result returned: {{ result.ping }}"
+        msg: "{{ result.ping }}"
 
-    - name: Ensure JCL folder exists to hold JCL
+    # ##########################################################################
+    # Modules zos_job_submit, zos_job_query, zos_job_output, zos_data_set
+    # ##########################################################################
+    # +-------------------------------------------------------------------------
+    # | Create a directory in USS on the target, write sample JCL on target,
+    # | submit the target JCL, query for the submitted job and obtain the
+    # | job output, demonstrate creating and deleting data sets
+    # +-------------------------------------------------------------------------
+
+    - name: Create directory {{ tgt_tmp_dir }}/ansible/jcl on USS
+            target {{ system_name }}
       file:
-        path: /tmp/ansible/jcl
+        path: "{{ tgt_tmp_dir }}/ansible/jcl"
         state: directory
 
-    - name: Write HELLO JCL to system
-      shell: "echo {{ lookup('file', playbook_dir + '/files/HELLO.jcl') | quote }} > /tmp/ansible/jcl/HELLO"
+    - name: Write sample {{ job_name }} JCL in {{ tgt_tmp_dir }}/ansible/jcl
+            on USS
+            target {{ system_name }}
+      shell: "echo {{ lookup('file', playbook_dir + '/files/{{job_name}}.jcl') | quote }} > {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}"
       changed_when: true
+      register: result
 
-    - name: Submit HELLO jcl program
+    - name: Response for write sample {{job_name}} JCL in {{ tgt_tmp_dir }}/ansible/jcl
+            on USS target {{ system_name }}
+      debug:
+        msg: "{{ result }}"
+
+    - name: Submit {{job_name}} jcl located on target
+            in {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}
       zos_job_submit:
-        src: /tmp/ansible/jcl/HELLO
+        src: "{{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}"
         location: USS
         wait: True
 
-    - name: Query submitted job 'HELLO'
+    - name: Response for submit {{job_name}} jcl located on target
+            in {{ tgt_tmp_dir }}/ansible/jcl/{{job_name}}
+      debug:
+        msg: "{{ result }}"
+
+    - name: Query the submitted job {{job_name}} on USS target {{ system_name }}
       zos_job_query:
-        job_name: HELLO
+        job_name: "{{job_name}}"
       register: result
 
-    - name: Response
+    - name: Response for Query the submitted job {{job_name}}
+            on USS target {{ system_name }}
       debug:
-        msg: "Query submitted job 'HELLO' result: {{ result }}"
+        msg: "{{ result }}"
 
-    - name: Get HELLO job output
+    - name: Get {{job_name}} job output on USS target {{ system_name }}
       zos_job_output:
-        job_name: "HELLO"
+        job_name: "{{job_name}}"
       register: result
 
-    - name: Response
+    - name: Response for Get {{job_name}} job output on USS target {{ system_name }}
       debug:
-        msg: "Get the job output of submitted job 'HELLO' result: {{ result }}"
+        msg: "{{ result }}"
 
-    - name: Remove HELLO JCL and supporting folder from z/OS target node
+    - name: Remove {{job_name}} JCL and folder on USS target {{ system_name }}
       file:
-        path: /tmp/ansible/jcl
+        path: "{{ tgt_tmp_dir }}/ansible"
         state: absent
 
-    # Create a data set
-    - name: Create a PDS data set 'USER.PRIVATE.TEST'
+    - name: Response for remove {{job_name}} JCL and folder on
+            USS target {{ system_name }}
+      debug:
+        msg: "{{ result }}"
+
+    - name: Create a PDS data set {{ data_set_name }}
       zos_data_set:
-        name: USER.PRIVATE.TEST
+        name: "{{ data_set_name }}"
         type: pds
         size: 5M
         format: fb
@@ -81,26 +173,25 @@
         replace: yes
       register: result
 
-    - name: Response
+    - name: Response create a PDS data set {{ data_set_name }}
       debug:
-        msg: "Create a PDS data set 'USER.PRIVATE.TEST' result: {{ result }}"
+        msg: "{{ result }}"
 
-    # Validate data set Created
-    - name: Check for data set 'USER.PRIVATE.TEST'
-      command: "dls USER.PRIVATE.TEST"
+    - name: Check if data set {{ data_set_name }} was created
+      command: "dls {{ data_set_name }}"
       register: result
       changed_when: true
 
-    - name: Response
+    - name: Response for check if data set {{ data_set_name }} was created
       debug:
-        msg: "Check for data set 'USER.PRIVATE.TEST' returned {{ result }}"
+        msg: "{{ result }}"
 
-    # Delete data set
-    - name: Delete data set 'USER.PRIVATE.TEST'
+    - name: Delete data set {{ data_set_name }}
       zos_data_set:
-        name: USER.PRIVATE.TEST
+        name: "{{ data_set_name }}"
         state: absent
       register: result
-    - name: Response
+
+    - name: Response for delete data set {{ data_set_name }}
       debug:
-        msg: "Delete data set 'USER.PRIVATE.TEST' returned: {{ result }}"
+        msg: "{{ result }}"

--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -15,8 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 module: zos_encode
 author: "Zhao Lu (@yourfuwa2015)"
-short_description: Convert the encoding of characters read from a USS file or
-                   an MVS data set.
+short_description: Encoding USS files and data sets
 description:
     - Convert the encoding of characters read from either Unix System
       Services (USS) file or path, PS(sequential data set), PDS/E or KSDS(

--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 module: zos_encode
 author: "Zhao Lu (@yourfuwa2015)"
-short_description: Encoding USS files and data sets
+short_description: Encode data in USS and data sets
 description:
     - Convert the encoding of characters read from either Unix System
       Services (USS) file or path, PS(sequential data set), PDS/E or KSDS(

--- a/plugins/modules/zos_ping.rexx
+++ b/plugins/modules/zos_ping.rexx
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
 ---
 module: zos_ping
 version_added: 2.9
-short_description: Determine if required and optional dependencies are present on the target host.
+short_description: Ping z/OS and check dependencies.
 description:
   - M(zos_ping) verifies the presence of z/OS Web Client Enablement Toolkit,
     iconv, and Python.

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 module: zos_tso_command
 author: "Xiao Yuan Ma (@bjmaxy)"
-short_description: Execute a TSO command
+short_description: Execute a TSO commands
 description:
     - Execute TSO commands on the target z/OS system with the provided options
       and receive a structured response.


### PR DESCRIPTION
##### SUMMARY
- Update all RST and MD files that populate the webdocs to reflect the latest upcoming release and its dependencies. 

- Update the zos_encode.py module short description to fit within the limits of the generated html for 'read-the-docs-plugin'

- Update the Make file so its shortcut is more generic and not seem that it will only work for IBM z/OS core collections, remove 'ibm_zos_core" with 'ibm_zos_doc'.

Bugfixes:
https://jsw.ibm.com/browse/NAZARE-782 - allow for user configuration and control the target and data set scratch directories
https://jsw.ibm.com/browse/NAZARE-1077 - doc bug semi colon over colon in path
https://jsw.ibm.com/browse/NAZARE-1081 - JCL and documentation updates to reflect necessary and option changes need in the playbook and JCL submitted by the the playbook.
https://jsw.ibm.com/browse/NAZARE-1080 - documentation around advanced inventory and ansible.cfg (ie, port and target tmp dirs)

##### ISSUE TYPE
- Docs Pull Request
