### PR TITLE
Feature/2810/copy multiple members

### DIFF
--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3,9 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-from os import replace
 import shutil
-from sys import executable
 import tempfile
 
 __metaclass__ = type


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR introduces a new feature for zos_copy module. It is now possible to copy multiple PDS/PDSE members to another PDS/PDSE using wildcards.
```
- name: Copy all members inside a PDS to another PDS
  zos_copy:
    src: SOME.SRC.PDS(*)
    dest: SOME.DEST.PDS
    remote_src: true

- name: Copy all members starting with 'ABC' inside a PDS to another PDS
  zos_copy:
    src: SOME.SRC.PDS(ABC*)
    dest: SOME.DEST.PDS
    remote_src: true
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy
