### PR TITLE
add FQCN to action plugins

### DIFF
--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -1,7 +1,7 @@
 # Copyright (c) IBM Corporation 2019, 2020
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
@@ -19,7 +19,9 @@ from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.data_set import (
-    is_member, is_data_set, extract_member_name
+    is_member,
+    is_data_set,
+    extract_member_name,
 )
 
 
@@ -32,23 +34,25 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp
 
-        src = self._task.args.get('src', None)
-        b_src = to_bytes(src, errors='surrogate_or_strict')
-        dest = self._task.args.get('dest', None)
-        content = self._task.args.get('content', None)
-        sftp_port = self._task.args.get('sftp_port', 22)
-        force = _process_boolean(self._task.args.get('force'), default=True)
-        backup = _process_boolean(self._task.args.get('backup'), default=False)
-        local_follow = _process_boolean(self._task.args.get('local_follow'), default=False)
-        remote_src = _process_boolean(self._task.args.get('remote_src'), default=False)
-        is_binary = _process_boolean(self._task.args.get('is_binary'), default=False)
+        src = self._task.args.get("src", None)
+        b_src = to_bytes(src, errors="surrogate_or_strict")
+        dest = self._task.args.get("dest", None)
+        content = self._task.args.get("content", None)
+        sftp_port = self._task.args.get("sftp_port", 22)
+        force = _process_boolean(self._task.args.get("force"), default=True)
+        backup = _process_boolean(self._task.args.get("backup"), default=False)
+        local_follow = _process_boolean(
+            self._task.args.get("local_follow"), default=False
+        )
+        remote_src = _process_boolean(self._task.args.get("remote_src"), default=False)
+        is_binary = _process_boolean(self._task.args.get("is_binary"), default=False)
         backup_name = self._task.args.get("backup_name", None)
-        encoding = self._task.args.get('encoding', None)
-        mode = self._task.args.get('mode', None)
-        owner = self._task.args.get('owner', None)
-        group = self._task.args.get('group', None)
+        encoding = self._task.args.get("encoding", None)
+        mode = self._task.args.get("mode", None)
+        owner = self._task.args.get("owner", None)
+        group = self._task.args.get("group", None)
         ignore_sftp_stderr = _process_boolean(
-            self._task.args.get('ignore_sftp_stderr'), default=False
+            self._task.args.get("ignore_sftp_stderr"), default=False
         )
 
         new_module_args = self._task.args.copy()
@@ -60,7 +64,7 @@ class ActionModule(ActionBase):
                 msg = "Invalid type supplied for 'dest' option, it must be a string"
                 return self._exit_action(result, msg, failed=True)
             else:
-                is_uss = '/' in dest
+                is_uss = "/" in dest
                 is_mvs_dest = is_data_set(dest)
                 copy_member = is_member(dest)
         else:
@@ -138,16 +142,20 @@ class ActionModule(ActionBase):
                 if is_src_dir:
                     path, dirs, files = next(os.walk(src))
                     if dirs:
-                        result['msg'] = "Subdirectory found inside source directory"
-                        result.update(dict(src=src, dest=dest, changed=False, failed=True))
+                        result["msg"] = "Subdirectory found inside source directory"
+                        result.update(
+                            dict(src=src, dest=dest, changed=False, failed=True)
+                        )
                         return result
-                    new_module_args['size'] = sum(
+                    new_module_args["size"] = sum(
                         os.stat(path + "/" + f).st_size for f in files
                     )
                 else:
-                    if mode == 'preserve':
-                        new_module_args['mode'] = '0{0:o}'.format(stat.S_IMODE(os.stat(b_src).st_mode))
-                    new_module_args['size'] = os.stat(src).st_size
+                    if mode == "preserve":
+                        new_module_args["mode"] = "0{0:o}".format(
+                            stat.S_IMODE(os.stat(b_src).st_mode)
+                        )
+                    new_module_args["size"] = os.stat(src).st_size
                 transfer_res = self._copy_to_remote(
                     src, sftp_port, is_dir=is_src_dir, ignore_stderr=ignore_sftp_stderr
                 )
@@ -163,33 +171,33 @@ class ActionModule(ActionBase):
                 copy_member=copy_member,
                 src_member=src_member,
                 temp_path=temp_path,
-                is_mvs_dest=is_mvs_dest
+                is_mvs_dest=is_mvs_dest,
             )
         )
         copy_res = self._execute_module(
-            module_name='zos_copy',
+            module_name="ibm.ibm_zos_core.zos_copy",
             module_args=new_module_args,
-            task_vars=task_vars
+            task_vars=task_vars,
         )
 
