### PR TITLE
remove ZOAU Python API deps for zos_operator

### DIFF
--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -159,8 +159,7 @@ def run_operator_command(params):
     verbose = "-v" if params.get("verbose") else ""
     debug = "-d" if params.get("debug") else ""
     rc, stdout, stderr = module.run_command(
-        "opercmd {0} {1} {2}".format(verbose, debug, quote(command)),
-        use_unsafe_shell=True,
+        "opercmd {0} {1} {2}".format(verbose, debug, command),
     )
     message = stdout + stderr
     if rc > 0:

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) IBM Corporation 2019, 2020

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) IBM Corporation 2019, 2020
@@ -96,18 +95,24 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 import re
-from traceback import format_exc
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
-    MissingZOAUImport,
-)
+from ansible.module_utils.six import PY3
 
-try:
-    from zoautil_py import OperatorCmd
-except Exception:
-    OperatorCmd = MissingZOAUImport()
+# from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
+#     MissingZOAUImport,
+# )
+
+# try:
+#     from zoautil_py import OperatorCmd
+# except Exception:
+#     OperatorCmd = MissingZOAUImport()
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
     BetterArgParser,
 )
+
+if PY3:
+    from shlex import quote
+else:
+    from pipes import quote
 
 
 def run_module():
@@ -127,11 +132,10 @@ def run_module():
         result["rc"] = rc_message.get("rc")
         result["content"] = rc_message.get("message").split("\n")
     except Error as e:
-        module.fail_json(msg=e.msg, **result)
+        module.fail_json(msg=repr(e), **result)
     except Exception as e:
-        trace = format_exc()
         module.fail_json(
-            msg="An unexpected error occurred: {0}".format(trace), **result
+            msg="An unexpected error occurred: {0}".format(repr(e)), **result
         )
     result["changed"] = True
     module.exit_json(**result)
@@ -149,16 +153,18 @@ def parse_params(params):
 
 
 def run_operator_command(params):
+    module = AnsibleModule(argument_spec={}, check_invalid_arguments=False)
     command = params.get("cmd")
-    verbose = params.get("verbose")
-    debug = params.get("debug")
-    rc_message = []
-    rc_message = OperatorCmd.execute(command, "", verbose, debug)
-    rc = rc_message.get("rc")
-    message = rc_message.get("message")
+    verbose = "-v" if params.get("verbose") else ""
+    debug = "-d" if params.get("debug") else ""
+    rc, stdout, stderr = module.run_command(
+        "opercmd {0} {1} {2}".format(verbose, debug, quote(command)),
+        use_unsafe_shell=True,
+    )
+    message = stdout + stderr
     if rc > 0:
-        raise OperatorCmdError(command, message.split("\n") if message else message)
-    return rc_message
+        raise OperatorCmdError(command, rc, message.split("\n") if message else message)
+    return {"rc": rc, "message": message}
 
 
 class Error(Exception):
@@ -166,9 +172,9 @@ class Error(Exception):
 
 
 class OperatorCmdError(Error):
-    def __init__(self, cmd, message):
-        self.msg = 'An error occurred executing the operator command "{0}", with response "{1}"'.format(
-            cmd, message
+    def __init__(self, cmd, rc, message):
+        self.msg = 'An error occurred executing the operator command "{0}", with RC={1} and response "{2}"'.format(
+            cmd, str(rc), message
         )
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes issue #2814 in Jira, "Certain operator commands result in heap error zos_operator". This PR removed usage of ZOAU Python API previously used to run operator commands, this works around the heap issues that were encountered previously with the ZOAU Python API. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- plugins/modules/zos_operator.py

