### PR TITLE
Release v1.2.1

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,7 +147,7 @@ scv_greatest_tag = True
 # White list which Git tags documentation will be generated and linked into the
 # version selection box. This is currently a manual selection, until more
 # versions are released, there are no regular expressions used.
-scv_whitelist_tags = ('v1.0.0', 'v1.1.0$', 'v1.2.0$',)
+scv_whitelist_tags = ('v1.0.0', 'v1.1.0$', 'v1.2.1$',)
 
 # Sort versions by one or more values. Valid values are semver, alpha, and time.
 # Semantic is referred to as 'semver', this would ensure our latest VRM is

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,70 @@
 Releases
 ========
 
+Version 1.2.1
+=============
+
+Notes
+-----
+
+* Update required
+* Module changes
+
+  * Noteworthy Python 2.x support
+  
+    * encode - removed TemporaryDirectory usage.
+    * zos_copy - fixed regex support, dictionary merge operation fix
+    * zos_fetch - fix quote import
+
+* Collection changes
+
+  * Beginning this release, all sample playbooks previously included with the
+    collection will be made available on the `samples repository`_. The
+    `samples repository`_ explains the playbook concepts,
+    discusses z/OS administration, provides links to the samples support site,
+    blogs and other community resources.
+
+* Documentation changes
+
+  * In this release, documentation related to playbook configuration has been
+    migrated to the `samples repository`_. Each sample contains a README that
+    explains what configurations must be made to run the sample playbook.
+
+.. _samples repository:
+   https://github.com/IBM/z_ansible_collections_samples/blob/master/README.md
+
+Availability
+------------
+
+* `Automation Hub`_
+* `Galaxy`_
+* `GitHub`_
+
+Reference
+---------
+
+* Supported by IBM Open Enterprise Python for z/OS: 3.8.2 or later
+* Supported by IBM Z Open Automation Utilities 1.0.3 PTF UI70435
+* Supported by z/OS V2R3
+* The z/OS® shell
+
+Known issues
+------------
+
+* Modules
+
+  * When executing programs using ``zos_mvs_raw``, you may encounter errors
+    that originate in the programs implementation. Two such known issues are
+    noted below of which one has been addressed with an APAR.
+
+    #. ``zos_mvs_raw`` module execution fails when invoking
+       Database Image Copy 2 Utility or Database Recovery Utility in conjunction
+       with FlashCopy or Fast Replication.
+    #. ``zos_mvs_raw`` module execution fails when invoking DFSRRC00 with parm
+       "UPB,PRECOMP", "UPB, POSTCOMP" or "UPB,PRECOMP,POSTCOMP". This issue is
+       addressed by APAR PH28089.
+
+
 Version 1.2.0
 =============
 
@@ -33,7 +97,6 @@ Notes
 Availability
 ------------
 
-* `Automation Hub`_
 * `Galaxy`_
 * `GitHub`_
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -61,6 +61,7 @@ Known issues
        "UPB,PRECOMP", "UPB, POSTCOMP" or "UPB,PRECOMP,POSTCOMP". This issue is
        addressed by APAR PH28089.
 
+
 Version 1.2.0-beta.4
 ====================
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,7 +16,7 @@ Notes
 * Module changes
 
   * Noteworthy Python 2.x support
-  
+
     * encode - removed TemporaryDirectory usage.
     * zos_copy - fixed regex support, dictionary merge operation fix
     * zos_fetch - fix quote import

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: ibm
 name: ibm_zos_core
 
 # The collection version
-version: 1.2.0
+version: 1.2.1
 
 # Collection README file
 readme: README.md

--- a/plugins/module_utils/system.py
+++ b/plugins/module_utils/system.py
@@ -93,7 +93,7 @@ def run_command(args, stdin=None, **kwargs):
         err = "'args' must be list or string"
         return rc, out, err
 
