### PR TITLE
fail on non-zero zoau copy return code

### DIFF
--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-from os import fdopen
 import shutil
 import tempfile
 from tempfile import mkstemp
@@ -332,7 +331,9 @@ def test_copy_local_file_to_pdse_member_binary(ansible_zos_module):
     hosts = ansible_zos_module
     dest = "USER.TEST.PDS.FUNCTEST"
     dest_path = "USER.TEST.PDS.FUNCTEST(DATA)"
-    src_file = "/etc/profile"
+    fd, src_file = mkstemp()
+    with open(src_file, 'w') as infile:
+        infile.write(DUMMY_DATA)
     try:
         hosts.all.zos_data_set(
             name=dest,
@@ -353,6 +354,8 @@ def test_copy_local_file_to_pdse_member_binary(ansible_zos_module):
             assert v_cp.get("rc") == 0
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
+        os.close(fd)
+        os.remove(src_file)
 
 
 def test_copy_uss_file_to_uss_file(ansible_zos_module):

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3,8 +3,10 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+from os import fdopen
 import shutil
 import tempfile
+from tempfile import mkstemp
 
 __metaclass__ = type
 
@@ -297,7 +299,10 @@ def test_copy_local_file_to_pds_member_binary(ansible_zos_module):
     hosts = ansible_zos_module
     dest = "USER.TEST.PDS.FUNCTEST"
     dest_path = "USER.TEST.PDS.FUNCTEST(DATA)"
-    src_file = "/etc/profile"
+    fd, src_file = mkstemp()
+    with open(src_file, 'w') as infile:
+        infile.write(DUMMY_DATA)
+
     try:
         hosts.all.zos_data_set(
             name=dest,
@@ -319,6 +324,8 @@ def test_copy_local_file_to_pds_member_binary(ansible_zos_module):
             assert v_cp.get("rc") == 0
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
+        os.close(fd)
+        os.remove(src_file)
 
 
 def test_copy_local_file_to_pdse_member_binary(ansible_zos_module):

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -143,14 +143,15 @@ def test_copy_local_file_to_existing_pdse_member(ansible_zos_module):
     try:
         hosts.all.zos_data_set(
             name=dest,
-            type="pds",
+            type="pdse",
             space_primary=5,
             space_type="M",
             record_format="fba",
-            record_length=25,
+            record_length=80,
         )
         hosts.all.zos_data_set(name=dest_path, type="MEMBER", replace="yes")
         copy_result = hosts.all.zos_copy(src=src_file, dest=dest_path)
+        print(vars(copy_result))
         verify_copy = hosts.all.shell(
             cmd="cat \"//'{0}'\" > /dev/null 2>/dev/null".format(dest_path),
             executable=SHELL_EXECUTABLE,
@@ -170,11 +171,11 @@ def test_copy_local_file_to_non_existing_pdse_member(ansible_zos_module):
     try:
         hosts.all.zos_data_set(
             name=dest,
-            type="pds",
+            type="pdse",
             space_primary=5,
             space_type="M",
             record_format="fba",
-            record_length=25,
+            record_length=80,
         )
         copy_result = hosts.all.zos_copy(src=src_file, dest=dest)
         verify_copy = hosts.all.shell(
@@ -220,7 +221,7 @@ def test_copy_local_dir_to_existing_pdse(ansible_zos_module):
             space_primary=5,
             space_type="M",
             record_format="fba",
-            record_length=25,
+            record_length=80,
         )
         hosts.all.zos_data_set(name=dest + "(FILE1)", type="MEMBER", replace="yes")
         copy_result = hosts.all.zos_copy(src=source_path, dest=dest)
@@ -303,11 +304,11 @@ def test_copy_local_file_to_pds_member_binary(ansible_zos_module):
             type="pds",
             space_primary=5,
             space_type="M",
-            record_format="fba",
-            record_length=25,
+            record_format="fb",
+            record_length=255,
         )
-        hosts.all.zos_data_set(name=dest_path, type="MEMBER", replace="yes")
         copy_result = hosts.all.zos_copy(src=src_file, dest=dest_path, is_binary=True)
+        print(vars(copy_result))
         verify_copy = hosts.all.shell(
             cmd="cat \"//'{0}'\" > /dev/null 2>/dev/null".format(dest_path),
             executable=SHELL_EXECUTABLE,
@@ -331,10 +332,9 @@ def test_copy_local_file_to_pdse_member_binary(ansible_zos_module):
             type="pdse",
             space_primary=5,
             space_type="M",
-            record_format="fba",
-            record_length=25,
+            record_format="fb",
+            record_length=255,
         )
-        hosts.all.zos_data_set(name=dest_path, type="MEMBER", replace="yes")
         copy_result = hosts.all.zos_copy(src=src_file, dest=dest_path, is_binary=True)
         verify_copy = hosts.all.shell(
             cmd="cat \"//'{0}'\" > /dev/null 2>/dev/null".format(dest_path),
@@ -430,7 +430,7 @@ def test_copy_uss_file_to_non_existing_pdse_member(ansible_zos_module):
             space_primary=5,
             space_type="M",
             record_format="fba",
-            record_length=25,
+            record_length=80,
         )
         copy_result = hosts.all.zos_copy(src=src_file, dest=dest_path, remote_src=True)
         verify_copy = hosts.all.shell(
@@ -457,7 +457,7 @@ def test_copy_uss_file_to_existing_pdse_member(ansible_zos_module):
             space_primary=5,
             space_type="M",
             record_format="fba",
-            record_length=25,
+            record_length=80,
         )
         hosts.all.zos_data_set(name=dest_path, type="MEMBER", replace="yes")
         copy_result = hosts.all.zos_copy(src=src_file, dest=dest_path, remote_src=True)
@@ -484,7 +484,7 @@ def test_copy_uss_dir_to_existing_pdse(ansible_zos_module):
             space_primary=5,
             space_type="M",
             record_format="fba",
-            record_length=25,
+            record_length=80,
         )
         hosts.all.file(path=src_dir, state="directory")
         for i in range(5):
@@ -1628,7 +1628,7 @@ def test_backup_pds_default_backup_path(ansible_zos_module):
             space_primary=5,
             space_type="M",
             record_format="fba",
-            record_length=25,
+            record_length=80,
         )
         hosts.all.zos_data_set(name=dest + "(FILE1)", type="MEMBER", replace="yes")
         copy_res = hosts.all.zos_copy(src=src, dest=dest, backup=True)
