### PR TITLE
Bugfix/4407/job utility fails on special chars

### DIFF
--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -93,7 +93,10 @@ def _parse_jobs(output_str):
         for job_str in job_strs:
             job = {}
             job_info_match = re.search(
-                r"job_id:([^\n]*)\njob_name:([^\n]*)\nsubsystem:([^\n]*)\nsystem:([^\n]*)\nowner:([^\n]*)\nret_code_msg:([^\n]*)\nclass:([^\n]*)\ncontent_type:([^\n]*)",
+                (
+                    r"job_id:([^\n]*)\njob_name:([^\n]*)\nsubsystem:([^\n]*)\nsystem:([^\n]*)\n"
+                    r"owner:([^\n]*)\nret_code_msg:([^\n]*)\nclass:([^\n]*)\ncontent_type:([^\n]*)"
+                ),
                 job_str,
             )
             job["job_id"] = job_info_match.group(1).strip()
@@ -139,7 +142,10 @@ def _parse_dds(job_str):
         for dd_str in dd_strs:
             dd = {}
             dd_info_match = re.search(
-                r"ddname:([^\n]*)\nrecord_count:([^\n]*)\nid:([^\n]*)\nstepname:([^\n]*)\nprocstep:([^\n]*)\nbyte_count:([^\n]*)",
+                (
+                    r"ddname:([^\n]*)\nrecord_count:([^\n]*)\nid:([^\n]*)\nstepname:([^\n]*)\n"
+                    r"procstep:([^\n]*)\nbyte_count:([^\n]*)"
+                ),
                 dd_str,
             )
             dd["ddname"] = dd_info_match.group(1).strip()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes #4407 in Jira and fixes #203 in GitHub. Prior to this PR, the job utility was relying on REXX script to build valid JSON. If the job output contained special characters often the job utility would fail to parse the output as valid JSON. This PR updates the REXX script output for easier parsing with regular expressions instead of loading with JSON.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- *plugins/module_utils/job.py* - Update job utility to use python parsing instead of rexx building JSON

