### PR TITLE
Default MVS charset should be IBM-037

### DIFF
--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -215,7 +215,6 @@ class ActionModule(ActionBase):
         # ********************************************************** #
         #                Execute module on remote host               #
         # ********************************************************** #
-
         new_module_args = self._task.args.copy()
         new_module_args.update(
             dict(local_charset=encode.Defaults.get_default_system_charset())

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -16,6 +16,8 @@ from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
 
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import encode
+
 
 SUPPORTED_DS_TYPES = frozenset({"PS", "PO", "VSAM", "USS"})
 
@@ -214,10 +216,14 @@ class ActionModule(ActionBase):
         #                Execute module on remote host               #
         # ********************************************************** #
 
+        new_module_args = self._task.args.copy()
+        new_module_args.update(
+            dict(local_charset=encode.Defaults.get_default_system_charset())
+        )
         try:
             fetch_res = self._execute_module(
                 module_name="ibm.ibm_zos_core.zos_fetch",
-                module_args=self._task.args,
+                module_args=new_module_args,
                 task_vars=task_vars
             )
             ds_type = fetch_res.get('ds_type')

--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -42,6 +42,7 @@ else:
 class Defaults:
     DEFAULT_LOCAL_CHARSET = "ISO8859-1"
     DEFAULT_REMOTE_CHARSET = "IBM-1047"
+    DEFAULT_MVS_CHARSET = "IBM-037"
 
 
 class EncodeUtils(object):

--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -42,9 +42,9 @@ else:
 
 
 class Defaults:
-    DEFAULT_NON_ZOS_CHARSET = "UTF-8"
-    DEFAULT_ZOS_USS_CHARSET = "IBM-1047"
-    DEFAULT_ZOS_MVS_CHARSET = "IBM-037"
+    DEFAULT_ASCII_CHARSET = "UTF-8"
+    DEFAULT_EBCDIC_USS_CHARSET = "IBM-1047"
+    DEFAULT_EBCDIC_MVS_CHARSET = "IBM-037"
 
     @staticmethod
     def get_default_system_charset():
@@ -64,9 +64,9 @@ class Defaults:
                 system_charset = out[1].strip() if len(out) > 1 else out[0].strip()
             else:
                 if system.is_zos():
-                    system_charset = Defaults.DEFAULT_ZOS_USS_CHARSET
+                    system_charset = Defaults.DEFAULT_EBCDIC_USS_CHARSET
                 else:
-                    system_charset = Defaults.DEFAULT_NON_ZOS_CHARSET
+                    system_charset = Defaults.DEFAULT_ASCII_CHARSET
 
         return system_charset
 

--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -10,14 +10,13 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory, mkstemp
 from math import floor, ceil
 from os import path, walk, makedirs, unlink
 from ansible.module_utils.six import PY3
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
-    AnsibleModuleHelper,
-)
+
 import shutil
 import errno
 import os
 import re
 import locale
+
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
     MissingZOAUImport,
 )
@@ -27,9 +26,12 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     copy, system
 )
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
+    AnsibleModuleHelper,
+)
 
 try:
-    from zoautil_py import Datasets, MVSCmd
+    from zoautil_py import Datasets
 except Exception:
     Datasets = MissingZOAUImport()
     MVSCmd = MissingZOAUImport()
@@ -53,20 +55,17 @@ class Defaults:
         Returns:
             str -- The encoding of the current machine
         """
-        module = AnsibleModuleHelper(argument_spec={})
         system_charset = locale.getdefaultlocale()[1]
         if system_charset is None:
-            rc, out, err = module.run_command("locale -c charmap")
-            if rc != 0:
-                raise DiscoverCharsetError(rc, out, err)
-            out = out.splitlines()
-            if out:
-                system_charset = out[1].strip() if len(out) > 1 else out[0].strip()
-            else:
+            rc, out, err = system.run_command("locale -c charmap")
+            if rc != 0 or not out or err:
                 if system.is_zos():
                     system_charset = Defaults.DEFAULT_EBCDIC_USS_CHARSET
                 else:
                     system_charset = Defaults.DEFAULT_ASCII_CHARSET
+            else:
+                out = out.splitlines()
+                system_charset = out[1].strip() if len(out) > 1 else out[0].strip()
 
         return system_charset
 
@@ -433,12 +432,3 @@ class MoveFileError(Exception):
     def __init__(self, src, dest, e):
         self.msg = "Failed when moving {0} to {1}: {2}".format(src, dest, e)
         super().__init__(self.msg)
-
-
-class DiscoverCharsetError(Exception):
-    def __init__(self, rc, out, err):
-        self.msg = (
-            ("An error occurred while determining default charset of remote system; ")
-            ("stderr: {0}; stdout: {1}; rc: {2}".format(rc, out, err))
-        )
-        super(DiscoverCharsetError, self).__init__(self.msg)

--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -9,7 +9,6 @@ __metaclass__ = type
 from tempfile import NamedTemporaryFile, TemporaryDirectory, mkstemp
 from math import floor, ceil
 from os import path, walk, makedirs, unlink
-from platform import platform
 from ansible.module_utils.six import PY3
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
     AnsibleModuleHelper,

--- a/plugins/module_utils/system.py
+++ b/plugins/module_utils/system.py
@@ -41,7 +41,7 @@ def is_nix():
     """
     if not is_posix():
         return False
