### PR TITLE
copy/fetch: Ignore stderr

### DIFF
--- a/docs/source/modules/zos_copy.rst
+++ b/docs/source/modules/zos_copy.rst
@@ -235,6 +235,26 @@ validate
 
 
 
+sftp_port
+  Indicates which port should be used to connect to the remote z/OS system to perform data transfer. Default is port 22.
+
+
+  | **required**: False
+  | **type**: int
+  | **default**: 22
+
+
+
+ignore_sftp_stderr
+  During data transfer through sftp, the module fails if the sftp command directs any content to stderr. The user is able to override this behavior by setting this parameter to C(true). By doing so, the module would essentially ignore the stderr stream produced by sftp and continue execution.
+
+
+  | **required**: False
+  | **type**: bool
+  | **default**: false
+
+
+
 
 Examples
 --------

--- a/docs/source/modules/zos_fetch.rst
+++ b/docs/source/modules/zos_fetch.rst
@@ -135,6 +135,26 @@ validate_checksum
 
 
 
+sftp_port
+  Indicates which port should be used to connect to the remote z/OS system to perform data transfer. Default is port 22.
+
+
+  | **required**: False
+  | **type**: int
+  | **default**: 22
+
+
+
+ignore_sftp_stderr
+  During data transfer through sftp, the module fails if the sftp command directs any content to stderr. The user is able to override this behavior by setting this parameter to C(true). By doing so, the module would essentially ignore the stderr stream produced by sftp and continue execution.
+
+
+  | **required**: False
+  | **type**: bool
+  | **default**: false
+
+
+
 
 Examples
 --------

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -183,6 +183,15 @@ options:
     type: bool
     required: false
     default: false
+  ignore_sftp_stderr:
+    description:
+      - During data transfer through sftp, the module fails if the sftp command
+        directs any content to stderr. The user is able to override this behavior
+        by setting this parameter to C(true). By doing so, the module would
+        essentially ignore the stderr stream produced by sftp and continue execution.
+    type: bool
+    required: false
+    default: false
 notes:
     - Destination data sets are assumed to be in catalog. When trying to copy
       to an uncataloged data set, the module assumes that the data set does
@@ -1457,6 +1466,7 @@ def main():
             local_follow=dict(type='bool', default=True),
             remote_src=dict(type='bool', default=False),
             sftp_port=dict(type='int', default=22),
+            ignore_sftp_stderr=dict(type='bool', default=False),
             validate=dict(type='bool'),
             is_uss=dict(type='bool'),
             is_pds=dict(type='bool'),

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -530,9 +530,15 @@ class CopyHandler(object):
             if not model_ds:
                 ps_size = "{0}K".format(math.ceil(Path(new_src).stat().st_size / 1024))
                 self._allocate_ps(dest, size=ps_size)
-            if Datasets.copy(new_src, dest) != 0:
+            rc, out, err = self.run_command(
+                "cp {0} {1} \"//'{2}'\"".format(
+                    "-B" if self.is_binary else "", new_src, dest
+                )
+            )
+            if rc != 0:
                 self.fail_json(
-                    msg="Error calling ZOAU 'copy' command while copying {0} to {1}".format(src, dest)
+                    msg="Unable to copy source {0} to {1}".format(src, dest),
+                    rc=rc, stderr=err, stdout=out
                 )
         else:
             rc = Datasets.copy(new_src, dest)

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -98,19 +98,27 @@ options:
     suboptions:
       from:
         description:
-            - The character set of the source I(src).
-            - Supported character sets rely on the charset conversion utility
-              (iconv) version; the most common character sets are supported.
+          - The character set of the source I(src).
+          - Supported character sets rely on the charset conversion utility
+            (iconv) version; the most common character sets are supported.
         required: true
         type: str
       to:
         description:
-            - The destination I(dest) character set for the output to be written
-              as.
-            - Supported character sets rely on the charset conversion utility
-              (iconv) version; the most common character sets are supported.
+          - The destination I(dest) character set for the output to be written as.
+          - Supported character sets rely on the charset conversion utility
+            (iconv) version; the most common character sets are supported.
         required: true
         type: str
+  ignore_sftp_stderr:
+    description:
+      - During data transfer through sftp, the module fails if the sftp command
+        directs any content to stderr. The user is able to override this behavior
+        by setting this parameter to C(true). By doing so, the module would
+        essentially ignore the stderr stream produced by sftp and continue execution.
+    type: bool
+    required: false
+    default: false
 notes:
     - When fetching PDSE and VSAM data sets, temporary storage will be used
       on the remote z/OS system. After the PDSE or VSAM data set is
@@ -129,6 +137,7 @@ notes:
       U(https://ansible-collections.github.io/ibm_zos_core/supplementary.html#encode)
 seealso:
 - module: zos_data_set
+- module: zos_copy
 """
 
 EXAMPLES = r"""
@@ -512,7 +521,8 @@ def run_module():
             use_qualifier=dict(required=False, default=False, type="bool"),
             validate_checksum=dict(required=False, default=True, type="bool"),
             encoding=dict(required=False, type="dict"),
-            sftp_port=dict(type='int', default=22, required=False)
+            sftp_port=dict(type='int', default=22, required=False),
+            ignore_sftp_stderr=dict(type='bool', default=False, required=False)
         )
     )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR Fixes #150 where zos_fetch and zos_copy fails if there is a pre-login prompt when connecting to the remote z/OS server through ftp. The fix adds a new parameter that allows the user to override the default behavior of failing when `stderr` of sftp command is non-empty.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy, zos_fetch