### PR TITLE
Copy + Fetch Update

### DIFF
--- a/docs/source/modules/zos_copy.rst
+++ b/docs/source/modules/zos_copy.rst
@@ -254,6 +254,29 @@ validate
 
 
 
+sftp_port
+  Indicates which port should be used to connect to the remote z/OS system to perform data transfer.
+
+  If this parameter is not specified, ``ansible_port`` will be used.
+
+  If ``ansible_port`` is not specified, port 22 will be used.
+
+
+  | **required**: False
+  | **type**: int
+
+
+
+ignore_sftp_stderr
+  During data transfer through sftp, the module fails if the sftp command directs any content to stderr. The user is able to override this behavior by setting this parameter to C(true). By doing so, the module would essentially ignore the stderr stream produced by sftp and continue execution.
+
+
+  | **required**: False
+  | **type**: bool
+  | **default**: false
+
+
+
 
 Examples
 --------

--- a/docs/source/modules/zos_fetch.rst
+++ b/docs/source/modules/zos_fetch.rst
@@ -154,6 +154,29 @@ validate_checksum
 
 
 
+sftp_port
+  Indicates which port should be used to connect to the remote z/OS system to perform data transfer.
+
+  If this parameter is not specified, ``ansible_port`` will be used.
+
+  If ``ansible_port`` is not specified, port 22 will be used.
+
+
+  | **required**: False
+  | **type**: int
+
+
+
+ignore_sftp_stderr
+  During data transfer through sftp, the module fails if the sftp command directs any content to stderr. The user is able to override this behavior by setting this parameter to C(true). By doing so, the module would essentially ignore the stderr stream produced by sftp and continue execution.
+
+
+  | **required**: False
+  | **type**: bool
+  | **default**: false
+
+
+
 
 Examples
 --------

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -103,7 +103,15 @@ Reference
 
 
 Version 1.1.0
+<<<<<<< HEAD
 =============
+=======
+<<<<<<< HEAD
+=============
+=======
+-------------
+>>>>>>> master
+>>>>>>> master
 
 Notes
    * Update recommended

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -103,15 +103,7 @@ Reference
 
 
 Version 1.1.0
-<<<<<<< HEAD
 =============
-=======
-<<<<<<< HEAD
-=============
-=======
--------------
->>>>>>> master
->>>>>>> master
 
 Notes
    * Update recommended

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -34,18 +34,18 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp
 
-        src = self._task.args.get("src", None)
-        b_src = to_bytes(src, errors="surrogate_or_strict")
-        dest = self._task.args.get("dest", None)
-        content = self._task.args.get("content", None)
-        sftp_port = self._task.args.get("sftp_port", 22)
-        force = _process_boolean(self._task.args.get("force"), default=True)
-        backup = _process_boolean(self._task.args.get("backup"), default=False)
-        local_follow = _process_boolean(
-            self._task.args.get("local_follow"), default=False
-        )
-        remote_src = _process_boolean(self._task.args.get("remote_src"), default=False)
-        is_binary = _process_boolean(self._task.args.get("is_binary"), default=False)
+        src = self._task.args.get('src', None)
+        b_src = to_bytes(src, errors='surrogate_or_strict')
+        dest = self._task.args.get('dest', None)
+        content = self._task.args.get('content', None)
+        # If self._play_context.port is None, that implies the default port 22
+        # was used to connect to the remote host.
+        sftp_port = self._task.args.get('sftp_port', self._play_context.port or 22)
+        force = _process_boolean(self._task.args.get('force'), default=True)
+        backup = _process_boolean(self._task.args.get('backup'), default=False)
+        local_follow = _process_boolean(self._task.args.get('local_follow'), default=False)
+        remote_src = _process_boolean(self._task.args.get('remote_src'), default=False)
+        is_binary = _process_boolean(self._task.args.get('is_binary'), default=False)
         backup_name = self._task.args.get("backup_name", None)
         encoding = self._task.args.get("encoding", None)
         mode = self._task.args.get("mode", None)

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -91,12 +91,14 @@ class ActionModule(ActionBase):
         #                 Parameter initializations                  #
         # ********************************************************** #
 