-    system_platform = platform()
+    system_platform = platform().lower()
     for p_name in NIX_PLATFORMS:
         if p_name in system_platform:
             return True
@@ -54,7 +54,7 @@ def is_win():
     Returns:
         bool -- Whether the system is Windows
     """
-    return "win32" in platform() or OS_NAME == "nt"
+    return "win32" in platform().lower() or OS_NAME == "nt"
 
 
 def is_zos():

--- a/plugins/module_utils/system.py
+++ b/plugins/module_utils/system.py
@@ -1,0 +1,63 @@
+# Copyright (c) IBM Corporation 2020
+# Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from platform import platform
+from os import name as OS_NAME
+from sys import platform as SYS_PLATFORM
+
+
+NIX_PLATFORMS = frozenset({
+    "linux",
+    "linux2",
+    "darwin",
+    "freebsd",
+    "openbsd",
+    "sunos",
+    "netbsd"
+})
+
+
+def is_posix():
+    """ Determine if the system is POSIX certified or compliant
+
+    Returns:
+        bool -- Whether the system is POSIX
+    """
+    return OS_NAME == "posix"
+
+
+def is_nix():
+    """ Determine if the system is a variant of Unix, supported by Python.
+
+    Returns:
+        bool -- Whether the system is Unix-based
+    """
+    if not is_posix():
+        return False
+    system_platform = platform()
+    for p_name in NIX_PLATFORMS:
+        if p_name in system_platform:
+            return True
+    return False
+
+
+def is_win():
+    """ Determine if the system is a Windows platform
+
+    Returns:
+        bool -- Whether the system is Windows
+    """
+    return "win32" in platform() or OS_NAME == "nt"
+
+
+def is_zos():
+    """ Determine if the system is a z/OS distribution
+
+    Returns:
+        bool -- Whether the system is z/OS
+    """
+    is_zos_unix = is_posix() and not is_nix()
+    return is_zos_unix and SYS_PLATFORM == "zos"

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1370,7 +1370,7 @@ def run_module(module):
             )
         # 'conv_path' points to the converted src file or directory
         if is_mvs_dest:
-            encoding['to'] = encode.Defaults.DEFAULT_MVS_CHARSET
+            encoding['to'] = encode.Defaults.DEFAULT_EBCDIC_MVS_CHARSET
 
         conv_path = copy_handler.convert_encoding(src, temp_path, encoding)
 

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1377,6 +1377,9 @@ def run_module(module, arg_def):
                 msg="Encoding conversion is only valid for USS source"
             )
         # 'conv_path' points to the converted src file or directory
+        if is_mvs_dest:
+            encoding['to'] = encode.Defaults.DEFAULT_MVS_CHARSET
+
         conv_path = copy_handler.convert_encoding(src, temp_path, encoding)
 
     # ------------------------------- o -----------------------------------

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1499,13 +1499,10 @@ def main():
         and not module.params.get("remote_src")
         and not module.params.get("is_binary")
     ):
-        try:
-            module.params["encoding"] = {
-                'from': module.params.get("local_charset"),
-                'to': encode.Defaults.get_default_system_charset()
-            }
-        except Exception as err:
-            module.fail_json(msg=str(err))
+        module.params["encoding"] = {
+            'from': module.params.get("local_charset"),
+            'to': encode.Defaults.get_default_system_charset()
+        }
 
     if module.params.get("encoding"):
         module.params.update(dict(

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -446,7 +446,7 @@ class FetchHandler:
             )
         if (not is_binary) and encoding:
             enc_utils = encode.EncodeUtils()
-            from_code_set = encoding.get('from')
+            from_code_set = encoding.get("from")
             to_code_set = encoding.get("to")
             root, dirs, files = next(os.walk(dir_path))
             try:
@@ -489,7 +489,7 @@ class FetchHandler:
             )
         if (not is_binary) and encoding:
             enc_utils = encode.EncodeUtils()
-            from_code_set = encoding.get('from')
+            from_code_set = encoding.get("from")
             to_code_set = encoding.get("to")
             try:
                 enc_utils.uss_convert_encoding(

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -546,11 +546,7 @@ def run_module():
 
     if not module.params.get("encoding") and not module.params.get("is_binary"):
         mvs_src = data_set.is_data_set(src)
-        remote_charset = None
-        try:
-            remote_charset = encode.Defaults.get_default_system_charset()
-        except Exception as err:
-            module.fail_json(msg=str(err))
+        remote_charset = encode.Defaults.get_default_system_charset()
 
         module.params["encoding"] = {
             'from': encode.Defaults.DEFAULT_EBCDIC_MVS_CHARSET if mvs_src else remote_charset,

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -553,7 +553,7 @@ def run_module():
             module.fail_json(msg=str(err))
 
         module.params["encoding"] = {
-            'from': encode.Defaults.DEFAULT_MVS_CHARSET if mvs_src else remote_charset,
+            'from': encode.Defaults.DEFAULT_EBCDIC_MVS_CHARSET if mvs_src else remote_charset,
             'to': module.params.get("local_charset")
         }
 

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -523,7 +523,8 @@ def run_module():
             validate_checksum=dict(required=False, default=True, type="bool"),
             encoding=dict(required=False, type="dict"),
             sftp_port=dict(type='int', required=False),
-            ignore_sftp_stderr=dict(type='bool', default=False, required=False)
+            ignore_sftp_stderr=dict(type='bool', default=False, required=False),
+            local_charset=dict(type='str')
         )
     )
 
@@ -545,10 +546,15 @@ def run_module():
 
     if not module.params.get("encoding") and not module.params.get("is_binary"):
         mvs_src = data_set.is_data_set(src)
-        remote_charset = encode.EncodeUtils().remote_charset()
+        remote_charset = None
+        try:
+            remote_charset = encode.Defaults.get_default_system_charset()
+        except Exception as err:
+            module.fail_json(msg=str(err))
+
         module.params["encoding"] = {
             'from': encode.Defaults.DEFAULT_MVS_CHARSET if mvs_src else remote_charset,
-            'to': encode.Defaults.DEFAULT_LOCAL_CHARSET
+            'to': module.params.get("local_charset")
         }
 
     if module.params.get("encoding"):

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -446,7 +446,7 @@ class FetchHandler:
             )
         if (not is_binary) and encoding:
             enc_utils = encode.EncodeUtils()
-            from_code_set = encode.Defaults.DEFAULT_MVS_CHARSET
+            from_code_set = encoding.get('from')
             to_code_set = encoding.get("to")
             root, dirs, files = next(os.walk(dir_path))
             try:
@@ -489,7 +489,7 @@ class FetchHandler:
             )
         if (not is_binary) and encoding:
             enc_utils = encode.EncodeUtils()
-            from_code_set = encode.Defaults.DEFAULT_MVS_CHARSET
+            from_code_set = encoding.get('from')
             to_code_set = encoding.get("to")
             try:
                 enc_utils.uss_convert_encoding(
@@ -544,8 +544,10 @@ def run_module():
     )
 
     if not module.params.get("encoding") and not module.params.get("is_binary"):
+        mvs_src = data_set.is_data_set(src)
+        remote_charset = encode.EncodeUtils().remote_charset()
         module.params["encoding"] = {
-            'from': encode.EncodeUtils().remote_charset(),
+            'from': encode.Defaults.DEFAULT_MVS_CHARSET if mvs_src else remote_charset,
             'to': encode.Defaults.DEFAULT_LOCAL_CHARSET
         }
 

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -446,7 +446,7 @@ class FetchHandler:
             )
         if (not is_binary) and encoding:
             enc_utils = encode.EncodeUtils()
-            from_code_set = encoding.get("from")
+            from_code_set = encode.Defaults.DEFAULT_MVS_CHARSET
             to_code_set = encoding.get("to")
             root, dirs, files = next(os.walk(dir_path))
             try:
@@ -489,7 +489,7 @@ class FetchHandler:
             )
         if (not is_binary) and encoding:
             enc_utils = encode.EncodeUtils()
-            from_code_set = encoding.get("from")
+            from_code_set = encode.Defaults.DEFAULT_MVS_CHARSET
             to_code_set = encoding.get("to")
             try:
                 enc_utils.uss_convert_encoding(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,10 @@ def ansible_zos_module(request, z_python_interpreter):
         host.vars["ansible_python_interpreter"] = interpreter
         host.vars["ansible_connection"] = "zos_ssh"
     yield adhoc
-    clean_logs(adhoc)
+    try:
+        clean_logs(adhoc)
+    except Exception:
+        pass
 
 
 # * We no longer edit sys.modules directly to add zoautil_py mock

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -19,3 +19,5 @@ plugins/modules/zos_copy.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/zos_copy.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
 plugins/modules/zos_copy.py validate-modules:undocumented-parameter # Passing args from action plugin
 plugins/modules/zos_mvs_raw.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_fetch.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
+plugins/modules/zos_fetch.py validate-modules:undocumented-parameter # Passing args from action plugin

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -19,3 +19,5 @@ plugins/modules/zos_copy.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/zos_copy.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
 plugins/modules/zos_copy.py validate-modules:undocumented-parameter # Passing args from action plugin
 plugins/modules/zos_mvs_raw.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_fetch.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
+plugins/modules/zos_fetch.py validate-modules:undocumented-parameter # Passing args from action plugin


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, the copy and fetch modules use `locale` command to discover default remote charset. However, USS would return IBM-1047 as output for that command, which is not accurate for MVS data sets. MVS data sets are almost always encoded in IBM-037. This PR fixes this issue.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy, zos_fetch
##### ADDITIONAL INFORMATION
![image](https://user-images.githubusercontent.com/20392124/90838435-c191f380-e309-11ea-8c79-ef3a313a0dd6.png)