-        if copy_res.get('note') and not force:
-            result['note'] = copy_res.get('note')
+        if copy_res.get("note") and not force:
+            result["note"] = copy_res.get("note")
             return result
 
-        if copy_res.get('msg'):
+        if copy_res.get("msg"):
             result.update(
                 dict(
-                    msg=copy_res.get('msg'),
-                    stdout=copy_res.get('stdout') or copy_res.get("module_stdout"),
-                    stderr=copy_res.get('stderr') or copy_res.get("module_stderr"),
+                    msg=copy_res.get("msg"),
+                    stdout=copy_res.get("stdout") or copy_res.get("module_stdout"),
+                    stderr=copy_res.get("stderr") or copy_res.get("module_stderr"),
                     stdout_lines=copy_res.get("stdout_lines"),
                     stderr_lines=copy_res.get("stderr_lines"),
-                    rc=copy_res.get('rc'),
-                    invocation=dict(module_args=self._task.args)
+                    rc=copy_res.get("rc"),
+                    invocation=dict(module_args=self._task.args),
                 )
             )
             if backup or backup_name:
-                result['backup_name'] = copy_res.get("backup_name")
+                result["backup_name"] = copy_res.get("backup_name")
             self._remote_cleanup(dest, copy_res.get("dest_exists"), task_vars)
             return result
 
@@ -200,11 +208,11 @@ class ActionModule(ActionBase):
         ansible_user = self._play_context.remote_user
         ansible_host = self._play_context.remote_addr
         temp_path = "/{0}/{1}".format(gettempprefix(), _create_temp_path_name())
-        cmd = ['sftp', "-oPort={0}".format(port), ansible_user + '@' + ansible_host]
-        stdin = "put -r {0} {1}".format(src.replace('#', '\\#'), temp_path)
+        cmd = ["sftp", "-oPort={0}".format(port), ansible_user + "@" + ansible_host]
+        stdin = "put -r {0} {1}".format(src.replace("#", "\\#"), temp_path)
 
         if is_dir:
-            src = src.rstrip('/') if src.endswith('/') else src
+            src = src.rstrip("/") if src.endswith("/") else src
             base = os.path.basename(src)
             self._connection.exec_command("mkdir -p {0}/{1}".format(temp_path, base))
         else:
@@ -221,7 +229,7 @@ class ActionModule(ActionBase):
                 rc=transfer_data.returncode,
                 stderr=err,
                 stderr_lines=err.splitlines(),
-                failed=True
+                failed=True,
             )
 
         return dict(temp_path=temp_path)