-    if isinstance(args, text_type):
+    if isinstance(args, (text_type, str)):
         if PY2:
             args = to_bytes(args, errors='surrogate_or_strict')
         elif PY3:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3,12 +3,15 @@
 # Copyright (c) IBM Corporation 2019, 2020
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['stableinterface'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["stableinterface"],
+    "supported_by": "community",
+}
 
 DOCUMENTATION = r"""
 ---
@@ -464,9 +467,9 @@ import stat
 import shutil
 import glob
 
-from pathlib import Path
 from hashlib import sha256
-from re import fullmatch, IGNORECASE
+from re import IGNORECASE
+from ansible.module_utils.six import PY3
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
@@ -475,12 +478,23 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module im
 from ansible.module_utils._text import to_bytes
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
-    better_arg_parser, data_set, encode, vtoc, backup, copy, mvs_cmd
+    better_arg_parser,
+    data_set,
+    encode,
+    vtoc,
+    backup,
+    copy,
+    mvs_cmd,
 )
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
-    MissingZOAUImport
+    MissingZOAUImport,
 )
+
+if PY3:
+    from re import fullmatch
+else:
+    from re import match as fullmatch
 
 try:
     from zoautil_py import Datasets
@@ -490,8 +504,8 @@ except Exception:
     types = MissingZOAUImport()
 
 
-MVS_PARTITIONED = frozenset({'PE', 'PO', 'PDSE', 'PDS'})
-MVS_SEQ = frozenset({'PS', 'SEQ'})
+MVS_PARTITIONED = frozenset({"PE", "PO", "PDSE", "PDS"})
+MVS_SEQ = frozenset({"PS", "SEQ"})
 
 
 class CopyHandler(object):
@@ -514,7 +528,7 @@ class CopyHandler(object):
     def fail_json(self, **kwargs):
         """ Wrapper for AnsibleModule.fail_json """
         self.module.fail_json(
-            **kwargs, dest_exists=self.dest_exists, backup_name=self.backup_name
+            dest_exists=self.dest_exists, backup_name=self.backup_name, **kwargs
         )
 
     def run_command(self, cmd, **kwargs):
@@ -524,7 +538,7 @@ class CopyHandler(object):
     def exit_json(self, **kwargs):
         """ Wrapper for AnsibleModule.exit_json """
         self.module.exit_json(
-            **kwargs, dest_exists=self.dest_exists, backup_name=self.backup_name
+            dest_exists=self.dest_exists, backup_name=self.backup_name, **kwargs
         )
 
     def copy_to_seq(self, src, temp_path, conv_path, dest, src_ds_type, model_ds=None):
@@ -544,7 +558,7 @@ class CopyHandler(object):
             self.allocate_model(dest, model_ds)
         if src_ds_type == "USS":
             if not model_ds:
-                ps_size = "{0}K".format(math.ceil(Path(new_src).stat().st_size / 1024))
+                ps_size = "{0}K".format(math.ceil(os.stat(new_src).st_size / 1024))
                 self._allocate_ps(dest, size=ps_size)
             rc, out, err = self.run_command(
                 "cp {0} {1} \"//'{2}'\"".format(
@@ -554,7 +568,9 @@ class CopyHandler(object):
             if rc != 0:
                 self.fail_json(
                     msg="Unable to copy source {0} to {1}".format(src, dest),
-                    rc=rc, stderr=err, stdout=out
+                    rc=rc,
+                    stderr=err,
+                    stdout=out,
                 )
         else:
             rc = Datasets.copy(new_src, dest)
@@ -570,11 +586,11 @@ class CopyHandler(object):
                 if rc != 0:
                     self.fail_json(
                         msg="Unable to copy source {0} to {1}".format(new_src, dest),
-                        rc=rc
+                        rc=rc,
                     )
 
     def copy_to_vsam(self, src, dest):
-        """ Copy source VSAM to destination VSAM. If source VSAM exists, then
+        """Copy source VSAM to destination VSAM. If source VSAM exists, then
         it will be deleted and a new VSAM cluster will be allocated.
 
         Arguments:
@@ -585,23 +601,28 @@ class CopyHandler(object):
             rc = Datasets.delete(dest)
             if rc != 0:
                 self.fail_json(
-                    msg="Unable to delete destination data set {0}".format(dest),
-                    rc=rc
+                    msg="Unable to delete destination data set {0}".format(dest), rc=rc
                 )
         self.allocate_model(dest, src)
 
-        repro_cmd = '''  REPRO -
+        repro_cmd = """  REPRO -
         INDATASET({0}) -
-        OUTDATASET({1})'''.format(src, dest)
+        OUTDATASET({1})""".format(
+            src, dest
+        )
         rc, out, err = mvs_cmd.idcams(repro_cmd, authorized=True)
         if rc != 0:
             self.fail_json(
-                msg=("IDCAMS REPRO encountered a problem while "
-                     "copying {0} to {1}".format(src, dest)),
-                stdout=out, stderr=err, rc=rc,
+                msg=(
+                    "IDCAMS REPRO encountered a problem while "
+                    "copying {0} to {1}".format(src, dest)
+                ),
+                stdout=out,
+                stderr=err,
+                rc=rc,
                 stdout_lines=out.splitlines(),
                 stderr_lines=err.splitlines(),
-                cmd=repro_cmd
+                cmd=repro_cmd,
             )
 
     def convert_encoding(self, src, temp_path, encoding):
@@ -625,8 +646,10 @@ class CopyHandler(object):
 
         if os.path.isdir(new_src):
             if temp_path:
-                if src.endswith('/'):
-                    new_src = "{0}/{1}".format(temp_path, os.path.basename(os.path.dirname(src)))
+                if src.endswith("/"):
+                    new_src = "{0}/{1}".format(
+                        temp_path, os.path.basename(os.path.dirname(src))
+                    )
                 else:
                     new_src = "{0}/{1}".format(temp_path, os.path.basename(src))
             try:
@@ -648,7 +671,9 @@ class CopyHandler(object):
                     shutil.copy(new_src, temp_src)
                     new_src = temp_src
 
-                rc = enc_utils.uss_convert_encoding(new_src, new_src, from_code_set, to_code_set)
+                rc = enc_utils.uss_convert_encoding(
+                    new_src, new_src, from_code_set, to_code_set
+                )
                 if not rc:
                     raise EncodingConversionError(new_src, from_code_set, to_code_set)
                 self._tag_file_encoding(new_src, to_code_set)
@@ -673,7 +698,9 @@ class CopyHandler(object):
         """
         alloc_cmd = """  ALLOC -
         DS('{0}') -
-        LIKE('{1}')""".format(ds_name, model)
+        LIKE('{1}')""".format(
+            ds_name, model
+        )
         blksize = data_set.DataSetUtils(model).blksize()
         if blksize:
             alloc_cmd += " BLKSIZE({0})".format(blksize)
@@ -682,10 +709,12 @@ class CopyHandler(object):
         if rc != 0:
             self.fail_json(
                 msg="Unable to allocate destination {0}".format(ds_name),
-                stdout=out, stderr=err, rc=rc,
+                stdout=out,
+                stderr=err,
+                rc=rc,
                 stdout_lines=out.splitlines(),
                 stderr_lines=err.splitlines(),
-                cmd=alloc_cmd
+                cmd=alloc_cmd,
             )
         return rc
 
@@ -708,7 +737,9 @@ class CopyHandler(object):
                 full_file_path, full_file_path, from_code_set, to_code_set
             )
             if not rc:
-                raise EncodingConversionError(full_file_path, from_code_set, to_code_set)
+                raise EncodingConversionError(
+                    full_file_path, from_code_set, to_code_set
+                )
 
     def _tag_file_encoding(self, file_path, tag, is_dir=False):
         """Tag the file specified by 'file_path' with the given code set.
@@ -728,9 +759,11 @@ class CopyHandler(object):
         if rc != 0:
             self.fail_json(
                 msg="Unable to tag the file {0} to {1}".format(file_path, tag),
-                stdout=out, stderr=err, rc=rc,
+                stdout=out,
+                stderr=err,
+                rc=rc,
                 stdout_lines=out.splitlines(),
-                stderr_lines=err.splitlines()
+                stderr_lines=err.splitlines(),
             )
 
     def _allocate_ps(self, name, size="5M"):
@@ -748,7 +781,12 @@ class CopyHandler(object):
 
 class USSCopyHandler(CopyHandler):
     def __init__(
-        self, module, dest_exists, is_binary=False, common_file_args=None, backup_name=None
+        self,
+        module,
+        dest_exists,
+        is_binary=False,
+        common_file_args=None,
+        backup_name=None,
     ):
         """Utility class to handle copying files or data sets to USS target
 
@@ -763,7 +801,9 @@ class USSCopyHandler(CopyHandler):
             is_binary {bool} -- Whether the file to be copied contains binary data
             backup_name {str} -- The USS path or data set name of destination backup
         """
-        super().__init__(module, dest_exists, is_binary=is_binary, backup_name=backup_name)
+        super().__init__(
+            module, dest_exists, is_binary=is_binary, backup_name=backup_name
+        )
         self.common_file_args = common_file_args
 
     def copy_to_uss(self, conv_path, temp_path, src_ds_type, src_member, member_name):
@@ -782,7 +822,9 @@ class USSCopyHandler(CopyHandler):
         src = self.module.params.get("src")
         dest = self.module.params.get("dest")
         if src_ds_type in MVS_SEQ.union(MVS_PARTITIONED):
-            self._mvs_copy_to_uss(src, dest, src_ds_type, src_member, member_name=member_name)
+            self._mvs_copy_to_uss(
+                src, dest, src_ds_type, src_member, member_name=member_name
+            )
         else:
             if os.path.isfile(temp_path or conv_path or src):
                 dest = self._copy_to_file(src, dest, conv_path, temp_path)
@@ -814,7 +856,7 @@ class USSCopyHandler(CopyHandler):
             {str} -- Destination where the file was copied to
         """
         if os.path.isdir(dest):
-            dest = os.path.join(dest, os.path.basename(src) if src else 'inline_copy')
+            dest = os.path.join(dest, os.path.basename(src) if src else "inline_copy")
 
         new_src = temp_path or conv_path or src
         try:
@@ -824,13 +866,12 @@ class USSCopyHandler(CopyHandler):
                 shutil.copy(new_src, dest)
         except OSError as err:
             self.fail_json(
-                msg="Destination {0} is not writable".format(dest),
-                stderr=str(err)
+                msg="Destination {0} is not writable".format(dest), stderr=str(err)
             )
         except Exception as err:
             self.fail_json(
                 msg="Unable to copy file {0} to {1}".format(new_src, dest),
-                stderr=str(err)
+                stderr=str(err),
             )
         return dest
 
@@ -853,14 +894,16 @@ class USSCopyHandler(CopyHandler):
             except Exception as err:
                 self.fail_json(
                     msg="Unable to delete pre-existing directory {0}".format(dest_dir),
-                    stdout=str(err)
+                    stdout=str(err),
                 )
         try:
             shutil.copytree(new_src_dir, dest_dir)
         except Exception as err:
             self.fail_json(
-                msg="Error while copying data to destination directory {0}".format(dest_dir),
-                stdout=str(err)
+                msg="Error while copying data to destination directory {0}".format(
+                    dest_dir
+                ),
+                stdout=str(err),
             )
         return dest_dir
 
@@ -900,7 +943,7 @@ class USSCopyHandler(CopyHandler):
 
 class PDSECopyHandler(CopyHandler):
     def __init__(self, module, dest_exists, is_binary=False, backup_name=None):
-        """ Utility class to handle copying to partitioned data sets or
+        """Utility class to handle copying to partitioned data sets or
         partitioned data set members.
 
         Arguments:
@@ -911,7 +954,9 @@ class PDSECopyHandler(CopyHandler):
             is_binary {bool} -- Whether the data set to be copied contains binary data
             backup_name {str} -- The USS path or data set name of destination backup
         """
-        super().__init__(module, dest_exists, is_binary=is_binary, backup_name=backup_name)
+        super().__init__(
+            module, dest_exists, is_binary=is_binary, backup_name=backup_name
+        )
 
     def copy_to_pdse(self, src, temp_path, conv_path, dest, src_ds_type):
         """Copy source to a PDS/PDSE or PDS/PDSE member.
@@ -929,43 +974,57 @@ class PDSECopyHandler(CopyHandler):
                 rc = Datasets.delete_members(dest + "(*)")
                 if rc != 0:
                     self.fail_json(
-                        msg="Unable to delete data set members for data set {0}".format(dest),
-                        rc=rc
+                        msg="Unable to delete data set members for data set {0}".format(
+                            dest
+                        ),
+                        rc=rc,
                     )
-            if src.endswith('/'):
-                new_src = "{0}/{1}".format(temp_path, os.path.basename(os.path.dirname(src)))
+            if src.endswith("/"):
+                new_src = "{0}/{1}".format(
+                    temp_path, os.path.basename(os.path.dirname(src))
+                )
 
             path, dirs, files = next(os.walk(new_src))
             for file in files:
-                member_name = file[:file.rfind('.')] if '.' in file else file
+                member_name = file[: file.rfind(".")] if "." in file else file
                 full_file_path = path + "/" + file
                 self.copy_to_member(
-                    full_file_path, None, None, "{0}({1})".format(dest, member_name), copy_member=True
+                    full_file_path,
+                    None,
+                    None,
+                    "{0}({1})".format(dest, member_name),
+                    copy_member=True,
                 )
         else:
             if is_member_wildcard(src):
                 members = []
                 data_set_base = data_set.extract_dsname(src)
                 try:
-                    members = list(map(str.strip, Datasets.list_members(src).splitlines()))
+                    members = list(
+                        map(str.strip, Datasets.list_members(src).splitlines())
+                    )
                 except AttributeError:
                     self.exit_json(
-                        note="The src {0} is likely empty. No data was copied".format(data_set_base)
+                        note="The src {0} is likely empty. No data was copied".format(
+                            data_set_base
+                        )
                     )
                 for member in members:
                     self.copy_to_member(
                         "{0}({1})".format(data_set_base, member),
                         None,
                         None,
-                        "{0}({1})".format(dest, member)
+                        "{0}({1})".format(dest, member),
                     )
             else:
                 if self.dest_exists:
                     rc = Datasets.delete(dest)
                     if rc != 0:
                         self.fail_json(
-                            msg="Error while removing existing destination {0}".format(dest),
-                            rc=rc
+                            msg="Error while removing existing destination {0}".format(
+                                dest
+                            ),
+                            rc=rc,
                         )
                     self.allocate_model(dest, new_src)
 
@@ -974,11 +1033,15 @@ class PDSECopyHandler(CopyHandler):
                 rc, out, err = mvs_cmd.iebcopy(copy_cmd, dds=dds)
                 if rc != 0:
                     self.fail_json(
-                        msg="IEBCOPY encountered a problem while copying {0} to {1}".format(new_src, dest),
-                        stdout=out, stderr=err, rc=rc,
+                        msg="IEBCOPY encountered a problem while copying {0} to {1}".format(
+                            new_src, dest
+                        ),
+                        stdout=out,
+                        stderr=err,
+                        rc=rc,
                         stdout_lines=out.splitlines(),
                         stderr_lines=err.splitlines(),
-                        cmd=copy_cmd
+                        cmd=copy_cmd,
                     )
 
     def copy_to_member(self, src, temp_path, conv_path, dest, copy_member=False):
@@ -1000,16 +1063,12 @@ class PDSECopyHandler(CopyHandler):
         Returns:
             {str} -- Destination where the member was copied to
         """
-        is_uss_src = (
-            temp_path is not None
-            or conv_path is not None
-            or '/' in src
-        )
+        is_uss_src = temp_path is not None or conv_path is not None or "/" in src
         if src and is_uss_src and not copy_member:
             dest = "{0}({1})".format(dest, os.path.basename(src))
 
-        new_src = (temp_path or conv_path or src).replace('$', "\\$")
-        dest = dest.replace('$', "\\$")
+        new_src = (temp_path or conv_path or src).replace("$", "\\$")
+        dest = dest.replace("$", "\\$")
 
         if is_uss_src:
             rc = Datasets.copy(new_src, dest)
@@ -1022,13 +1081,22 @@ class PDSECopyHandler(CopyHandler):
             rc = Datasets.copy(new_src, dest)
             if rc != 0:
                 self.fail_json(
-                    msg="Unable to copy data set member {0} to {1}".format(new_src, dest),
-                    rc=rc
+                    msg="Unable to copy data set member {0} to {1}".format(
+                        new_src, dest
+                    ),
+                    rc=rc,
                 )
-        return dest.replace('\\', '')
+        return dest.replace("\\", "")
 
     def create_pdse(
-        self, src, dest_name, size, src_ds_type, remote_src=False, vol=None, model_ds=None
+        self,
+        src,
+        dest_name,
+        size,
+        src_ds_type,
+        remote_src=False,
+        vol=None,
+        model_ds=None,
     ):
         """Create a partitioned data set specified by 'dest_name'
 
@@ -1050,7 +1118,7 @@ class PDSECopyHandler(CopyHandler):
             elif src_ds_type in MVS_SEQ:
                 rc = self._allocate_pdse(dest_name, vol=vol, src=src)
             elif os.path.isfile(src):
-                size = Path(src).stat().st_size
+                size = os.stat(src).st_size
                 rc = self._allocate_pdse(dest_name, size=size)
             elif os.path.isdir(src):
                 path, dirs, files = next(os.walk(src))
@@ -1058,16 +1126,18 @@ class PDSECopyHandler(CopyHandler):
                     self.fail_json(
                         msg="Subdirectory found in source directory {0}".format(src)
                     )
-                size = sum(Path(path + "/" + f).stat().st_size for f in files)
+                size = sum(os.stat(path + "/" + f).st_size for f in files)
                 rc = self._allocate_pdse(dest_name, size=size)
         else:
             rc = self._allocate_pdse(dest_name, size=size, model_ds=model_ds)
         if rc != 0:
             self.fail_json(
                 msg="Unable to allocate destination data set to copy {0}".format(src),
-                stdout=out, stderr=err, rc=rc,
+                stdout=out,
+                stderr=err,
+                rc=rc,
                 stdout_lines=out.splitlines() if out else None,
-                stderr_lines=err.splitlines() if err else None
+                stderr_lines=err.splitlines() if err else None,
             )
 
     def _allocate_pdse(self, ds_name, size=None, vol=None, src=None, model_ds=None):
@@ -1102,7 +1172,7 @@ class PDSECopyHandler(CopyHandler):
                     recfm = vtoc_info.get("record_format") or recfm
                     lrecl = int(vtoc_info.get("record_length")) or lrecl
                 else:
-                    alloc_size = 5242880    # Use the default 5 Megabytes
+                    alloc_size = 5242880  # Use the default 5 Megabytes
 
             alloc_size = "{0}K".format(str(int(math.ceil(alloc_size / 1024))))
             rc = Datasets.create(ds_name, "PDSE", alloc_size, recfm, "", lrecl)
@@ -1130,8 +1200,10 @@ def backup_data(ds_name, ds_type, backup_name):
         return backup.mvs_file_backup(ds_name, backup_name)
     except Exception as err:
         module.fail_json(
-            msg="Unable to back up destination {0}. Make sure that it exists".format(ds_name),
-            stderr=str(err)
+            msg="Unable to back up destination {0}. Make sure that it exists".format(
+                ds_name
+            ),
+            stderr=str(err),
         )
 
 
@@ -1162,8 +1234,7 @@ def is_compatible(src_type, dest_type, copy_member, src_member):
     # ********************************************************************
     if src_type in MVS_SEQ:
         return not (
-            (dest_type in MVS_PARTITIONED and not copy_member) or
-            dest_type == "VSAM"
+            (dest_type in MVS_PARTITIONED and not copy_member) or dest_type == "VSAM"
         )
 
     # ********************************************************************
@@ -1182,9 +1253,7 @@ def is_compatible(src_type, dest_type, copy_member, src_member):
         if dest_type == "VSAM":
             return False
         if not src_member:
-            return not (
-                copy_member or dest_type in MVS_SEQ
-            )
+            return not (copy_member or dest_type in MVS_SEQ)
         return True
 
     elif src_type == "USS":
@@ -1209,7 +1278,7 @@ def get_file_checksum(src):
     blksize = 64 * 1024
     hash_digest = sha256()
     try:
-        with open(to_bytes(src, errors='surrogate_or_strict'), 'rb') as infile:
+        with open(to_bytes(src, errors="surrogate_or_strict"), "rb") as infile:
             block = infile.read(blksize)
             while block:
                 hash_digest.update(block)
@@ -1233,7 +1302,7 @@ def cleanup(src_list):
     conv_list = glob.glob(tmp_dir + "/converted*")
     tmp_list = glob.glob(tmp_dir + "/{0}*".format(tmp_prefix))
 
-    for file in (dir_list + conv_list + tmp_list + src_list):
+    for file in dir_list + conv_list + tmp_list + src_list:
         try:
             if file and os.path.exists(file):
                 if os.path.isfile(file):
@@ -1244,8 +1313,7 @@ def cleanup(src_list):
             err = str(err)
             if "Permission denied" not in err:
                 module.fail_json(
-                    msg="Error during clean up of file {0}".format(file),
-                    stderr=err
+                    msg="Error during clean up of file {0}".format(file), stderr=err
                 )
 
 
@@ -1263,7 +1331,7 @@ def is_member_wildcard(src):
     return fullmatch(
         r"^(?:(?:[A-Z$#@]{1}[A-Z0-9$#@-]{0,7})(?:[.]{1})){1,21}[A-Z$#@]{1}[A-Z0-9$#@-]{0,7}\([A-Z$#@\*]{1}[A-Z0-9$#@\*]{0,7}\)$",
         src,
-        IGNORECASE
+        IGNORECASE,
     )
 
 
@@ -1277,33 +1345,31 @@ def run_module(module, arg_def):
         parser.parse_args(module.params)
     except ValueError as err:
         # Bypass BetterArgParser when src is of the form 'SOME.DATA.SET(*)'
-        if not is_member_wildcard(module.params['src']):
-            module.fail_json(
-                msg="Parameter verification failed", stderr=str(err)
-            )
+        if not is_member_wildcard(module.params["src"]):
+            module.fail_json(msg="Parameter verification failed", stderr=str(err))
     # ********************************************************************
     # Initialize module variables
     # ********************************************************************
-    src = module.params.get('src')
-    b_src = to_bytes(src, errors='surrogate_or_strict')
-    dest = module.params.get('dest')
-    remote_src = module.params.get('remote_src')
-    is_binary = module.params.get('is_binary')
-    backup = module.params.get('backup')
-    backup_name = module.params.get('backup_name')
-    model_ds = module.params.get('model_ds')
-    validate = module.params.get('validate')
-    mode = module.params.get('mode')
-    group = module.params.get('group')
-    owner = module.params.get('owner')
-    encoding = module.params.get('encoding')
-    is_uss = module.params.get('is_uss')
-    is_pds = module.params.get('is_pds')
-    is_mvs_dest = module.params.get('is_mvs_dest')
-    temp_path = module.params.get('temp_path')
-    alloc_size = module.params.get('size')
-    src_member = module.params.get('src_member')
-    copy_member = module.params.get('copy_member')
+    src = module.params.get("src")
+    b_src = to_bytes(src, errors="surrogate_or_strict")
+    dest = module.params.get("dest")
+    remote_src = module.params.get("remote_src")
+    is_binary = module.params.get("is_binary")
+    backup = module.params.get("backup")
+    backup_name = module.params.get("backup_name")
+    model_ds = module.params.get("model_ds")
+    validate = module.params.get("validate")
+    mode = module.params.get("mode")
+    group = module.params.get("group")
+    owner = module.params.get("owner")
+    encoding = module.params.get("encoding")
+    is_uss = module.params.get("is_uss")
+    is_pds = module.params.get("is_pds")
+    is_mvs_dest = module.params.get("is_mvs_dest")
+    temp_path = module.params.get("temp_path")
+    alloc_size = module.params.get("size")
+    src_member = module.params.get("src_member")
+    copy_member = module.params.get("copy_member")
 
     # ********************************************************************
     # When copying to and from a data set member, 'dest' or 'src' will be
@@ -1325,13 +1391,13 @@ def run_module(module, arg_def):
     # 2. Capture the file or data sets mode bits when mode param is set
     #    to 'preserve'
     # ********************************************************************
-    if remote_src and '/' in src:
+    if remote_src and "/" in src:
         if not os.path.exists(b_src):
             module.fail_json(msg="Source {0} does not exist".format(src))
         if not os.access(src, os.R_OK):
             module.fail_json(msg="Source {0} is not readable".format(src))
-        if mode == 'preserve':
-            mode = '0{0:o}'.format(stat.S_IMODE(os.stat(b_src).st_mode))
+        if mode == "preserve":
+            mode = "0{0:o}".format(stat.S_IMODE(os.stat(b_src).st_mode))
 
     # ********************************************************************
     # 1. Use DataSetUtils to determine the src and dest data set type.
@@ -1347,7 +1413,7 @@ def run_module(module, arg_def):
             if copy_member:
                 dest_exists = dest_exists and dest_du.member_exists(dest_member)
             dest_ds_type = dest_du.ds_type()
-        if temp_path or '/' in src:
+        if temp_path or "/" in src:
             src_ds_type = "USS"
         else:
             src_du = data_set.DataSetUtils(src_name)
@@ -1367,9 +1433,7 @@ def run_module(module, arg_def):
     # not possible to copy a PDS member to a VSAM data set or a USS file
     # to a PDS. Perform these sanity checks.
     # ********************************************************************
-    if not is_compatible(
-        src_ds_type, dest_ds_type, copy_member, src_member
-    ):
+    if not is_compatible(src_ds_type, dest_ds_type, copy_member, src_member):
         module.fail_json(
             msg="Incompatible target type '{0}' for source '{1}'".format(
                 dest_ds_type, src_ds_type
@@ -1385,9 +1449,9 @@ def run_module(module, arg_def):
     # ********************************************************************
     if dest_exists:
         if backup or backup_name:
-            if (dest_ds_type in MVS_PARTITIONED and data_set.is_empty(dest_name)):
+            if dest_ds_type in MVS_PARTITIONED and data_set.is_empty(dest_name):
                 # The partitioned data set is empty
-                res_args['note'] = "Destination is emtpy, backup request ignored"
+                res_args["note"] = "Destination is emtpy, backup request ignored"
             else:
                 backup_name = backup_data(dest, dest_ds_type, backup_name)
     # ********************************************************************
@@ -1405,24 +1469,29 @@ def run_module(module, arg_def):
     # ********************************************************************
     else:
         if not dest_ds_type:
-            if(
-                is_pds or
-                copy_member or
-                (src_ds_type in MVS_PARTITIONED and (not src_member) and is_mvs_dest) or
-                (os.path.isdir(b_src) and is_mvs_dest)
+            if (
+                is_pds
+                or copy_member
+                or (src_ds_type in MVS_PARTITIONED and (not src_member) and is_mvs_dest)
+                or (os.path.isdir(b_src) and is_mvs_dest)
             ):
                 dest_ds_type = "PDSE"
                 pch = PDSECopyHandler(module, dest_exists, backup_name=backup_name)
                 pch.create_pdse(
-                    src, dest_name, alloc_size, src_ds_type,
-                    remote_src=remote_src, vol=src_ds_vol, model_ds=model_ds
+                    src,
+                    dest_name,
+                    alloc_size,
+                    src_ds_type,
+                    remote_src=remote_src,
+                    vol=src_ds_vol,
+                    model_ds=model_ds,
                 )
             elif src_ds_type == "VSAM":
                 dest_ds_type = "VSAM"
             elif not is_uss:
                 dest_ds_type = "SEQ"
 
-        res_args['changed'] = True
+        res_args["changed"] = True
 
     # ********************************************************************
     # Encoding conversion is only valid if the source is a local file,
@@ -1438,7 +1507,7 @@ def run_module(module, arg_def):
             )
         # 'conv_path' points to the converted src file or directory
         if is_mvs_dest:
-            encoding['to'] = encode.Defaults.DEFAULT_EBCDIC_MVS_CHARSET
+            encoding["to"] = encode.Defaults.DEFAULT_EBCDIC_MVS_CHARSET
 
         conv_path = copy_handler.convert_encoding(src, temp_path, encoding)
 
@@ -1447,19 +1516,19 @@ def run_module(module, arg_def):
     # ---------------------------------------------------------------------
     if is_uss:
         if dest_exists and not os.access(dest, os.W_OK):
-            copy_handler.fail_json(
-                msg="Destination {0} is not writable".format(dest)
-            )
+            copy_handler.fail_json(msg="Destination {0} is not writable".format(dest))
 
         uss_copy_handler = USSCopyHandler(
-            module, dest_exists, is_binary=is_binary,
+            module,
+            dest_exists,
+            is_binary=is_binary,
             common_file_args=dict(mode=mode, group=group, owner=owner),
-            backup_name=backup_name
+            backup_name=backup_name,
         )
         dest = uss_copy_handler.copy_to_uss(
             conv_path, temp_path, src_ds_type, src_member, member_name
         )
-        res_args['size'] = Path(dest).stat().st_size
+        res_args["size"] = os.stat(dest).st_size
         if validate:
             try:
                 remote_checksum = get_file_checksum(temp_path or src)
@@ -1468,8 +1537,8 @@ def run_module(module, arg_def):
                 copy_handler.fail_json(
                     msg="Unable to calculate checksum", stderr=str(err)
                 )
-            res_args['checksum'] = remote_checksum
-            res_args['changed'] = (
+            res_args["checksum"] = remote_checksum
+            res_args["changed"] = (
                 res_args.get("changed") or remote_checksum != dest_checksum
             )
 
@@ -1496,9 +1565,7 @@ def run_module(module, arg_def):
                 src, temp_path, conv_path, dest, copy_member=copy_member
             )
         else:
-            pdse_copy_handler.copy_to_pdse(
-                src, temp_path, conv_path, dest, src_ds_type
-            )
+            pdse_copy_handler.copy_to_pdse(src, temp_path, conv_path, dest, src_ds_type)
 
     # ------------------------------- o -----------------------------------
     # Copy to VSAM data set
@@ -1512,7 +1579,7 @@ def run_module(module, arg_def):
             dest=dest,
             ds_type=dest_ds_type,
             dest_exists=dest_exists,
-            backup_name=backup_name
+            backup_name=backup_name,
         )
     )
 
@@ -1522,44 +1589,44 @@ def run_module(module, arg_def):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            src=dict(type='str'),
-            dest=dict(required=True, type='str'),
-            is_binary=dict(type='bool', default=False),
-            encoding=dict(type='dict'),
-            content=dict(type='str', no_log=True),
-            backup=dict(type='bool', default=False),
-            backup_name=dict(type='str'),
-            model_ds=dict(type='str', required=False),
-            local_follow=dict(type='bool', default=True),
-            remote_src=dict(type='bool', default=False),
-            sftp_port=dict(type='int', required=False),
-            ignore_sftp_stderr=dict(type='bool', default=False),
-            validate=dict(type='bool'),
-            is_uss=dict(type='bool'),
-            is_pds=dict(type='bool'),
-            is_mvs_dest=dict(type='bool'),
-            size=dict(type='int'),
-            temp_path=dict(type='str'),
-            copy_member=dict(type='bool'),
-            src_member=dict(type='bool'),
-            local_charset=dict(type='str')
+            src=dict(type="str"),
+            dest=dict(required=True, type="str"),
+            is_binary=dict(type="bool", default=False),
+            encoding=dict(type="dict"),
+            content=dict(type="str", no_log=True),
+            backup=dict(type="bool", default=False),
+            backup_name=dict(type="str"),
+            model_ds=dict(type="str", required=False),
+            local_follow=dict(type="bool", default=True),
+            remote_src=dict(type="bool", default=False),
+            sftp_port=dict(type="int", required=False),
+            ignore_sftp_stderr=dict(type="bool", default=False),
+            validate=dict(type="bool"),
+            is_uss=dict(type="bool"),
+            is_pds=dict(type="bool"),
+            is_mvs_dest=dict(type="bool"),
+            size=dict(type="int"),
+            temp_path=dict(type="str"),
+            copy_member=dict(type="bool"),
+            src_member=dict(type="bool"),
+            local_charset=dict(type="str"),
         ),
-        add_file_common_args=True
+        add_file_common_args=True,
     )
 
     arg_def = dict(
-        src=dict(arg_type='data_set_or_path', required=False),
-        dest=dict(arg_type='data_set_or_path', required=True),
-        is_binary=dict(arg_type='bool', required=False, default=False),
-        content=dict(arg_type='str', required=False),
-        backup=dict(arg_type='bool', default=False, required=False),
-        backup_name=dict(arg_type='data_set_or_path', required=False),
-        model_ds=dict(arg_type='data_set', required=False),
-        local_follow=dict(arg_type='bool', default=True, required=False),
-        remote_src=dict(arg_type='bool', default=False, required=False),
-        checksum=dict(arg_type='str', required=False),
-        validate=dict(arg_type='bool', required=False),
-        sftp_port=dict(arg_type='int', required=False)
+        src=dict(arg_type="data_set_or_path", required=False),
+        dest=dict(arg_type="data_set_or_path", required=True),
+        is_binary=dict(arg_type="bool", required=False, default=False),
+        content=dict(arg_type="str", required=False),
+        backup=dict(arg_type="bool", default=False, required=False),
+        backup_name=dict(arg_type="data_set_or_path", required=False),
+        model_ds=dict(arg_type="data_set", required=False),
+        local_follow=dict(arg_type="bool", default=True, required=False),
+        remote_src=dict(arg_type="bool", default=False, required=False),
+        checksum=dict(arg_type="str", required=False),
+        validate=dict(arg_type="bool", required=False),
+        sftp_port=dict(arg_type="int", required=False),
     )
 
     if (
@@ -1568,19 +1635,23 @@ def main():
         and not module.params.get("is_binary")
     ):
         module.params["encoding"] = {
-            'from': module.params.get("local_charset"),
-            'to': encode.Defaults.get_default_system_charset()
+            "from": module.params.get("local_charset"),
+            "to": encode.Defaults.get_default_system_charset(),
         }
 
     if module.params.get("encoding"):
-        module.params.update(dict(
-            from_encoding=module.params.get('encoding').get('from'),
-            to_encoding=module.params.get('encoding').get('to'))
+        module.params.update(
+            dict(
+                from_encoding=module.params.get("encoding").get("from"),
+                to_encoding=module.params.get("encoding").get("to"),
+            )
         )
-        arg_def.update(dict(
-            from_encoding=dict(arg_type='encoding'),
-            to_encoding=dict(arg_type='encoding')
-        ))
+        arg_def.update(
+            dict(
+                from_encoding=dict(arg_type="encoding"),
+                to_encoding=dict(arg_type="encoding"),
+            )
+        )
 
     res_args = temp_path = conv_path = None
     try:
@@ -1592,7 +1663,9 @@ def main():
 
 class EncodingConversionError(Exception):
     def __init__(self, src, f_code, t_code):
-        self.msg = "Unable to convert encoding for {0} from {1} to {2}".format(src, f_code, t_code)
+        self.msg = "Unable to convert encoding for {0} from {1} to {2}".format(
+            src, f_code, t_code
+        )
         super().__init__(self.msg)
 
 
@@ -1602,5 +1675,5 @@ class NonExistentSourceError(Exception):
         super().__init__(self.msg)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -262,18 +262,24 @@ import os
 
 from math import ceil
 from shutil import rmtree, move
-from shlex import quote
+from ansible.module_utils.six import PY3
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     better_arg_parser,
     data_set,
-    encode
+    encode,
 )
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
     MissingZOAUImport,
 )
+
+
+if PY3:
+    from shlex import quote
+else:
+    from pipes import quote
 
 try:
     from zoautil_py import Datasets, MVSCmd, types
@@ -296,8 +302,8 @@ class FetchHandler:
         return self.module.run_command(cmd, **kwargs)
 
     def _get_vsam_size(self, vsam):
-        """ Invoke IDCAMS LISTCAT command to get the record length and space used.
-            Then estimate the space used by the VSAM data set.
+        """Invoke IDCAMS LISTCAT command to get the record length and space used.
+        Then estimate the space used by the VSAM data set.
         """
         space_pri = 0
         total_size = 0
@@ -380,8 +386,8 @@ class FetchHandler:
         return out_ds_name
 
     def _fetch_uss_file(self, src, is_binary, encoding=None):
-        """ Convert encoding of a USS file. Return a tuple of temporary file
-            name containing converted data.
+        """Convert encoding of a USS file. Return a tuple of temporary file
+        name containing converted data.
         """
         file_path = None
         if (not is_binary) and encoding:
@@ -390,7 +396,9 @@ class FetchHandler:
             to_code_set = encoding.get("to")
             enc_utils = encode.EncodeUtils()
             try:
-                enc_utils.uss_convert_encoding(src, file_path, from_code_set, to_code_set)
+                enc_utils.uss_convert_encoding(
+                    src, file_path, from_code_set, to_code_set
+                )
             except Exception as err:
                 os.remove(file_path)
                 self._fail_json(
@@ -407,8 +415,8 @@ class FetchHandler:
         return file_path if file_path else src
 
     def _fetch_vsam(self, src, is_binary, encoding=None):
-        """ Copy the contents of a VSAM to a sequential data set.
-            Afterwards, copy that data set to a USS file.
+        """Copy the contents of a VSAM to a sequential data set.
+        Afterwards, copy that data set to a USS file.
         """
         temp_ds = self._copy_vsam_to_temp_data_set(src)
         file_path = self._fetch_mvs_data(temp_ds, is_binary, encoding)
@@ -422,9 +430,9 @@ class FetchHandler:
         return file_path
 
     def _fetch_pdse(self, src, is_binary, encoding=None):
-        """ Copy a partitioned data set to a USS directory. If the data set
-            is not being fetched in binary mode, encoding for all members inside
-            the data set will be converted.
+        """Copy a partitioned data set to a USS directory. If the data set
+        is not being fetched in binary mode, encoding for all members inside
+        the data set will be converted.
         """
         dir_path = tempfile.mkdtemp()
         cmd = "cp -B \"//'{0}'\" {1}"
@@ -468,8 +476,8 @@ class FetchHandler:
         return dir_path
 
     def _fetch_mvs_data(self, src, is_binary, encoding=None):
-        """ Copy a sequential data set or a partitioned data set member
-            to a USS file
+        """Copy a sequential data set or a partitioned data set member
+        to a USS file
         """
         fd, file_path = tempfile.mkstemp()
         os.close(fd)
@@ -522,9 +530,9 @@ def run_module():
             use_qualifier=dict(required=False, default=False, type="bool"),
             validate_checksum=dict(required=False, default=True, type="bool"),
             encoding=dict(required=False, type="dict"),
-            sftp_port=dict(type='int', required=False),
-            ignore_sftp_stderr=dict(type='bool', default=False, required=False),
-            local_charset=dict(type='str')
+            sftp_port=dict(type="int", required=False),
+            ignore_sftp_stderr=dict(type="bool", default=False, required=False),
+            local_charset=dict(type="str"),
         )
     )
 
@@ -541,7 +549,7 @@ def run_module():
         dest=dict(arg_type="path", required=True),
         fail_on_missing=dict(arg_type="bool", required=False, default=True),
         is_binary=dict(arg_type="bool", required=False, default=False),
-        use_qualifier=dict(arg_type="bool", required=False, default=False)
+        use_qualifier=dict(arg_type="bool", required=False, default=False),
     )
 
     if not module.params.get("encoding") and not module.params.get("is_binary"):
@@ -549,19 +557,25 @@ def run_module():
         remote_charset = encode.Defaults.get_default_system_charset()
 
         module.params["encoding"] = {
-            'from': encode.Defaults.DEFAULT_EBCDIC_MVS_CHARSET if mvs_src else remote_charset,
-            'to': module.params.get("local_charset")
+            "from": encode.Defaults.DEFAULT_EBCDIC_MVS_CHARSET
+            if mvs_src
+            else remote_charset,
+            "to": module.params.get("local_charset"),
         }
 
     if module.params.get("encoding"):
-        module.params.update(dict(
-            from_encoding=module.params.get('encoding').get('from'),
-            to_encoding=module.params.get('encoding').get('to'))
+        module.params.update(
+            dict(
+                from_encoding=module.params.get("encoding").get("from"),
+                to_encoding=module.params.get("encoding").get("to"),
+            )
         )
-        arg_def.update(dict(
-            from_encoding=dict(arg_type='encoding'),
-            to_encoding=dict(arg_type='encoding')
-        ))
+        arg_def.update(
+            dict(
+                from_encoding=dict(arg_type="encoding"),
+                to_encoding=dict(arg_type="encoding"),
+            )
+        )
 
     fetch_handler = FetchHandler(module)
     try:


### PR DESCRIPTION
Version 1.2.1
=============

Notes
-----

* Update required
* Module changes

  * Noteworthy Python 2.x support

    * encode - removed TemporaryDirectory usage.
    * zos_copy - fixed regex support, dictionary merge operation fix
    * zos_fetch - fix quote import

* Collection changes

  * Beginning this release, all sample playbooks previously included with the
    collection will be made available on the  [samples repository](https://github.com/IBM/z_ansible_collections_samples/blob/master/README.md). The
     [samples repository](https://github.com/IBM/z_ansible_collections_samples/blob/master/README.md) explains the playbook concepts,
    discusses z/OS administration, provides links to the samples support site,
    blogs and other community resources.

* Documentation changes

  * In this release, documentation related to playbook configuration has been
    migrated to the [samples repository](https://github.com/IBM/z_ansible_collections_samples/blob/master/README.md). Each sample contains a README that
    explains what configurations must be made to run the sample playbook.

Availability
------------

* [Automation Hub](https://www.ansible.com/products/automation-hub)
* [Galaxy](https://galaxy.ansible.com/ibm/ibm_zos_core)
* [GitHub](https://github.com/ansible-collections/ibm_zos_core)

Reference
---------

* Supported by IBM Open Enterprise Python for z/OS: 3.8.2 or later
* Supported by IBM Z Open Automation Utilities 1.0.3 PTF UI70435
* Supported by z/OS V2R3
* The z/OS® shell

Known issues
------------

* Modules

  * When executing programs using ``zos_mvs_raw``, you may encounter errors
    that originate in the programs implementation. Two such known issues are
    noted below of which one has been addressed with an APAR.

    #. ``zos_mvs_raw`` module execution fails when invoking
       Database Image Copy 2 Utility or Database Recovery Utility in conjunction
       with FlashCopy or Fast Replication.
    #. ``zos_mvs_raw`` module execution fails when invoking DFSRRC00 with parm
       "UPB,PRECOMP", "UPB, POSTCOMP" or "UPB,PRECOMP,POSTCOMP". This issue is
       addressed by APAR PH28089.