### PR TITLE
fix job utility to work on all z/OS systems

### DIFF
--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -44,9 +44,9 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None):
         {"job_id": job_id, "owner": owner, "job_name": job_name, "dd_name": dd_name}
     )
 
-    job_id = parsed_args.get("job_id") or ""
-    job_name = parsed_args.get("job_name") or ""
-    owner = parsed_args.get("owner") or ""
+    job_id = parsed_args.get("job_id") or "*"
+    job_name = parsed_args.get("job_name") or "*"
+    owner = parsed_args.get("owner") or "*"
     dd_name = parsed_args.get("ddname") or ""
 
     job_detail_json = {}
@@ -74,7 +74,7 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None):
     return job_detail_json
 
 
-def _get_job_output_str(job_id="", owner="", job_name="", dd_name=""):
+def _get_job_output_str(job_id="*", owner="*", job_name="*", dd_name=""):
     """Generate JSON output string containing Job info from SDSF.
     Writes a temporary REXX script to the USS filesystem to gather output.
 
@@ -246,9 +246,9 @@ def job_status(job_id=None, owner=None, job_name=None):
         {"job_id": job_id, "owner": owner, "job_name": job_name}
     )
 
-    job_id = parsed_args.get("job_id") or ""
-    job_name = parsed_args.get("job_name") or ""
-    owner = parsed_args.get("owner") or ""
+    job_id = parsed_args.get("job_id") or "*"
+    job_name = parsed_args.get("job_name") or "*"
+    owner = parsed_args.get("owner") or "*"
 
     job_status_json = {}
     rc, out, err = _get_job_status_str(job_id, owner, job_name)
@@ -275,7 +275,7 @@ def job_status(job_id=None, owner=None, job_name=None):
     return job_status_json
 
 
-def _get_job_status_str(job_id="", owner="", job_name=""):
+def _get_job_status_str(job_id="*", owner="*", job_name="*"):
     """Generate JSON output string containing Job status info from SDSF.
     Writes a temporary REXX script to the USS filesystem to gather output.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #2006 in jira and possibly another issue in GitHub. Two separate users have been experiencing an error when attempting to retrieve job information from SDSF using only a job ID. The problem was traced back to the SDSF `FILTER` command not returning any job information if an owner or jobname was not provided as well.

This update changes default search behavior for underlying SDSF calls to `job_name='*'` and `owner='*'`. This fixes the issue on at least one user's system.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- plugins/module_utils/job.py