@@ -234,28 +242,28 @@ class ActionModule(ActionBase):
         created files or data sets.
         """
         if dest_exists is False:
-            if '/' in dest:
+            if "/" in dest:
                 self._connection.exec_command("rm -rf {0}".format(dest))
             else:
-                module_args = dict(name=dest, state='absent')
+                module_args = dict(name=dest, state="absent")
                 if is_member(dest):
-                    module_args['type'] = "MEMBER"
+                    module_args["type"] = "MEMBER"
                 self._execute_module(
-                    module_name='zos_data_set',
+                    module_name="ibm.ibm_zos_core.zos_data_set",
                     module_args=module_args,
-                    task_vars=task_vars
+                    task_vars=task_vars,
                 )
 
     def _dest_exists(self, src, dest, task_vars):
         """Determine if destination exists on remote z/OS system"""
-        if '/' in dest:
+        if "/" in dest:
             rc, out, err = self._connection.exec_command("ls -l {0}".format(dest))
             if rc != 0:
                 return False
             if len(to_text(out).split("\n")) == 2:
                 return True
-            if '/' in src:
-                src = src.rstrip('/') if src.endswith('/') else src
+            if "/" in src:
+                src = src.rstrip("/") if src.endswith("/") else src
                 dest += "/" + os.path.basename(src)
             else:
                 dest += "/" + extract_member_name(src) if is_member(src) else src
@@ -265,12 +273,12 @@ class ActionModule(ActionBase):
         else:
             cmd = "LISTDS '{0}'".format(dest)
             tso_cmd = self._execute_module(
-                module_name='zos_tso_command',
+                module_name="ibm.ibm_zos_core.zos_tso_command",
                 module_args=dict(commands=[cmd]),
-                task_vars=task_vars
-            ).get('output')[0]
-            if tso_cmd.get('rc') != 0:
-                for line in tso_cmd.get('content'):
+                task_vars=task_vars,
+            ).get("output")[0]
+            if tso_cmd.get("rc") != 0:
+                for line in tso_cmd.get("content"):
                     if "NOT IN CATALOG" in line:
                         return False
         return True
@@ -279,14 +287,15 @@ class ActionModule(ActionBase):
         """Exit action plugin with a message"""
         result.update(
             dict(
-                changed=False, failed=failed,
-                invocation=dict(module_args=self._task.args)
+                changed=False,
+                failed=failed,
+                invocation=dict(module_args=self._task.args),
             )
         )
         if failed:
-            result['msg'] = msg
+            result["msg"] = msg
         else:
-            result['note'] = msg
+            result["note"] = msg
         return result
 
 
@@ -297,17 +306,17 @@ def _update_result(is_binary, copy_res, original_args):
     note = copy_res.get("note")
     backup_name = copy_res.get("backup_name")
     updated_result = dict(
-        dest=copy_res.get('dest'),
+        dest=copy_res.get("dest"),
         is_binary=is_binary,
         changed=copy_res.get("changed"),
-        invocation=dict(module_args=original_args)
+        invocation=dict(module_args=original_args),
     )
     if src:
-        updated_result['src'] = src
+        updated_result["src"] = src
     if note:
-        updated_result['note'] = note
+        updated_result["note"] = note
     if backup_name:
-        updated_result['backup_name'] = backup_name
+        updated_result["backup_name"] = backup_name
 
     if ds_type == "USS":
         updated_result.update(
@@ -323,7 +332,7 @@ def _update_result(is_binary, copy_res, original_args):
         )
         checksum = copy_res.get("checksum")
         if checksum:
-            updated_result['checksum'] = checksum
+            updated_result["checksum"] = checksum
 
     return updated_result
 
@@ -360,7 +369,7 @@ def _write_content_to_temp_file(content):
     """Write given content to a temp file and return its path """
     fd, path = mkstemp()
     try:
-        with os.fdopen(fd, 'w') as infile:
+        with os.fdopen(fd, "w") as infile:
             infile.write(content)
     except (OSError, IOError) as err:
         os.remove(path)

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -133,7 +133,7 @@ class ActionModule(ActionBase):
         ds_type = None
         fetch_member = "(" in src and src.endswith(")")
         if fetch_member:
-            member_name = src[src.find("(") + 1 : src.find(")")]
+            member_name = src[src.find("(") + 1: src.find(")")]
         src = self._connection._shell.join_path(src)
         src = self._remote_expand_user(src)
 

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -1,7 +1,7 @@
 # Copyright (c) IBM Corporation 2019, 2020
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
@@ -17,27 +17,29 @@ from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
 
 
-SUPPORTED_DS_TYPES = frozenset({'PS', 'PO', 'VSAM', 'USS'})
+SUPPORTED_DS_TYPES = frozenset({"PS", "PO", "VSAM", "USS"})
 
 
 def _update_result(result, src, dest, ds_type="USS", is_binary=False):
     """ Helper function to update output result with the provided values """
     data_set_types = {
-        'PS': "Sequential",
-        'PO': "Partitioned",
-        'PDSE': "Partitioned Extended",
-        'PE': "Partitioned Extended",
-        'VSAM': "VSAM",
-        'USS': "USS"
+        "PS": "Sequential",
+        "PO": "Partitioned",
+        "PDSE": "Partitioned Extended",
+        "PE": "Partitioned Extended",
+        "VSAM": "VSAM",
+        "USS": "USS",
     }
-    file_or_ds = "file" if ds_type == 'USS' else "data set"
+    file_or_ds = "file" if ds_type == "USS" else "data set"
     updated_result = dict((k, v) for k, v in result.items())
-    updated_result.update({
-        'file': src,
-        'dest': dest,
-        'data_set_type': data_set_types[ds_type],
-        'is_binary': is_binary
-    })
+    updated_result.update(
+        {
+            "file": src,
+            "dest": dest,
+            "data_set_type": data_set_types[ds_type],
+            "is_binary": is_binary,
+        }
+    )
     return updated_result
 
 
@@ -59,7 +61,7 @@ def _get_file_checksum(src):
     blksize = 64 * 1024
     hash_digest = sha256()
     try:
-        with open(to_bytes(src, errors='surrogate_or_strict'), 'rb') as infile:
+        with open(to_bytes(src, errors="surrogate_or_strict"), "rb") as infile:
             block = infile.read(blksize)
             while block:
                 hash_digest.update(block)
@@ -91,17 +93,17 @@ class ActionModule(ActionBase):
         #                 Parameter initializations                  #
         # ********************************************************** #
 
-        src = self._task.args.get('src')
-        dest = self._task.args.get('dest')
-        encoding = self._task.args.get('encoding')
-        sftp_port = self._task.args.get('sftp_port', 22)
-        flat = _process_boolean(self._task.args.get('flat'), default=False)
-        is_binary = _process_boolean(self._task.args.get('is_binary'))
+        src = self._task.args.get("src")
+        dest = self._task.args.get("dest")
+        encoding = self._task.args.get("encoding")
+        sftp_port = self._task.args.get("sftp_port", 22)
+        flat = _process_boolean(self._task.args.get("flat"), default=False)
+        is_binary = _process_boolean(self._task.args.get("is_binary"))
         ignore_sftp_stderr = _process_boolean(
-            self._task.args.get('ignore_sftp_stderr'), default=False
+            self._task.args.get("ignore_sftp_stderr"), default=False
         )
         validate_checksum = _process_boolean(
-            self._task.args.get('validate_checksum'), default=True
+            self._task.args.get("validate_checksum"), default=True
         )
 
         # ********************************************************** #
@@ -112,14 +114,10 @@ class ActionModule(ActionBase):
         if src is None or dest is None:
             msg = "Source and destination are required"
         elif not isinstance(src, string_types):
-            msg = (
-                "Invalid type supplied for 'source' option, "
-                "it must be a string"
-            )
+            msg = "Invalid type supplied for 'source' option, " "it must be a string"
         elif not isinstance(dest, string_types):
             msg = (
-                "Invalid type supplied for 'destination' option, "
-                "it must be a string"
+                "Invalid type supplied for 'destination' option, " "it must be a string"
             )
         elif len(src) < 1 or len(dest) < 1:
             msg = "Source and destination parameters must not be empty"
@@ -128,14 +126,14 @@ class ActionModule(ActionBase):
             msg = "Invalid port provided for SFTP. Expected an integer between 0 to 65535."
 
         if msg:
-            result['msg'] = msg
-            result['failed'] = True
+            result["msg"] = msg
+            result["failed"] = True
             return result
 
         ds_type = None
-        fetch_member = '(' in src and src.endswith(')')
+        fetch_member = "(" in src and src.endswith(")")
         if fetch_member:
-            member_name = src[src.find('(') + 1:src.find(')')]
+            member_name = src[src.find("(") + 1 : src.find(")")]
         src = self._connection._shell.join_path(src)
         src = self._remote_expand_user(src)
 
@@ -155,24 +153,23 @@ class ActionModule(ActionBase):
         #  and dest is: /tmp/, then updated dest would be /tmp/DATA  #
         # ********************************************************** #
 
-        if os.path.sep not in self._connection._shell.join_path('a', ''):
+        if os.path.sep not in self._connection._shell.join_path("a", ""):
             src = self._connection._shell._unquote(src)
-            source_local = src.replace('\\', '/')
+            source_local = src.replace("\\", "/")
         else:
             source_local = src
 
         dest = os.path.expanduser(dest)
         if flat:
-            if (
-                os.path.isdir(to_bytes(dest, errors='surrogate_or_strict')) and
-                not dest.endswith(os.sep)
-            ):
-                result['msg'] = (
+            if os.path.isdir(
+                to_bytes(dest, errors="surrogate_or_strict")
+            ) and not dest.endswith(os.sep):
+                result["msg"] = (
                     "dest is an existing directory, append a forward "
                     "slash to the dest if you want to fetch src into "
                     "that directory"
                 )
-                result['failed'] = True
+                result["failed"] = True
                 return result
             if dest.endswith(os.sep):
                 if fetch_member:
@@ -184,22 +181,22 @@ class ActionModule(ActionBase):
             if not dest.startswith("/"):
                 dest = self._loader.path_dwim(dest)
         else:
-            if 'inventory_hostname' in task_vars:
-                target_name = task_vars['inventory_hostname']
+            if "inventory_hostname" in task_vars:
+                target_name = task_vars["inventory_hostname"]
             else:
                 target_name = self._play_context.remote_addr
             suffix = member_name if fetch_member else source_local
             dest = "{0}/{1}/{2}".format(
-                self._loader.path_dwim(dest),
-                target_name,
-                suffix
+                self._loader.path_dwim(dest), target_name, suffix
             )
             try:
                 dirname = os.path.dirname(dest).replace("//", "/")
                 if not os.path.exists(dirname):
                     os.makedirs(dirname)
             except OSError as err:
-                result["msg"] = "Unable to create destination directory {0}".format(dirname)
+                result["msg"] = "Unable to create destination directory {0}".format(
+                    dirname
+                )
                 result["stderr"] = str(err)
                 result["stderr_lines"] = str(err).splitlines()
                 result["failed"] = True
@@ -214,59 +211,69 @@ class ActionModule(ActionBase):
 
         try:
             fetch_res = self._execute_module(
-                module_name='zos_fetch',
+                module_name="ibm.ibm_zos_core.zos_fetch",
                 module_args=self._task.args,
-                task_vars=task_vars
+                task_vars=task_vars,
             )
-            ds_type = fetch_res.get('ds_type')
-            src = fetch_res.get('file')
-            remote_path = fetch_res.get('remote_path')
+            ds_type = fetch_res.get("ds_type")
+            src = fetch_res.get("file")
+            remote_path = fetch_res.get("remote_path")
 
-            if fetch_res.get('msg'):
-                result['msg'] = fetch_res.get('msg')
-                result['stdout'] = fetch_res.get('stdout') or fetch_res.get("module_stdout")
-                result['stderr'] = fetch_res.get('stderr') or fetch_res.get("module_stderr")
-                result['stdout_lines'] = fetch_res.get('stdout_lines')
-                result['stderr_lines'] = fetch_res.get('stderr_lines')
+            if fetch_res.get("msg"):
+                result["msg"] = fetch_res.get("msg")
+                result["stdout"] = fetch_res.get("stdout") or fetch_res.get(
+                    "module_stdout"
+                )
+                result["stderr"] = fetch_res.get("stderr") or fetch_res.get(
+                    "module_stderr"
+                )
+                result["stdout_lines"] = fetch_res.get("stdout_lines")
+                result["stderr_lines"] = fetch_res.get("stderr_lines")
                 result["rc"] = fetch_res.get("rc")
-                result['failed'] = True
+                result["failed"] = True
                 return result
 
-            elif fetch_res.get('note'):
-                result['note'] = fetch_res.get('note')
+            elif fetch_res.get("note"):
+                result["note"] = fetch_res.get("note")
                 return result
 
             if ds_type in SUPPORTED_DS_TYPES:
                 if ds_type == "PO" and os.path.isfile(dest) and not fetch_member:
-                    result["msg"] = "Destination must be a directory to fetch a partitioned data set"
+                    result[
+                        "msg"
+                    ] = "Destination must be a directory to fetch a partitioned data set"
                     result["failed"] = True
                     return result
 
                 fetch_content = self._transfer_remote_content(
-                    dest, remote_path, ds_type, sftp_port, ignore_stderr=ignore_sftp_stderr
+                    dest,
+                    remote_path,
+                    ds_type,
+                    sftp_port,
+                    ignore_stderr=ignore_sftp_stderr,
                 )
-                if fetch_content.get('msg'):
+                if fetch_content.get("msg"):
                     return fetch_content
 
                 if validate_checksum and ds_type != "PO" and not is_binary:
                     new_checksum = _get_file_checksum(dest)
-                    result['changed'] = local_checksum != new_checksum
-                    result['checksum'] = new_checksum
+                    result["changed"] = local_checksum != new_checksum
+                    result["checksum"] = new_checksum
                 else:
-                    result['changed'] = True
+                    result["changed"] = True
 
             else:
-                result['msg'] = (
+                result["msg"] = (
                     "The data set type '{0}' is not"
                     " currently supported".format(ds_type)
                 )
-                result['failed'] = True
+                result["failed"] = True
                 return result
         except Exception as err:
-            result['msg'] = "Failure during module execution"
-            result['stderr'] = str(err)
-            result['stderr_lines'] = str(err).splitlines()
-            result['failed'] = True
+            result["msg"] = "Failure during module execution"
+            result["stderr"] = str(err)
+            result["stderr_lines"] = str(err).splitlines()
+            result["failed"] = True
             return result
 
         # ********************************************************** #
@@ -277,7 +284,9 @@ class ActionModule(ActionBase):
             self._remote_cleanup(remote_path, ds_type, encoding)
         return _update_result(result, src, dest, ds_type, is_binary=is_binary)
 
-    def _transfer_remote_content(self, dest, remote_path, src_type, port, ignore_stderr=False):
+    def _transfer_remote_content(
+        self, dest, remote_path, src_type, port, ignore_stderr=False
+    ):
         """ Transfer a file or directory from USS to local machine.
             After the transfer is complete, the USS file or directory will
             be removed.
