### PR TITLE
Bugfix/78/fetch-encode

### DIFF
--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -429,7 +429,7 @@ class FetchHandler:
                 rc=rc,
             )
         if (not is_binary) and encoding:
-            enc_utils = encode.EncodeUtils(self.module)
+            enc_utils = encode.EncodeUtils()
             from_code_set = encoding.get("from")
             to_code_set = encoding.get("to")
             root, dirs, files = next(os.walk(dir_path))
@@ -472,7 +472,7 @@ class FetchHandler:
                 stderr_lines=str(err).splitlines(),
             )
         if (not is_binary) and encoding:
-            enc_utils = encode.EncodeUtils(self.module)
+            enc_utils = encode.EncodeUtils()
             from_code_set = encoding.get("from")
             to_code_set = encoding.get("to")
             try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The EncodeUtil no longer requires the module to be passed in to the constructor. This was causing a bug in the fetch module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_fetch