-        src = self._task.args.get("src")
-        dest = self._task.args.get("dest")
-        encoding = self._task.args.get("encoding")
-        sftp_port = self._task.args.get("sftp_port", 22)
-        flat = _process_boolean(self._task.args.get("flat"), default=False)
-        is_binary = _process_boolean(self._task.args.get("is_binary"))
+        src = self._task.args.get('src')
+        dest = self._task.args.get('dest')
+        encoding = self._task.args.get('encoding')
+        # If self._play_context.port is None, that implies the default port 22
+        # was used to connect to the remote host.
+        sftp_port = self._task.args.get('sftp_port', self._play_context.port or 22)
+        flat = _process_boolean(self._task.args.get('flat'), default=False)
+        is_binary = _process_boolean(self._task.args.get('is_binary'))
         ignore_sftp_stderr = _process_boolean(
             self._task.args.get("ignore_sftp_stderr"), default=False
         )

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -1,7 +1,7 @@
 # Copyright (c) IBM Corporation 2019, 2020
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
@@ -23,23 +23,21 @@ SUPPORTED_DS_TYPES = frozenset({"PS", "PO", "VSAM", "USS"})
 def _update_result(result, src, dest, ds_type="USS", is_binary=False):
     """ Helper function to update output result with the provided values """
     data_set_types = {
-        "PS": "Sequential",
-        "PO": "Partitioned",
-        "PDSE": "Partitioned Extended",
-        "PE": "Partitioned Extended",
-        "VSAM": "VSAM",
-        "USS": "USS",
+        'PS': "Sequential",
+        'PO': "Partitioned",
+        'PDSE': "Partitioned Extended",
+        'PE': "Partitioned Extended",
+        'VSAM': "VSAM",
+        'USS': "USS"
     }
-    file_or_ds = "file" if ds_type == "USS" else "data set"
+    file_or_ds = "file" if ds_type == 'USS' else "data set"
     updated_result = dict((k, v) for k, v in result.items())
-    updated_result.update(
-        {
-            "file": src,
-            "dest": dest,
-            "data_set_type": data_set_types[ds_type],
-            "is_binary": is_binary,
-        }
-    )
+    updated_result.update({
+        'file': src,
+        'dest': dest,
+        'data_set_type': data_set_types[ds_type],
+        'is_binary': is_binary
+    })
     return updated_result
 
 
@@ -61,7 +59,7 @@ def _get_file_checksum(src):
     blksize = 64 * 1024
     hash_digest = sha256()
     try:
-        with open(to_bytes(src, errors="surrogate_or_strict"), "rb") as infile:
+        with open(to_bytes(src, errors='surrogate_or_strict'), 'rb') as infile:
             block = infile.read(blksize)
             while block:
                 hash_digest.update(block)
@@ -103,7 +101,7 @@ class ActionModule(ActionBase):
             self._task.args.get("ignore_sftp_stderr"), default=False
         )
         validate_checksum = _process_boolean(
-            self._task.args.get("validate_checksum"), default=True
+            self._task.args.get('validate_checksum'), default=True
         )
 
         # ********************************************************** #
@@ -114,10 +112,14 @@ class ActionModule(ActionBase):
         if src is None or dest is None:
             msg = "Source and destination are required"
         elif not isinstance(src, string_types):
-            msg = "Invalid type supplied for 'source' option, " "it must be a string"
+            msg = (
+                "Invalid type supplied for 'source' option, "
+                "it must be a string"
+            )
         elif not isinstance(dest, string_types):
             msg = (
-                "Invalid type supplied for 'destination' option, " "it must be a string"
+                "Invalid type supplied for 'destination' option, "
+                "it must be a string"
             )
         elif len(src) < 1 or len(dest) < 1:
             msg = "Source and destination parameters must not be empty"
@@ -126,12 +128,12 @@ class ActionModule(ActionBase):
             msg = "Invalid port provided for SFTP. Expected an integer between 0 to 65535."
 
         if msg:
-            result["msg"] = msg
-            result["failed"] = True
+            result['msg'] = msg
+            result['failed'] = True
             return result
 
         ds_type = None
