### PR TITLE
add out-of-box awx support

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,27 @@
+################################################################################
+# Copyright (c) IBM Corporation 2020
+################################################################################
+
+################################################################################
+# For for on ansible.cfg options see:
+#   https://docs.ansible.com/ansible/latest/reference_appendices/config.html
+#
+# For a full sample see:
+#   https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg
+#
+# Note:
+#   Some of the common options configured are `remote_temp` and `ansible_port`.
+#   remote_temp - The temporary directory Ansible uses to transfer files onto
+#                  the controller. Default is `/.ansible/tmp`
+#   ansible_port - The connection port number Ansible uses to connect to the
+#                  target; configure the target if is not using default SSH
+#                  port 22
+################################################################################
+
+[defaults]
+forks = 25
+# remote_tmp = /u/ansible/tmp
+# remote_port = 2022
+
+[ssh_connection]
+pipelining = True

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,0 +1,9 @@
+################################################################################
+# Copyright (c) IBM Corporation 2020
+################################################################################
+# This file is required when using repository directly in AWX/Tower
+# for more info: https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#install-multiple-collections-with-a-requirements-file
+#                https://docs.ansible.com/ansible-tower/latest/html/userguide/projects.html#collections-support
+---
+collections:
+  - ibm.ibm_zos_core


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add required requirements file and additional ansible.cfg file to simplify collection sample usage in AWX and Ansible Tower
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Update Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- collections/requirements.yml tells AWX/Tower what collections are used inside of the project
- ansible.cfg is required at root because AWX/Tower always calls playbooks from project root folder