@@ -286,27 +295,26 @@ class ActionModule(ActionBase):
         ansible_user = self._play_context.remote_user
         ansible_host = self._play_context.remote_addr
 
-        cmd = ['sftp', "-oPort={0}".format(port), ansible_user + '@' + ansible_host]
+        cmd = ["sftp", "-oPort={0}".format(port), ansible_user + "@" + ansible_host]
         stdin = "get -r {0} {1}".format(remote_path, dest)
         if src_type != "PO":
             stdin = stdin.replace(" -r", "")
 
         transfer_pds = subprocess.Popen(
-            cmd,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
         out, err = transfer_pds.communicate(to_bytes(stdin))
         err = _detect_sftp_errors(err)
         if re.findall(r"Permission denied", err):
-            result["msg"] = "Insufficient write permission for destination {0}".format(dest)
+            result["msg"] = "Insufficient write permission for destination {0}".format(
+                dest
+            )
         elif transfer_pds.returncode != 0 or (err and not ignore_stderr):
-            result['msg'] = "Error transferring remote data from z/OS system"
-            result['rc'] = transfer_pds.returncode
+            result["msg"] = "Error transferring remote data from z/OS system"
+            result["rc"] = transfer_pds.returncode
         if result.get("msg"):
-            result['stderr'] = err
-            result['failed'] = True
+            result["stderr"] = err
+            result["failed"] = True
         return result
 
     def _remote_cleanup(self, remote_path, src_type, encoding):

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -1,7 +1,7 @@
 # Copyright (c) IBM Corporation 2019, 2020
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
@@ -115,7 +115,7 @@ class ActionModule(ActionBase):
             )
             result.update(
                 self._execute_module(
-                    module_name="zos_job_submit",
+                    module_name="ibm.ibm_zos_core.zos_job_submit",
                     module_args=module_args,
                     task_vars=task_vars,
                 )
@@ -123,7 +123,7 @@ class ActionModule(ActionBase):
         else:
             result.update(
                 self._execute_module(
-                    module_name="zos_job_submit",
+                    module_name="ibm.ibm_zos_core.zos_job_submit",
                     module_args=module_args,
                     task_vars=task_vars,
                 )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a bug which causes action plugins to fail when collections are referenced using fully qualified collection names instead of playbook level imports. Since playbook level imports do not work in roles, this causes any of our modules that use action plugins to fail when used inside roles.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request