### PR TITLE
Encode util close file descriptor

### DIFF
--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -243,6 +243,7 @@ class EncodeUtils(object):
         finally:
             if temp_fo:
                 try:
+                    os.close(temp_fo)
                     unlink(temp_fi)
                 except OSError as e:
                     if e.errno != errno.ENOENT:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`uss_convert_encoding` does not close file descriptor returned by `mkstemp` function, causing too open file descriptors on large conversion workloads


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
encode