@@ -1667,7 +1667,7 @@ def test_backup_pdse_default_backup_path(ansible_zos_module):
             space_primary=5,
             space_type="M",
             record_format="fba",
-            record_length=25,
+            record_length=80,
         )
         hosts.all.zos_data_set(name=dest + "(FILE1)", type="MEMBER", replace="yes")
         copy_res = hosts.all.zos_copy(src=src, dest=dest, backup=True)
@@ -1790,12 +1790,13 @@ def test_backup_pds_user_backup_path(ansible_zos_module):
             space_primary=5,
             space_type="M",
             record_format="fba",
-            record_length=25,
+            record_length=80,
         )
         hosts.all.zos_data_set(name=dest + "(FILE1)", type="MEMBER", replace="yes")
         copy_res = hosts.all.zos_copy(
             src=src, dest=dest, backup=True, backup_name=backup_name
         )
+        print(vars(copy_res))
 
         for result in copy_res.contacted.values():
             assert result.get("msg") is None
@@ -1830,7 +1831,7 @@ def test_backup_pdse_user_backup_path(ansible_zos_module):
             space_primary=5,
             space_type="M",
             record_format="fba",
-            record_length=25,
+            record_length=80,
         )
         hosts.all.zos_data_set(name=dest + "(FILE1)", type="MEMBER", replace="yes")
         copy_res = hosts.all.zos_copy(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes NAZARE-3862: the module should fail when encountering a non-zero return code from ZOAU copy API and display stdout and stderr information.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy
