### PR TITLE
Add an example that requires a command to be escaped

### DIFF
--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -56,6 +56,11 @@ EXAMPLES = r"""
     cmd: 'd u,all'
     verbose: true
     debug: true
+
+- name: Execute an operator command to purge all job logs (requires escaping)
+  zos_operator:
+    cmd: "\\$PJ(*)"
+
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY
Add an example for zos_operator that demonstrates a command that needs to be escaped to execute.

##### ISSUE TYPE
- Docs Pull Request