-        fetch_member = "(" in src and src.endswith(")")
+        fetch_member = '(' in src and src.endswith(')')
         if fetch_member:
             member_name = src[src.find("(") + 1: src.find(")")]
         src = self._connection._shell.join_path(src)
@@ -153,23 +155,24 @@ class ActionModule(ActionBase):
         #  and dest is: /tmp/, then updated dest would be /tmp/DATA  #
         # ********************************************************** #
 
-        if os.path.sep not in self._connection._shell.join_path("a", ""):
+        if os.path.sep not in self._connection._shell.join_path('a', ''):
             src = self._connection._shell._unquote(src)
-            source_local = src.replace("\\", "/")
+            source_local = src.replace('\\', '/')
         else:
             source_local = src
 
         dest = os.path.expanduser(dest)
         if flat:
-            if os.path.isdir(
-                to_bytes(dest, errors="surrogate_or_strict")
-            ) and not dest.endswith(os.sep):
-                result["msg"] = (
+            if (
+                os.path.isdir(to_bytes(dest, errors='surrogate_or_strict')) and
+                not dest.endswith(os.sep)
+            ):
+                result['msg'] = (
                     "dest is an existing directory, append a forward "
                     "slash to the dest if you want to fetch src into "
                     "that directory"
                 )
-                result["failed"] = True
+                result['failed'] = True
                 return result
             if dest.endswith(os.sep):
                 if fetch_member:
@@ -181,22 +184,22 @@ class ActionModule(ActionBase):
             if not dest.startswith("/"):
                 dest = self._loader.path_dwim(dest)
         else:
-            if "inventory_hostname" in task_vars:
-                target_name = task_vars["inventory_hostname"]
+            if 'inventory_hostname' in task_vars:
+                target_name = task_vars['inventory_hostname']
             else:
                 target_name = self._play_context.remote_addr
             suffix = member_name if fetch_member else source_local
             dest = "{0}/{1}/{2}".format(
-                self._loader.path_dwim(dest), target_name, suffix
+                self._loader.path_dwim(dest),
+                target_name,
+                suffix
             )
             try:
                 dirname = os.path.dirname(dest).replace("//", "/")
                 if not os.path.exists(dirname):
                     os.makedirs(dirname)
             except OSError as err:
-                result["msg"] = "Unable to create destination directory {0}".format(
-                    dirname
-                )
+                result["msg"] = "Unable to create destination directory {0}".format(dirname)
                 result["stderr"] = str(err)
                 result["stderr_lines"] = str(err).splitlines()
                 result["failed"] = True
@@ -213,35 +216,29 @@ class ActionModule(ActionBase):
             fetch_res = self._execute_module(
                 module_name="ibm.ibm_zos_core.zos_fetch",
                 module_args=self._task.args,
-                task_vars=task_vars,
+                task_vars=task_vars
             )
-            ds_type = fetch_res.get("ds_type")
-            src = fetch_res.get("file")
-            remote_path = fetch_res.get("remote_path")
+            ds_type = fetch_res.get('ds_type')
+            src = fetch_res.get('file')
+            remote_path = fetch_res.get('remote_path')
 
-            if fetch_res.get("msg"):
-                result["msg"] = fetch_res.get("msg")
-                result["stdout"] = fetch_res.get("stdout") or fetch_res.get(
-                    "module_stdout"
-                )
-                result["stderr"] = fetch_res.get("stderr") or fetch_res.get(
-                    "module_stderr"
-                )
-                result["stdout_lines"] = fetch_res.get("stdout_lines")
-                result["stderr_lines"] = fetch_res.get("stderr_lines")
+            if fetch_res.get('msg'):
+                result['msg'] = fetch_res.get('msg')
+                result['stdout'] = fetch_res.get('stdout') or fetch_res.get("module_stdout")
+                result['stderr'] = fetch_res.get('stderr') or fetch_res.get("module_stderr")
+                result['stdout_lines'] = fetch_res.get('stdout_lines')
+                result['stderr_lines'] = fetch_res.get('stderr_lines')
                 result["rc"] = fetch_res.get("rc")
-                result["failed"] = True
+                result['failed'] = True
                 return result
 
-            elif fetch_res.get("note"):
-                result["note"] = fetch_res.get("note")
+            elif fetch_res.get('note'):
+                result['note'] = fetch_res.get('note')
                 return result
 
             if ds_type in SUPPORTED_DS_TYPES:
                 if ds_type == "PO" and os.path.isfile(dest) and not fetch_member:
-                    result[
-                        "msg"
-                    ] = "Destination must be a directory to fetch a partitioned data set"
+                    result["msg"] = "Destination must be a directory to fetch a partitioned data set"
                     result["failed"] = True
                     return result
 
@@ -252,28 +249,28 @@ class ActionModule(ActionBase):
                     sftp_port,
                     ignore_stderr=ignore_sftp_stderr,
                 )
