### PR TITLE
Update/1979/default encoding value

### DIFF
--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -117,6 +117,9 @@ class ActionModule(ActionBase):
                 "Invalid type supplied for 'destination' option, "
                 "it must be a string"
             )
+        elif len(src) < 1 or len(dest) < 1:
+            msg = "Source and destination parameters must not be empty"
+
         if msg:
             result['msg'] = msg
             result['failed'] = True

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -111,6 +111,9 @@ options:
         required: false
         type: str
         default: IBM-1047
+notes:
+  - For supported character sets used to encode data, refer to
+    U(https://ansible-collections.github.io/ibm_zos_core/supplementary.html#encode)
 """
 
 RETURN = r"""
@@ -435,10 +438,6 @@ jobs:
               "subsystem": "STL1"
           }
      ]
-changed:
-  description: Indicates if any changes were made during module operation.
-  type: bool
-  returned: success
 message:
   description: The output message that the sample module generates.
   returned: success
@@ -647,14 +646,21 @@ def run_module():
         location=dict(
             arg_type="str", default="DATA_SET", choices=["DATA_SET", "USS", "LOCAL"],
         ),
+        from_encoding=dict(arg_type="encoding", default=DEFAULT_ASCII_CHARSET),
+        to_encoding=dict(arg_type="encoding", default=DEFAULT_EBCDIC_CHARSET),
         volume=dict(arg_type="volume", required=False),
         return_output=dict(arg_type="bool", default=True),
         wait_time_s=dict(arg_type="int", required=False, default=60),
         max_rc=dict(arg_type="int", required=False),
-        temp_file=dict(arg_type="path", required=False)
     )
 
     result = dict(changed=False)
+    module.params.update(
+        dict(
+            from_encoding=module.params.get('encoding').get('from'),
+            to_encoding=module.params.get('encoding').get('to')
+        )
+    )
     try:
         parser = BetterArgParser(arg_defs)
         parsed_args = parser.parse_args(module.params)
@@ -668,7 +674,7 @@ def run_module():
     return_output = parsed_args.get("return_output")
     wait_time_s = parsed_args.get("wait_time_s")
     max_rc = parsed_args.get("max_rc")
-    # get temporary file names for copied files
+    # get temporary file names for copied filesß
     temp_file = parsed_args.get("temp_file")
     if temp_file:
         temp_file_2 = NamedTemporaryFile(delete=True)

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -87,18 +87,18 @@ options:
         Ignored for USS and LOCAL.
   encoding:
     required: false
-    default: UTF-8
+    default: ISO8859-1
     type: str
     choices:
       - UTF-8
       - ASCII
-      - ISO-8859-1
+      - ISO8859-1
       - EBCDIC
       - IBM-037
       - IBM-1047
     description:
       - The encoding of the local JCL file on the ansible control node.
-      - If it is UTF-8, ASCII, ISO-8859-1, the file will be converted to EBCDIC
+      - If it is UTF-8, ASCII, ISO8859-1, the file will be converted to EBCDIC
         on the z/OS platform.
       - If it is EBCDIC, IBM-037, IBM-1047, the file will be unchanged when
         submitted on the z/OS platform.
@@ -617,8 +617,8 @@ def run_module():
         ),
         encoding=dict(
             type="str",
-            default="UTF-8",
-            choices=["UTF-8", "ASCII", "ISO-8859-1", "EBCDIC", "IBM-037", "IBM-1047"],
+            default="ISO8859-1",
+            choices=["UTF-8", "ASCII", "ISO8859-1", "EBCDIC", "IBM-037", "IBM-1047"],
         ),
         volume=dict(type="str", required=False),
         return_output=dict(type="bool", required=False, default=True),
@@ -635,7 +635,7 @@ def run_module():
         location=dict(
             arg_type="str", default="DATA_SET", choices=["DATA_SET", "USS", "LOCAL"],
         ),
-        encoding=dict(arg_type="encoding", default="UTF-8"),
+        encoding=dict(arg_type="encoding", default="ISO8859-1"),
         volume=dict(arg_type="volume", required=False),
         return_output=dict(arg_type="bool", default=True),
         wait_time_s=dict(arg_type="int", required=False, default=60),
@@ -692,7 +692,7 @@ def run_module():
             # 'UTF-8' 'ASCII' encoding will be converted.
             elif (
                 encoding == "UTF-8"
-                or encoding == "ISO-8859-1"
+                or encoding == "ISO8859-1"
                 or encoding == "ASCII"
                 or encoding is None
             ):
@@ -713,7 +713,7 @@ def run_module():
                 module.fail_json(
                     msg=(
                         "The Local file encoding format is not supported."
-                        "The supported encoding is UTF-8, ASCII, ISO-8859-1, EBCDIC, IBM-037, IBM-1047. Default is UTF-8."
+                        "The supported encoding is UTF-8, ASCII, ISO8859-1, EBCDIC, IBM-037, IBM-1047. Default is UTF-8."
                     ),
                     **result
                 )

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -674,7 +674,7 @@ def run_module():
     return_output = parsed_args.get("return_output")
     wait_time_s = parsed_args.get("wait_time_s")
     max_rc = parsed_args.get("max_rc")
-    # get temporary file names for copied filesß
+    # get temporary file names for copied files
     temp_file = parsed_args.get("temp_file")
     if temp_file:
         temp_file_2 = NamedTemporaryFile(delete=True)

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -102,6 +102,7 @@ options:
         on the z/OS platform.
       - If it is EBCDIC, IBM-037, IBM-1047, the file will be unchanged when
         submitted on the z/OS platform.
+      - If no encoding is specified, ISO8859-1 is used as the default value.
 """
 
 RETURN = r"""

--- a/tests/functional/modules/test_zos_fetch_func.py
+++ b/tests/functional/modules/test_zos_fetch_func.py
@@ -149,11 +149,11 @@ def test_fetch_partitioned_data_set(ansible_zos_module):
 def test_fetch_vsam_data_set(ansible_zos_module):
     hosts = ansible_zos_module
     params = dict(
-        src='IMSTESTL.LDS01.WADS2',
+        src='IMSTESTL.LDS01.WADS0',
         dest='/tmp/',
         flat=True
     )
-    dest_path = '/tmp/IMSTESTL.LDS01.WADS2'
+    dest_path = '/tmp/IMSTESTL.LDS01.WADS0'
     try:
         results = hosts.all.zos_fetch(**params)
         for result in results.contacted.values():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
+ Change zos_job_submit default local encoding from UTF-8 to ISO8859-1
+ Add an option to override remote encoding (currently hard-coded to IBM-1047)
+ Improve doc for zos_job_submit for the encoding parameter. Better explanation of the default encoding behavior.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_submit
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
