### PR TITLE
catalog only when we are sure data set exists on volume

### DIFF
--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -730,7 +730,7 @@ def data_set_name(contents, dependencies):
 # * dependent on state
 def space_type(contents, dependencies):
     """Validates provided data set unit of space is valid.
-    Returns the unit of space. """
+    Returns the unit of space."""
     if dependencies.get("state") == "absent":
         return None
     if contents is None:
@@ -748,7 +748,7 @@ def space_type(contents, dependencies):
 # * dependent on state
 def sms_class(contents, dependencies):
     """Validates provided sms class is of valid length.
-    Returns the sms class. """
+    Returns the sms class."""
     if dependencies.get("state") == "absent" or contents is None:
         return None
     if len(contents) < 1 or len(contents) > 8:
@@ -762,8 +762,8 @@ def sms_class(contents, dependencies):
 
 
 def valid_when_state_present(contents, dependencies):
-    """ Ensures no arguments that are invalid when state!=present
-    are allowed. """
+    """Ensures no arguments that are invalid when state!=present
+    are allowed."""
     if dependencies.get("state") == "absent" or contents is None:
         return None
     return contents
@@ -840,7 +840,11 @@ def volumes(contents, dependencies):
     if not isinstance(contents, list):
         contents = [contents]
     for vol in contents:
-        if not re.fullmatch(r"^[A-Z0-9]{1,6}$", str(vol), re.IGNORECASE,):
+        if not re.fullmatch(
+            r"^[A-Z0-9]{1,6}$",
+            str(vol),
+            re.IGNORECASE,
+        ):
             raise ValueError(
                 'Invalid argument type for "{0}". expected volume name'.format(vol)
             )
@@ -894,8 +898,8 @@ def key_offset(contents, dependencies):
 
 
 def perform_data_set_operations(name, state, **extra_args):
-    """ Calls functions to perform desired operations on
-    one or more data sets. Returns boolean indicating if changes were made. """
+    """Calls functions to perform desired operations on
+    one or more data sets. Returns boolean indicating if changes were made."""
     changed = False
     if state == "present" and extra_args.get("type") != "MEMBER":
         changed = DataSet.ensure_present(name, **extra_args)
@@ -1010,7 +1014,10 @@ def parse_and_validate_args(params):
                     required=False,
                     dependencies=["state", "type"],
                 ),
-                replace=dict(type="bool", default=False,),
+                replace=dict(
+                    type="bool",
+                    default=False,
+                ),
                 volumes=dict(
                     type=volumes,
                     required=False,
@@ -1055,19 +1062,31 @@ def parse_and_validate_args(params):
         ),
         sms_data_class=dict(type=sms_class, required=False, dependencies=["state"]),
         block_size=dict(
-            type=valid_when_state_present, required=False, dependencies=["state"],
+            type=valid_when_state_present,
+            required=False,
+            dependencies=["state"],
         ),
         directory_blocks=dict(
-            type=valid_when_state_present, required=False, dependencies=["state"],
+            type=valid_when_state_present,
+            required=False,
+            dependencies=["state"],
         ),
         record_length=dict(
-            type=record_length, required=False, dependencies=["state", "record_format"],
+            type=record_length,
+            required=False,
+            dependencies=["state", "record_format"],
         ),
         key_offset=dict(type=valid_when_state_present, required=False),
         key_length=dict(type=valid_when_state_present, required=False),
-        replace=dict(type="bool", default=False,),
+        replace=dict(
+            type="bool",
+            default=False,
+        ),
         volumes=dict(
-            type=volumes, required=False, aliases=["volume"], dependencies=["state"],
+            type=volumes,
+            required=False,
+            aliases=["volume"],
+            dependencies=["state"],
         ),
         mutually_exclusive=[
             ["batch", "name"],
@@ -1104,7 +1123,10 @@ def run_module():
             type="list",
             elements="dict",
             options=dict(
-                name=dict(type="str", required=False,),
+                name=dict(
+                    type="str",
+                    required=False,
+                ),
                 state=dict(
                     type="str",
                     default="present",
@@ -1123,17 +1145,32 @@ def run_module():
                     type="str", required=False, aliases=["data_class"]
                 ),
                 sms_data_class=dict(type="str", required=False),
-                block_size=dict(type="int", required=False,),
-                directory_blocks=dict(type="int", required=False,),
-                record_length=dict(type="int", required=False,),
+                block_size=dict(
+                    type="int",
+                    required=False,
+                ),
+                directory_blocks=dict(
+                    type="int",
+                    required=False,
+                ),
+                record_length=dict(
+                    type="int",
+                    required=False,
+                ),
                 key_offset=dict(type="int", required=False),
                 key_length=dict(type="int", required=False),
-                replace=dict(type="bool", default=False,),
+                replace=dict(
+                    type="bool",
+                    default=False,
+                ),
                 volumes=dict(type="raw", required=False, aliases=["volume"]),
             ),
         ),
         # For individual data set args
-        name=dict(type="str", required=False,),
+        name=dict(
+            type="str",
+            required=False,
+        ),
         state=dict(
             type="str",
             default="present",
@@ -1151,13 +1188,29 @@ def run_module():
         # support for backwards compatability with previous module versions
         sms_storage_class=dict(type="str", required=False, aliases=["data_class"]),
         sms_data_class=dict(type="str", required=False),
-        block_size=dict(type="int", required=False,),
-        directory_blocks=dict(type="int", required=False,),
-        record_length=dict(type="int", required=False,),
+        block_size=dict(
+            type="int",
+            required=False,
+        ),
+        directory_blocks=dict(
+            type="int",
+            required=False,
+        ),
+        record_length=dict(
+            type="int",
+            required=False,
+        ),
         key_offset=dict(type="int", required=False),
         key_length=dict(type="int", required=False),
-        replace=dict(type="bool", default=False,),
-        volumes=dict(type="raw", required=False, aliases=["volume"],),
+        replace=dict(
+            type="bool",
+            default=False,
+        ),
+        volumes=dict(
+            type="raw",
+            required=False,
+            aliases=["volume"],
+        ),
     )
     result = dict(changed=False, message="", names=[])
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes #3857 in Jira. This PR fixes a bug that sometimes occurs when attempting to catalog a data set that does not exist. The catalog command will run successfully and "catalog" the data set, but the data set will not actually exist. This leads to unexpected behavior in future commands that see the "existent" data set but cannot use it.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- plugins/module_utils/data_set.py - fix logic for ensuring data set present
- plugins/modules/zos_data_set.py - fix formatting