-                if fetch_content.get("msg"):
+                if fetch_content.get('msg'):
                     return fetch_content
 
                 if validate_checksum and ds_type != "PO" and not is_binary:
                     new_checksum = _get_file_checksum(dest)
-                    result["changed"] = local_checksum != new_checksum
-                    result["checksum"] = new_checksum
+                    result['changed'] = local_checksum != new_checksum
+                    result['checksum'] = new_checksum
                 else:
-                    result["changed"] = True
+                    result['changed'] = True
 
             else:
-                result["msg"] = (
+                result['msg'] = (
                     "The data set type '{0}' is not"
                     " currently supported".format(ds_type)
                 )
-                result["failed"] = True
+                result['failed'] = True
                 return result
         except Exception as err:
-            result["msg"] = "Failure during module execution"
-            result["stderr"] = str(err)
-            result["stderr_lines"] = str(err).splitlines()
-            result["failed"] = True
+            result['msg'] = "Failure during module execution"
+            result['stderr'] = str(err)
+            result['stderr_lines'] = str(err).splitlines()
+            result['failed'] = True
             return result
 
         # ********************************************************** #
@@ -301,7 +298,10 @@ class ActionModule(ActionBase):
             stdin = stdin.replace(" -r", "")
 
         transfer_pds = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
         )
         out, err = transfer_pds.communicate(to_bytes(stdin))
         err = _detect_sftp_errors(err)
@@ -313,8 +313,8 @@ class ActionModule(ActionBase):
             result["msg"] = "Error transferring remote data from z/OS system"
             result["rc"] = transfer_pds.returncode
         if result.get("msg"):
-            result["stderr"] = err
-            result["failed"] = True
+            result['stderr'] = err
+            result['failed'] = True
         return result
 
     def _remote_cleanup(self, remote_path, src_type, encoding):

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -8,7 +8,6 @@ __metaclass__ = type
 import re
 import tempfile
 from os import path
-from random import choice
 from string import ascii_uppercase, digits
 from random import randint
 from ansible.module_utils._text import to_bytes
@@ -1182,7 +1181,7 @@ class DataSetUtils(object):
                 if result.get("dsorg") != "VSAM":
                     result["recfm"] = ds_params[0]
                     result["lrecl"] = ds_params[1]
-                    if len(ds_params) > 2:
+                    if len(ds_params) > 2 and ds_params[2].isdigit():
                         result["blksize"] = int(ds_params[2])
         return result
 

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -1180,7 +1180,8 @@ class DataSetUtils(object):
                 result["dsorg"] = ds_params[-1]
                 if result.get("dsorg") != "VSAM":
                     result["recfm"] = ds_params[0]
-                    result["lrecl"] = ds_params[1]
+                    if ds_params[1].isdigit():
+                        result["lrecl"] = int(ds_params[1])
                     if len(ds_params) > 2 and ds_params[2].isdigit():
                         result["blksize"] = int(ds_params[2])
         return result

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -1197,9 +1197,10 @@ class DataSetUtils(object):
         result = dict()
         if "NOT FOUND" not in output:
             volser_output = re.findall(r"VOLSER-*[A-Z|0-9]*", output)
-            result["volser"] = "".join(
-                re.findall(r"-[A-Z|0-9]*", volser_output[0])
-            ).replace("-", "")
+            if volser_output:
+                result["volser"] = "".join(
+                    re.findall(r"-[A-Z|0-9]*", volser_output[0])
+                ).replace("-", "")
         return result
 
 

--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -425,4 +425,4 @@ class DiscoverCharsetError(Exception):
             ("An error occurred while determining default charset of remote system; ")
             ("stderr: {0}; stdout: {1}; rc: {2}".format(rc, out, err))
         )
-        super(EncodeError, self).__init__(self.msg)
+        super(DiscoverCharsetError, self).__init__(self.msg)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1495,15 +1495,17 @@ def main():
         sftp_port=dict(arg_type='int', required=False)
     )
 
-    if module.params.get("encoding"):
-        module.params.update(dict(
-            from_encoding=module.params.get('encoding').get('from'),
-            to_encoding=module.params.get('encoding').get('to'))
-        )
-        arg_def.update(dict(
-            from_encoding=dict(arg_type='encoding'),
-            to_encoding=dict(arg_type='encoding')
-        ))
+    if not module.params.get("encoding"):
+        module.params["encoding"] = {'from': 'ISO8859-1', 'to': 'IBM-1047'}
+
+    module.params.update(dict(
+        from_encoding=module.params.get('encoding').get('from'),
+        to_encoding=module.params.get('encoding').get('to'))
+    )
+    arg_def.update(dict(
+        from_encoding=dict(arg_type='encoding'),
+        to_encoding=dict(arg_type='encoding')
+    ))
     try:
         res_args = temp_path = conv_path = None
         res_args, temp_path, conv_path = run_module(module, arg_def)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -866,8 +866,11 @@ class USSCopyHandler(CopyHandler):
                 except FileExistsError:
                     pass
         try:
-            if src_ds_type in MVS_SEQ:
-                copy.copy_ps2uss(src, dest, is_binary=self.is_binary)
+            if src_member or src_ds_type in MVS_SEQ:
+                if Datasets.copy(src, dest) != 0:
+                    self.fail_json(
+                        msg="Error while copying source {0} to {1}".format(src, dest)
+                    )
             else:
                 copy.copy_pds2uss(src, dest, is_binary=self.is_binary)
         except Exception as err:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1498,17 +1498,24 @@ def main():
         sftp_port=dict(arg_type='int', required=False)
     )
 
-    if not module.params.get("encoding"):
-        module.params["encoding"] = {'from': 'ISO8859-1', 'to': 'IBM-1047'}
+    if (not module.params.get("encoding") 
+        and not module.params.get("remote_src")
+        and not module.params.get("is_binary")
+    ):
+        module.params["encoding"] = {
+            'from': encode.Defaults.DEFAULT_LOCAL_CHARSET,
+            'to': encode.EncodeUtils().remote_charset()
+        }
 
-    module.params.update(dict(
-        from_encoding=module.params.get('encoding').get('from'),
-        to_encoding=module.params.get('encoding').get('to'))
-    )
-    arg_def.update(dict(
-        from_encoding=dict(arg_type='encoding'),
-        to_encoding=dict(arg_type='encoding')
-    ))
+    if module.params.get("encoding"):
+        module.params.update(dict(
+            from_encoding=module.params.get('encoding').get('from'),
+            to_encoding=module.params.get('encoding').get('to'))
+        )
+        arg_def.update(dict(
+            from_encoding=dict(arg_type='encoding'),
+            to_encoding=dict(arg_type='encoding')
+        ))
     try:
         res_args = temp_path = conv_path = None
         res_args, temp_path, conv_path = run_module(module, arg_def)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1498,7 +1498,8 @@ def main():
         sftp_port=dict(arg_type='int', required=False)
     )
 
