### PR TITLE
Update/647/determine system default encoding if not provided

### DIFF
--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -517,7 +517,7 @@ def get_locale(module):
     if rc:
         return None
     else:
-        return stdout
+        return stdout.strip()
 
 
 def submit_pds_jcl(src, module):

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -496,7 +496,6 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser
     BetterArgParser,
 )
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.encode import (
-    EncodeUtils,
     Defaults,
 )
 from stat import S_IEXEC, S_IREAD, S_IWRITE
@@ -641,13 +640,13 @@ def run_module():
     encoding = module.params.get("encoding")
     if encoding is None:
         encoding = {
-            "from": Defaults.DEFAULT_LOCAL_CHARSET,
-            "to": EncodeUtils().remote_charset(),
+            "from": Defaults.DEFAULT_ASCII_CHARSET,
+            "to": Defaults.get_default_system_charset(),
         }
     if encoding.get("from") is None:
-        encoding["from"] = Defaults.DEFAULT_LOCAL_CHARSET
+        encoding["from"] = Defaults.DEFAULT_ASCII_CHARSET
     if encoding.get("to") is None:
-        encoding["to"] = EncodeUtils().remote_charset()
+        encoding["to"] = Defaults.get_default_system_charset()
 
     arg_defs = dict(
         src=dict(arg_type="data_set_or_path", required=True),
@@ -657,8 +656,10 @@ def run_module():
             default="DATA_SET",
             choices=["DATA_SET", "USS", "LOCAL"],
         ),
-        from_encoding=dict(arg_type="encoding", default=Defaults.DEFAULT_LOCAL_CHARSET),
-        to_encoding=dict(arg_type="encoding", default=Defaults.DEFAULT_REMOTE_CHARSET),
+        from_encoding=dict(arg_type="encoding", default=Defaults.DEFAULT_ASCII_CHARSET),
+        to_encoding=dict(
+            arg_type="encoding", default=Defaults.DEFAULT_EBCDIC_USS_CHARSET
+        ),
         volume=dict(arg_type="volume", required=False),
         return_output=dict(arg_type="bool", default=True),
         wait_time_s=dict(arg_type="int", required=False, default=60),

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -512,7 +512,7 @@ DEFAULT_ASCII_CHARSET = "ISO8859-1"
 DEFAULT_EBCDIC_CHARSET = "IBM-1047"
 
 
-def get_locale(module):
+def get_encoding_from_locale(module):
     rc, stdout, stderr = module.run_command("locale -c charmap")
     if rc:
         return None
@@ -646,12 +646,12 @@ def run_module():
     if encoding is None:
         encoding = {
             "from": DEFAULT_ASCII_CHARSET,
-            "to": get_locale(module) or DEFAULT_EBCDIC_CHARSET,
+            "to": get_encoding_from_locale(module) or DEFAULT_EBCDIC_CHARSET,
         }
     if encoding.get("from") is None:
         encoding["from"] = DEFAULT_ASCII_CHARSET
     if encoding.get("to") is None:
-        encoding["to"] = get_locale(module) or DEFAULT_EBCDIC_CHARSET
+        encoding["to"] = get_encoding_from_locale(module) or DEFAULT_EBCDIC_CHARSET
 
     arg_defs = dict(
         src=dict(arg_type="data_set_or_path", required=True),

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -495,6 +495,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import job_ou
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
     BetterArgParser,
 )
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.encode import EncodeUtils
 from stat import S_IEXEC, S_IREAD, S_IWRITE
 from ansible.module_utils.six import PY3
 
@@ -510,14 +511,6 @@ POLLING_COUNT = 60
 JOB_COMPLETION_MESSAGES = ["CC", "ABEND", "SEC"]
 DEFAULT_ASCII_CHARSET = "ISO8859-1"
 DEFAULT_EBCDIC_CHARSET = "IBM-1047"
-
-
-def get_encoding_from_locale(module):
-    rc, stdout, stderr = module.run_command("locale -c charmap")
-    if rc:
-        return None
-    else:
-        return stdout.strip()
 
 
 def submit_pds_jcl(src, module):
@@ -646,12 +639,12 @@ def run_module():
     if encoding is None:
         encoding = {
             "from": DEFAULT_ASCII_CHARSET,
-            "to": get_encoding_from_locale(module) or DEFAULT_EBCDIC_CHARSET,
+            "to": EncodeUtils().remote_charset(),
         }
     if encoding.get("from") is None:
         encoding["from"] = DEFAULT_ASCII_CHARSET
     if encoding.get("to") is None:
-        encoding["to"] = get_encoding_from_locale(module) or DEFAULT_EBCDIC_CHARSET
+        encoding["to"] = EncodeUtils().remote_charset()
 
     arg_defs = dict(
         src=dict(arg_type="data_set_or_path", required=True),

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -495,7 +495,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import job_ou
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
     BetterArgParser,
 )
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.encode import EncodeUtils
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import encode
 from stat import S_IEXEC, S_IREAD, S_IWRITE
 from ansible.module_utils.six import PY3
 
@@ -639,12 +639,12 @@ def run_module():
     if encoding is None:
         encoding = {
             "from": DEFAULT_ASCII_CHARSET,
-            "to": EncodeUtils().remote_charset(),
+            "to": encode.Defaults.get_default_system_charset(),
         }
     if encoding.get("from") is None:
         encoding["from"] = DEFAULT_ASCII_CHARSET
     if encoding.get("to") is None:
-        encoding["to"] = EncodeUtils().remote_charset()
+        encoding["to"] = encode.Defaults.get_default_system_charset()
 
     arg_defs = dict(
         src=dict(arg_type="data_set_or_path", required=True),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes #647 in Jira, this PR adds a feature to zos_job_submit which will determine the destination encoding based on the z/OS system's locale settings when no value is provided. If encoding can not be retrieved from locale command, the module falls back to IBM-1047.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Update Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/zos_job_submit.py

