### PR TITLE
Release v1.2.0 beta.4

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -150,8 +150,7 @@ scv_greatest_tag = True
 # White list which Git tags documentation will be generated and linked into the
 # version selection box. This is currently a manual selection, until more
 # versions are released, there are no regular expressions used.
-scv_whitelist_tags = ('v1.0.0', 'v1.1.0', 'v1.2.0-beta.1', 'v1.2.0-beta.2',
-                      'v1.2.0-beta.3', 'v1.2.0-beta.4')
+scv_whitelist_tags = ('v1.0.0', 'v1.1.0$', 'v1.2.0-beta.4',)
 
 # Sort versions by one or more values. Valid values are semver, alpha, and time.
 # Semantic is referred to as 'semver', this would ensure our latest VRM is
@@ -178,3 +177,8 @@ scv_show_banner = True
 # reason pre-release semantic versioning used with scv_banner_greatest_tag does
 # not generate the correct latest banner.
 scv_banner_recent_tag = True
+
+# Invert the order of branches/tags displayed in the sidebars in generated HTML
+# documents. The default order is whatever git prints when
+# running “ git ls-remote --tags ./.”
+scv_invert = True

--- a/docs/source/modules/zos_copy.rst
+++ b/docs/source/modules/zos_copy.rst
@@ -238,6 +238,8 @@ src
 
   If ``src`` is a VSAM data set, destination must also be a VSAM.
 
+  Wildcards can be used to copy multiple PDS/PDSE members to another PDS/PDSE.
+
   Required unless using ``content``.
 
 
@@ -392,6 +394,18 @@ Examples
      zos_copy:
        src: SRC.PDS
        dest: /tmp
+       remote_src: true
+
+   - name: Copy all members inside a PDS to another PDS
+     zos_copy:
+       src: SOME.SRC.PDS(*)
+       dest: SOME.DEST.PDS
+       remote_src: true
+
+   - name: Copy all members starting with 'ABC' inside a PDS to another PDS
+     zos_copy:
+       src: SOME.SRC.PDS(ABC*)
+       dest: SOME.DEST.PDS
        remote_src: true
 
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -25,12 +25,10 @@ Connection
 ----------
 
 * ``zos_ssh``: Enables the Ansible controller to communicate with a z/OS target machine by using SSH, with the added support to transfer ASCII as EBCDIC when transferring REXX modules. This connection plugin was forked from the Ansible `ssh.py`_ connection plugin.
-* For further reference, see the `zos_ssh quickstart`_ guide.
+* For further reference, see **z/OS Connection Plugin**.
 
 .. _ssh.py:
         https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/connection/ssh.py
-.. _zos_ssh quickstart:
-   quickstart.html#z-os-connection-plugin
 
 z/OS Connection Plugin
 ----------------------

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -63,6 +63,7 @@ Reference
 * Supported by z/OS V2R3
 * The z/OS® shell
 
+=======
 Version 1.2.0-beta.2
 ====================
 
@@ -131,164 +132,215 @@ Version 1.2.0-beta.1
 ====================
 
 Notes
-   * Update recommended
-   * New modules
+-----
 
-     * zos_copy
-     * zos_lineinfile
-     * zos_mvs_raw
+* Update recommended
+* New modules
 
-   * Bug fixes
-   * Documentation updates
-   * New samples
-   * Module enhancements:
+  * zos_copy
+  * zos_lineinfile
+  * zos_mvs_raw
 
-     * zos_data_set - includes full multi-volume support for data set creation,
-       addition of secondary space option, improved SMS support with storage,
-       data, and management classes
+* Bug fixes
+* Documentation updates
+* New samples
+* Module enhancements:
+
+  * zos_data_set - includes full multi-volume support for data set creation,
+    addition of secondary space option, improved SMS support with storage,
+    data, and management classes
 
 Availability
-  * Galaxy
-  * GitHub
+------------
+
+* Galaxy
+* GitHub
 
 Reference