-    if (not module.params.get("encoding") 
+    if (
+        not module.params.get("encoding")
         and not module.params.get("remote_src")
         and not module.params.get("is_binary")
     ):

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -150,10 +150,11 @@ options:
   sftp_port:
     description:
       - Indicates which port should be used to connect to the remote z/OS
-        system to perform data transfer. Default is port 22.
+        system to perform data transfer.
+      - If this parameter is not specified, C(ansible_port) will be used.
+      - If C(ansible_port) is not specified, port 22 will be used.
     type: int
     required: false
-    default: 22
   encoding:
     description:
       - Specifies which encodings the destination file or data set should be
@@ -1465,7 +1466,7 @@ def main():
             model_ds=dict(type='str', required=False),
             local_follow=dict(type='bool', default=True),
             remote_src=dict(type='bool', default=False),
-            sftp_port=dict(type='int', default=22),
+            sftp_port=dict(type='int', required=False),
             ignore_sftp_stderr=dict(type='bool', default=False),
             validate=dict(type='bool'),
             is_uss=dict(type='bool'),
@@ -1491,7 +1492,7 @@ def main():
         remote_src=dict(arg_type='bool', default=False, required=False),
         checksum=dict(arg_type='str', required=False),
         validate=dict(arg_type='bool', required=False),
-        sftp_port=dict(arg_type='int', required=False, default=22)
+        sftp_port=dict(arg_type='int', required=False)
     )
 
     if module.params.get("encoding"):

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -459,13 +459,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module im
 from ansible.module_utils._text import to_bytes
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
-    better_arg_parser,
-    data_set,
-    encode,
-    vtoc,
-    backup,
-    copy,
-    mvs_cmd
+    better_arg_parser, data_set, encode, vtoc, backup, copy, mvs_cmd
 )
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -84,10 +84,11 @@ options:
   sftp_port:
     description:
       - Indicates which port should be used to connect to the remote z/OS
-        system to perform data transfer. Default is port 22.
+        system to perform data transfer.
+      - If this parameter is not specified, C(ansible_port) will be used.
+      - If C(ansible_port) is not specified, port 22 will be used.
     type: int
     required: false
-    default: 22
   encoding:
     description:
       - Specifies which encodings the fetched data set should be converted from
@@ -521,7 +522,7 @@ def run_module():
             use_qualifier=dict(required=False, default=False, type="bool"),
             validate_checksum=dict(required=False, default=True, type="bool"),
             encoding=dict(required=False, type="dict"),
-            sftp_port=dict(type='int', default=22, required=False),
+            sftp_port=dict(type='int', required=False),
             ignore_sftp_stderr=dict(type='bool', default=False, required=False)
         )
     )

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -543,22 +543,23 @@ def run_module():
         use_qualifier=dict(arg_type="bool", required=False, default=False)
     )
 
+    if not module.params.get("encoding") and not module.params.get("is_binary"):
+        module.params["encoding"] = {
+            'from': encode.EncodeUtils().remote_charset(),
+            'to': encode.Defaults.DEFAULT_LOCAL_CHARSET
+        }
+
     if module.params.get("encoding"):
-        module.params.update(
-            dict(
-                from_encoding=module.params.get("encoding").get("from"),
-                to_encoding=module.params.get("encoding").get("to"),
-            )
+        module.params.update(dict(
+            from_encoding=module.params.get('encoding').get('from'),
+            to_encoding=module.params.get('encoding').get('to'))
         )
-        arg_def.update(
-            dict(
-                from_encoding=dict(arg_type="encoding"),
-                to_encoding=dict(arg_type="encoding"),
-            )
-        )
+        arg_def.update(dict(
+            from_encoding=dict(arg_type='encoding'),
+            to_encoding=dict(arg_type='encoding')
+        ))
 
     fetch_handler = FetchHandler(module)
-
     try:
         parser = better_arg_parser.BetterArgParser(arg_def)
         parsed_args = parser.parse_args(module.params)
@@ -567,7 +568,6 @@ def run_module():
     src = parsed_args.get("src")
     b_src = to_bytes(src)
     fail_on_missing = boolean(parsed_args.get("fail_on_missing"))
-    use_qualifier = boolean(parsed_args.get("use_qualifier"))
     is_binary = boolean(parsed_args.get("is_binary"))
     encoding = module.params.get("encoding")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR introduces a few enhancements and a bugfix

Enhancements:
- Use `ansible_port` as the default sftp port. This means that the user does not have to explicitly specify sftp port. The `sftp_port` parameter is still there if the user really wants to specify it.
- The user no longer has to specify `encoding` when copying/fetching text data. The modules are able to discover the default remote system charset to use. The `encoding` parameter is still there if the user wants to use different charsets.

Bugfixes:
- When copying a data set member to a USS file, the data appears to be duplicated. This is happening because the module uses USS `cp` command with `-F rec` flag. This has been changed to use ZOAU copy API.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_fetch, zos_copy, encode
