### PR TITLE
Specify SFTP port for fetch and copy

### DIFF
--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -100,6 +100,10 @@ class ActionModule(ActionBase):
                 msg = "Cannot specify 'mode', 'owner' or 'group' for MVS destination"
                 return self._exit_action(result, msg, failed=True)
 
+        if not isinstance(sftp_port, int) or not 0 < sftp_port <= 65535:
+            msg = "Invalid port provided for SFTP. Expected an integer between 0 to 65535."
+            return self._exit_action(result, msg, failed=True)
+
         if (not force) and self._dest_exists(src, dest, task_vars):
             return self._exit_action(result, "Destination exists. No data was copied.")
 

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -122,7 +122,7 @@ class ActionModule(ActionBase):
             if content:
                 try:
                     local_content = _write_content_to_temp_file(content)
-                    transfer_res = self._copy_to_remote(local_content)
+                    transfer_res = self._copy_to_remote(local_content, sftp_port)
                 finally:
                     os.remove(local_content)
             else:

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -121,6 +121,9 @@ class ActionModule(ActionBase):
         elif len(src) < 1 or len(dest) < 1:
             msg = "Source and destination parameters must not be empty"
 
+        elif not isinstance(sftp_port, int) or not 0 < sftp_port <= 65535:
+            msg = "Invalid port provided for SFTP. Expected an integer between 0 to 65535."
+
         if msg:
             result['msg'] = msg
             result['failed'] = True

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -147,6 +147,13 @@ options:
     type: bool
     default: false
     required: false
+  sftp_port:
+    description:
+      - Indiciates which port should be used to connect to the remote z/OS
+        system to perform data transfer. Default is port 22.
+    type: int
+    required: false
+    default: 22
   encoding:
     description:
       - Specifies which encodings the destination file or data set should be
@@ -1432,6 +1439,7 @@ def main():
             model_ds=dict(type='str', required=False),
             local_follow=dict(type='bool', default=True),
             remote_src=dict(type='bool', default=False),
+            sftp_port=dict(type='int', default=22),
             validate=dict(type='bool'),
             is_uss=dict(type='bool'),
             is_pds=dict(type='bool'),
@@ -1455,7 +1463,8 @@ def main():
         local_follow=dict(arg_type='bool', default=True, required=False),
         remote_src=dict(arg_type='bool', default=False, required=False),
         checksum=dict(arg_type='str', required=False),
-        validate=dict(arg_type='bool', required=False)
+        validate=dict(arg_type='bool', required=False),
+        sftp_port=dict(arg_type='int', required=False, default=22)
     )
 
     if module.params.get("encoding"):

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -149,7 +149,7 @@ options:
     required: false
   sftp_port:
     description:
-      - Indiciates which port should be used to connect to the remote z/OS
+      - Indicates which port should be used to connect to the remote z/OS
         system to perform data transfer. Default is port 22.
     type: int
     required: false

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -83,7 +83,7 @@ options:
     type: bool
   sftp_port:
     description:
-      - Indiciates which port should be used to connect to the remote z/OS
+      - Indicates which port should be used to connect to the remote z/OS
         system to perform data transfer. Default is port 22.
     type: int
     required: false

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -529,8 +529,7 @@ def run_module():
         dest=dict(arg_type="path", required=True),
         fail_on_missing=dict(arg_type="bool", required=False, default=True),
         is_binary=dict(arg_type="bool", required=False, default=False),
-        use_qualifier=dict(arg_type="bool", required=False, default=False),
-        sftp_port=dict(arg_type='int', required=False, default=22)
+        use_qualifier=dict(arg_type="bool", required=False, default=False)
     )
 
     if module.params.get("encoding"):

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -81,6 +81,13 @@ options:
     required: false
     default: "false"
     type: bool
+  sftp_port:
+    description:
+      - Indiciates which port should be used to connect to the remote z/OS
+        system to perform data transfer. Default is port 22.
+    type: int
+    required: false
+    default: 22
   encoding:
     description:
       - Specifies which encodings the fetched data set should be converted from
@@ -505,6 +512,7 @@ def run_module():
             use_qualifier=dict(required=False, default=False, type="bool"),
             validate_checksum=dict(required=False, default=True, type="bool"),
             encoding=dict(required=False, type="dict"),
+            sftp_port=dict(type='int', default=22, required=False)
         )
     )
 
@@ -522,6 +530,7 @@ def run_module():
         fail_on_missing=dict(arg_type="bool", required=False, default=True),
         is_binary=dict(arg_type="bool", required=False, default=False),
         use_qualifier=dict(arg_type="bool", required=False, default=False),
+        sftp_port=dict(arg_type='int', required=False, default=22)
     )
 
     if module.params.get("encoding"):

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1949,6 +1949,5 @@ def test_sftp_negative_port_specification_fails(ansible_zos_module):
         copy_res = hosts.all.zos_copy(src="/etc/profile", dest=dest_path, sftp_port=-1)
         for result in copy_res.contacted.values():
             assert result.get("msg") is not None
-            assert "Connection closed" in result.get('stderr')
     finally:
         hosts.all.file(path=dest_path, state="absent")

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -5,12 +5,6 @@ from __future__ import absolute_import, division, print_function
 import os
 import shutil
 import tempfile
-import stat
-
-import ansible.utils
-import pytest
-
-from ansible.utils.hashing import checksum
 
 __metaclass__ = type
 
@@ -1946,3 +1940,15 @@ def test_copy_sequential_data_set_to_vsam_fails(ansible_zos_module):
             assert "Incompatible" in result.get("msg")
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
+
+
+def test_sftp_negative_port_specification_fails(ansible_zos_module):
+    hosts = ansible_zos_module
+    dest_path = "/tmp/profile"
+    try:
+        copy_res = hosts.all.zos_copy(src="/etc/profile", dest=dest_path, sftp_port=-1)
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is not None
+            assert "Connection closed" in result.get('stderr')
+    finally:
+        hosts.all.file(path=dest_path, state="absent")

--- a/tests/functional/modules/test_zos_fetch_func.py
+++ b/tests/functional/modules/test_zos_fetch_func.py
@@ -463,7 +463,6 @@ def test_sftp_negative_port_specification_fails(ansible_zos_module):
         dest_path = "/tmp/profile"
         for result in results.contacted.values():
             assert result.get("msg") is not None
-            assert "Connection closed" in result.get('stderr')
     finally:
         if os.path.exists(dest_path):
             os.remove(dest_path)

--- a/tests/functional/modules/test_zos_fetch_func.py
+++ b/tests/functional/modules/test_zos_fetch_func.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, print_function
 import os
 import shutil
 import stat
-import pytest
 
 from hashlib import sha256
 from ansible.utils.hashing import checksum
@@ -454,3 +453,17 @@ def test_fetch_flat_create_dirs(ansible_zos_module, z_python_interpreter):
     finally:
         if os.path.exists(dest_path):
             shutil.rmtree("/tmp/" + remote_host)
+
+
+def test_sftp_negative_port_specification_fails(ansible_zos_module):
+    hosts = ansible_zos_module
+    params = dict(src="/etc/profile", dest="/tmp/", flat=True, sftp_port=-1)
+    try:
+        results = hosts.all.zos_fetch(**params)
+        dest_path = "/tmp/profile"
+        for result in results.contacted.values():
+            assert result.get("msg") is not None
+            assert "Connection closed" in result.get('stderr')
+    finally:
+        if os.path.exists(dest_path):
+            os.remove(dest_path)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Often, the default port 22 may not be available to perform data transfer. The `sftp_port` parameter lets the user specify which port should be used to connect to the remote sftp server.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_fetch, zos_copy