-  * Supported by IBM Open Enterprise Python for z/OS: 3.8.2 or later
-  * Supported by IBM Z Open Automation Utilities 1.0.3 PTF UI70435
-  * Supported by z/OS V2R3
-  * The z/OS® shell
+---------
+
+* Supported by IBM Open Enterprise Python for z/OS: 3.8.2 or later
+* Supported by IBM Z Open Automation Utilities 1.0.3 PTF UI70435
+* Supported by z/OS V2R3
+* The z/OS® shell
 
 
 Version 1.1.0
 =============
 
 Notes
-   * Update recommended
-   * New modules
+-----
+* Update recommended
+* New modules
 
-     * zos_fetch
-     * zos_encode
-     * zos_operator_action_query
-     * zos_operator
-     * zos_tso_command
-     * zos_ping
+  * zos_fetch
+  * zos_encode
+  * zos_operator_action_query
+  * zos_operator
+  * zos_tso_command
+  * zos_ping
 
-   * New filter
-   * Improved error handling and messages
-   * Bug fixes
-   * Documentation updates
-   * New samples
+* New filter
+* Improved error handling and messages
+* Bug fixes
+* Documentation updates
+* New samples
 
 Availability
-  * Automation Hub
-  * Galaxy
-  * GitHub
+------------
+
+* Automation Hub
+* Galaxy
+* GitHub
 
 Reference
-  * Supported by IBM Open Enterprise Python for z/OS: 3.8.2 or later
-  * Supported by IBM Z Open Automation Utilities: 1.0.3 PTF UI70435
-  * Supported by z/OS V2R3
-  * The z/OS® shell
+---------
+
+* Supported by IBM Open Enterprise Python for z/OS: 3.8.2 or later
+* Supported by IBM Z Open Automation Utilities: 1.0.3 PTF UI70435
+* Supported by z/OS V2R3
+* The z/OS® shell
 
 
 Version 1.1.0-beta1
 ===================
 
 Notes
-   * Update recommended
-   * New modules
+-----
 
-     * zos_fetch, zos_encode, zos_operator_action_query, zos_operator,
-       zos_tso_command, zos_ping
-   * New filter
-   * Improved error handling and messages
-   * Bug fixes
-   * Documentation updates
-   * New samples
+* Update recommended
+* New modules
+
+  * zos_fetch, zos_encode, zos_operator_action_query, zos_operator,
+    zos_tso_command, zos_ping
+* New filter
+* Improved error handling and messages
+* Bug fixes
+* Documentation updates
+* New samples
 
 Availability
-  * Galaxy
-  * GitHub
+------------
+
+* Galaxy
+* GitHub
 
 Reference
-  * Supported by IBM Z Open Automation Utilities: 1.0.2 or 1.0.3 PTF UI70435
+---------
+
+* Supported by IBM Z Open Automation Utilities: 1.0.2 or 1.0.3 PTF UI70435
 
 Version 1.0.0
 =============
+
 Notes
-   * Update recommended
-   * Security vulnerabilities fixed
-   * Improved test, security and injection coverage
-   * Module zos_data_set catalog support added
-   * Documentation updates
+-----
+
+* Update recommended
+* Security vulnerabilities fixed
+* Improved test, security and injection coverage
+* Module zos_data_set catalog support added
+* Documentation updates
 
 Availability
-  * Automation Hub
-  * Galaxy
-  * GitHub
+------------
+
+* Automation Hub
+* Galaxy
+* GitHub
 
 Reference
-  * Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
-    1.0.3 PTF UI70435
+---------
+
+* Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
+  1.0.3 PTF UI70435
 
 Version 0.0.4
 =============
 
 Notes
-  * Update recommended
-  * Includes fixes to modules zos_job_output and zos_job_submit
-  * Improved buffer utilization
-  * Optimized JSON response
-  * Functional test cases for all modules
-  * Updated document references
+-----
+
+* Update recommended
+* Includes fixes to modules zos_job_output and zos_job_submit
+* Improved buffer utilization
+* Optimized JSON response
+* Functional test cases for all modules
+* Updated document references
 
 Availability
-  * Galaxy
-  * GitHub
+------------
 
-Reference:
-  * Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
-    1.0.3 PTF UI70435
+* Galaxy
+* GitHub
+
+Reference
+---------
+
+* Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
+  1.0.3 PTF UI70435
 
 Version 0.0.3
 =============
+
 Notes
-  * Update recommended
-  * Includes updates to README.md for a malformed URL and product direction
-  * Includes fixes for zos_data_set module
+-----
+
+* Update recommended
+* Includes updates to README.md for a malformed URL and product direction
+* Includes fixes for zos_data_set module
 
 Availability
-  * Galaxy
-  * GitHub
+------------
+
+* Galaxy
+* GitHub
 
 Reference
-  * Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
-    1.0.3 PTF UI70435
+---------
+
+* Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
+  1.0.3 PTF UI70435
 
 Version 0.0.2
 =============
+
 Notes
-  * Update not required
-  * Updates to the README and included docs
+-----
+
+* Update not required
+* Updates to the README and included docs
 
 Availability
-  * Galaxy
-  * GitHub
+------------
+
+* Galaxy
+* GitHub
 
 Reference
-  * Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
-    1.0.3 PTF UI70435
+---------
+
+* Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
+  1.0.3 PTF UI70435
 
 Version 0.0.1
 =============
+
 Notes
-  * Initial beta release of IBM Z core collection, referred to as ibm_zos_core
-    which is part of the broader offering
-    Red Hat® Ansible Certified Content for IBM Z.
+-----
+
+* Initial beta release of IBM Z core collection, referred to as ibm_zos_core
+  which is part of the broader offering
+  Red Hat® Ansible Certified Content for IBM Z.
 
 Availability
-  * Galaxy
-  * GitHub
+------------
+
+* Galaxy
+* GitHub
 
 Reference
-  * Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
-    1.0.3 PTF UI70435
+---------
+
+* Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
+  1.0.3 PTF UI70435

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -30,8 +30,8 @@ Notes
 Availability
 ------------
 
-* Galaxy
-* GitHub
+* `Galaxy`_
+* `GitHub`_
 
 Reference
 ---------
@@ -40,6 +40,22 @@ Reference
 * Supported by IBM Z Open Automation Utilities 1.0.3 PTF UI70435
 * Supported by z/OS V2R3
 * The z/OS® shell
+
+Known issues
+------------
+
+* Modules
+
+  * When executing programs using ``zos_mvs_raw``, you may encounter errors
+    that originate in the programs implementation. Two such known issues are
+    noted below of which one has been addressed with an APAR.
+
+    #. ``zos_mvs_raw`` module execution fails when invoking
+       Database Image Copy 2 Utility or Database Recovery Utility in conjunction
+       with FlashCopy or Fast Replication.
+    #. ``zos_mvs_raw`` module execution fails when invoking DFSRRC00 with parm
+       "UPB,PRECOMP", "UPB, POSTCOMP" or "UPB,PRECOMP,POSTCOMP". This issue is
+       addressed by APAR PH28089.
 
 Version 1.2.0-beta.3
 ====================
@@ -57,8 +73,8 @@ Notes
 Availability
 ------------
 
-* Galaxy
-* GitHub
+* `Galaxy`_
+* `GitHub`_
 
 Reference
 ---------
@@ -68,7 +84,22 @@ Reference
 * Supported by z/OS V2R3
 * The z/OS® shell
 
-=======
+Known issues
+------------
+
+* Modules
+
+  * When executing programs using ``zos_mvs_raw``, you may encounter errors
+    that originate in the programs implementation. Two such known issues are
+    noted below of which one has been addressed with an APAR.
+
+    #. ``zos_mvs_raw`` module execution fails when invoking
+       Database Image Copy 2 Utility or Database Recovery Utility in conjunction
+       with FlashCopy or Fast Replication.
+    #. ``zos_mvs_raw`` module execution fails when invoking DFSRRC00 with parm
+       "UPB,PRECOMP", "UPB, POSTCOMP" or "UPB,PRECOMP,POSTCOMP". This issue is
+       addressed by APAR PH28089.
+
 Version 1.2.0-beta.2
 ====================
 
@@ -113,25 +144,20 @@ Known issues
 
 * Modules
 
-  * When executing programs using zos_mvs_raw, you may encounter errors
+  * When executing programs using ``zos_mvs_raw``, you may encounter errors
     that originate in the programs implementation. Two such known issues are
     noted below of which one has been addressed with an APAR.
 
-    #. zos_mvs_raw module execution fails when invoking
+    #. ``zos_mvs_raw`` module execution fails when invoking
        Database Image Copy 2 Utility or Database Recovery Utility in conjunction
        with FlashCopy or Fast Replication.
-    #. zos_mvs_raw module execution fails when invoking DFSRRC00 with parm
+    #. ``zos_mvs_raw`` module execution fails when invoking DFSRRC00 with parm
        "UPB,PRECOMP", "UPB, POSTCOMP" or "UPB,PRECOMP,POSTCOMP". This issue is
        addressed by APAR PH28089.
 
 .. _centralized content:
    https://ibm.github.io/z_ansible_collections_doc/index.html
 
-.. _GitHub:
-   https://github.com/ansible-collections/ibm_zos_core
-
-.. _Galaxy:
-   https://galaxy.ansible.com/ibm/ibm_zos_core
 
 Version 1.2.0-beta.1
 ====================
@@ -260,6 +286,7 @@ Reference
 * Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
   1.0.3 PTF UI70435
 
+
 Version 0.0.4
 =============
 
@@ -284,6 +311,7 @@ Reference
 
 * Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
   1.0.3 PTF UI70435
+
 
 Version 0.0.3
 =============
@@ -328,6 +356,7 @@ Reference
 * Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
   1.0.3 PTF UI70435
 
+
 Version 0.0.1
 =============
 
@@ -349,3 +378,13 @@ Reference
 
 * Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
   1.0.3 PTF UI70435
+
+.. .............................................................................
+.. Global Links
+.. .............................................................................
+
+.. _GitHub:
+   https://github.com/ansible-collections/ibm_zos_core
+
+.. _Galaxy:
+   https://galaxy.ansible.com/ibm/ibm_zos_core

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -22,6 +22,11 @@ Notes
     have been written as **duration_s**.
   * Fixes requirements version in sample playbook hosts-setup.yaml
 
+* Module Changes
+
+  * Module ``zos_copy`` can now use wildcards to copy multiple PDS/PDSE members
+    to another PDS/PDSE
+
 Availability
 ------------
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,11 @@ namespace: ibm
 name: ibm_zos_core
 
 # The collection version
+<<<<<<< HEAD
 version: 1.2.0-beta.4
+=======
+version: 1.2.0-beta.2
+>>>>>>> master
 
 # Collection README file
 readme: README.md

--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -447,7 +447,6 @@ def run_module():
             result = dict(changed=changed, src=src, dest=dest, backup_name=backup_name)
         else:
             result = dict(src=src, dest=dest, changed=changed, backup_name=backup_name)
-
     except Exception as e:
         module.fail_json(msg=repr(e), **result)
 


### PR DESCRIPTION
##### SUMMARY

Beta release to galaxy:

Version 1.2.0-beta.4
====================

Notes
-----

* Update recommended
* Bugfix

  * Fixes a bug for `zos_data_set` module where some parameters were not
    getting passed correctly because python considers integer value of 0
    to be false.
  * Fixes documentation in module `zos_job_submit` where **wait_time_s** should
    have been written as **duration_s**.
  * Fixes requirements version in sample playbook hosts-setup.yaml

* Module Changes

  * Module ``zos_copy`` can now use wildcards to copy multiple PDS/PDSE members
    to another PDS/PDSE

Availability
------------

* Galaxy
* GitHub

Reference
---------

* Supported by IBM Open Enterprise Python for z/OS: 3.8.2 or later
* Supported by IBM Z Open Automation Utilities 1.0.3 PTF UI70435
* Supported by z/OS V2R3
* The z/OS® shell

Known issues
------------

* Modules

  * When executing programs using ``zos_mvs_raw``, you may encounter errors
    that originate in the programs implementation. Two such known issues are
    noted below of which one has been addressed with an APAR.

    #. ``zos_mvs_raw`` module execution fails when invoking
       Database Image Copy 2 Utility or Database Recovery Utility in conjunction
       with FlashCopy or Fast Replication.
    #. ``zos_mvs_raw`` module execution fails when invoking DFSRRC00 with parm
       "UPB,PRECOMP", "UPB, POSTCOMP" or "UPB,PRECOMP,POSTCOMP". This issue is
       addressed by APAR PH28089.

##### ISSUE TYPE
- Feature Pull Request

