### PR TITLE
Update/2616/zos encode return backup file

### DIFF
--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -366,6 +366,8 @@ def run_module():
     changed = False
 
     result = dict(changed=changed, src=src, dest=dest)
+    if backup:
+      result["backup_name"] = None
 
     try:
         # Check the src is a USS file/path or an MVS data set

--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -88,6 +88,8 @@ options:
         e.g. /path/file_name.2020-04-23-08-32-29-bak.tar. If dest is an
         MVS data set, the default backup name will be a random name generated
         by IBM Z Open Automation Utilities.
+      - C(backup_name) will be returned on either success or failure of module 
+        execution such that data can be retrieved.
     required: false
     type: str
   backup_compress:
@@ -241,14 +243,9 @@ backup_name:
     sample: /path/file_name.2020-04-23-08-32-29-bak.tar
 """
 
-import time
 import re
 from os import path, makedirs
-from ansible.module_utils.six import PY3
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
-    AnsibleModuleHelper,
-)
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     better_arg_parser,
     data_set,
@@ -259,14 +256,8 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler im
     MissingZOAUImport,
 )
 
-
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
-
 try:
-    from zoautil_py import Datasets, MVSCmd
+    from zoautil_py import Datasets
 except Exception:
     Datasets = MissingZOAUImport()
     MVSCmd = MissingZOAUImport()
@@ -377,26 +368,6 @@ def run_module():
     result = dict(changed=changed, src=src, dest=dest)
 
     try:
-
-        eu = encode.EncodeUtils()
-
-        # Check input code set is valid or not
-        # If the value specified in from_encoding or to_encoding is not in the code_set, exit with an error message
-        # If the values specified in from_encoding and to_encoding are the same, exit with an message
-        code_set = eu.get_codeset()
-        if from_encoding not in code_set:
-            raise EncodeError(
-                "Invalid codeset: Please check the value of the from_encoding!"
-            )
-        if to_encoding not in code_set:
-            raise EncodeError(
-                "Invalid codeset: Please check the value of the to_encoding!"
-            )
-        if from_encoding == to_encoding:
-            raise EncodeError(
-                "The value of the from_encoding and to_encoding are the same, no need to do the conversion!"
-            )
-
         # Check the src is a USS file/path or an MVS data set
         is_uss_src, is_mvs_src, ds_type_src = check_file(src)
         if is_uss_src:
@@ -437,6 +408,24 @@ def run_module():
                 backup_name = zos_backup.mvs_file_backup(dest, backup_name)
             result["backup_name"] = backup_name
 
+        eu = encode.EncodeUtils()
+        # Check input code set is valid or not
+        # If the value specified in from_encoding or to_encoding is not in the code_set, exit with an error message
+        # If the values specified in from_encoding and to_encoding are the same, exit with an message
+        code_set = eu.get_codeset()
+        if from_encoding not in code_set:
+            raise EncodeError(
+                "Invalid codeset: Please check the value of the from_encoding!"
+            )
+        if to_encoding not in code_set:
+            raise EncodeError(
+                "Invalid codeset: Please check the value of the to_encoding!"
+            )
+        if from_encoding == to_encoding:
+            raise EncodeError(
+                "The value of the from_encoding and to_encoding are the same, no need to do the conversion!"
+            )
+
         if is_uss_src and is_uss_dest:
             convert_rc = eu.uss_convert_encoding_prev(
                 src, dest, from_encoding, to_encoding
@@ -456,6 +445,7 @@ def run_module():
             result = dict(changed=changed, src=src, dest=dest, backup_name=backup_name)
         else:
             result = dict(src=src, dest=dest, changed=changed, backup_name=backup_name)
+
     except Exception as e:
         module.fail_json(msg=repr(e), **result)
 

--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -367,7 +367,7 @@ def run_module():
 
     result = dict(changed=changed, src=src, dest=dest)
     if backup:
-      result["backup_name"] = None
+        result["backup_name"] = None
 
     try:
         # Check the src is a USS file/path or an MVS data set

--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -88,7 +88,7 @@ options:
         e.g. /path/file_name.2020-04-23-08-32-29-bak.tar. If dest is an
         MVS data set, the default backup name will be a random name generated
         by IBM Z Open Automation Utilities.
-      - C(backup_name) will be returned on either success or failure of module 
+      - C(backup_name) will be returned on either success or failure of module
         execution such that data can be retrieved.
     required: false
     type: str

--- a/tests/functional/modules/test_zos_encode_func.py
+++ b/tests/functional/modules/test_zos_encode_func.py
@@ -73,11 +73,9 @@ def test_uss_encoding_conversion_with_invalid_encoding(ansible_zos_module):
     )
     pprint(vars(results))
     for result in results.contacted.values():
-        assert result.get("src") == USS_FILE
-        assert result.get("dest") == USS_FILE
+        assert result.get("msg") is not None
         assert result.get("backup_name") is None
         assert result.get("changed") is False
-        assert result.get("msg") is not None
 
 
 def test_uss_encoding_conversion_with_the_same_encoding(ansible_zos_module):
@@ -87,11 +85,9 @@ def test_uss_encoding_conversion_with_the_same_encoding(ansible_zos_module):
     )
     pprint(vars(results))
     for result in results.contacted.values():
-        assert result.get("src") == USS_FILE
-        assert result.get("dest") == USS_FILE
+        assert result.get("msg") is not None
         assert result.get("backup_name") is None
         assert result.get("changed") is False
-        assert result.get("msg") is not None
 
 
 def test_uss_encoding_conversion_without_dest(ansible_zos_module):

--- a/tests/functional/modules/test_zos_encode_func.py
+++ b/tests/functional/modules/test_zos_encode_func.py
@@ -74,10 +74,10 @@ def test_uss_encoding_conversion_with_invalid_encoding(ansible_zos_module):
     pprint(vars(results))
     for result in results.contacted.values():
         assert result.get("src") == USS_FILE
-        assert result.get("dest") is None
+        assert result.get("dest") == USS_FILE
         assert result.get("backup_name") is None
         assert result.get("changed") is False
-        assert "Invalid codeset: Please check the value" in result.get("msg")
+        assert result.get("msg") is not None
 
 
 def test_uss_encoding_conversion_with_the_same_encoding(ansible_zos_module):
@@ -88,13 +88,10 @@ def test_uss_encoding_conversion_with_the_same_encoding(ansible_zos_module):
     pprint(vars(results))
     for result in results.contacted.values():
         assert result.get("src") == USS_FILE
-        assert result.get("dest") is None
+        assert result.get("dest") == USS_FILE
         assert result.get("backup_name") is None
         assert result.get("changed") is False
-        assert (
-            "The value of the from_encoding and to_encoding "
-            "are the same, no need to do the conversion!"
-        ) in result.get("msg")
+        assert result.get("msg") is not None
 
 
 def test_uss_encoding_conversion_without_dest(ansible_zos_module):
@@ -693,6 +690,7 @@ def test_return_backup_name_on_module_success_and_failure(ansible_zos_module):
     )
 
     for content in enc_ds.contacted.values():
+        assert content.get("msg") is not None
         assert content.get("backup_name") is not None
         assert content.get("backup_name") == BACKUP_DATA_SET
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR addresses [NAZARE-2616](https://jsw.ibm.com/browse/NAZARE-2616) by ensuring encode module returns `backup_file` on module failure.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_encode
