### PR TITLE
fix issue when no default encoding specified

### DIFF
--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -652,14 +652,12 @@ def run_module():
         return_output=dict(arg_type="bool", default=True),
         wait_time_s=dict(arg_type="int", required=False, default=60),
         max_rc=dict(arg_type="int", required=False),
+        temp_file=dict(arg_type="path", required=False),
     )
 
     result = dict(changed=False)
     module.params.update(
-        dict(
-            from_encoding=encoding.get("from"),
-            to_encoding=encoding.get("to"),
-        )
+        dict(from_encoding=encoding.get("from"), to_encoding=encoding.get("to"),)
     )
     try:
         parser = BetterArgParser(arg_defs)
@@ -721,7 +719,8 @@ def run_module():
             else:
                 module.fail_json(
                     msg="The Local file encoding conversion failed. Please check the source file."
-                    + stderr,
+                    + stderr
+                    or "",
                     **result
                 )
     except SubmitJCLError as e:

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -632,13 +632,13 @@ def run_module():
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
-    encoding = module.params.get('encoding')
+    encoding = module.params.get("encoding")
     if encoding is None:
-        encoding = {'from': DEFAULT_ASCII_CHARSET, 'to': DEFAULT_EBCDIC_CHARSET}
-    if encoding.get('from') is None:
-        encoding['from'] = DEFAULT_ASCII_CHARSET
-    if encoding.get('to') is None:
-        encoding['to'] = DEFAULT_EBCDIC_CHARSET
+        encoding = {"from": DEFAULT_ASCII_CHARSET, "to": DEFAULT_EBCDIC_CHARSET}
+    if encoding.get("from") is None:
+        encoding["from"] = DEFAULT_ASCII_CHARSET
+    if encoding.get("to") is None:
+        encoding["to"] = DEFAULT_EBCDIC_CHARSET
 
     arg_defs = dict(
         src=dict(arg_type="data_set_or_path", required=True),
@@ -657,8 +657,8 @@ def run_module():
     result = dict(changed=False)
     module.params.update(
         dict(
-            from_encoding=module.params.get('encoding').get('from'),
-            to_encoding=module.params.get('encoding').get('to')
+            from_encoding=encoding.get("from"),
+            to_encoding=encoding.get("to"),
         )
     )
     try:
@@ -705,11 +705,14 @@ def run_module():
             jobId = submit_uss_jcl(src, module)
         else:
             # For local file, it has been copied to the temp directory in action plugin.
-            from_encoding = encoding.get('from')
-            to_encoding = encoding.get('to')
+            from_encoding = encoding.get("from")
+            to_encoding = encoding.get("to")
             (conv_rc, stdout, stderr) = module.run_command(
                 "iconv -f {0} -t {1} {2} > {3}".format(
-                    from_encoding, to_encoding, quote(temp_file), quote(temp_file_2.name)
+                    from_encoding,
+                    to_encoding,
+                    quote(temp_file),
+                    quote(temp_file_2.name),
                 ),
                 use_unsafe_shell=True,
             )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes bug resulting in failure when no encoding specified for zos_job_submit.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- plugins/modules/zos_job_submit.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To reproduce, run zos_job_submit without any encoding argument provided.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
