### PR TITLE
add origin/ to default branch name

### DIFF
--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -434,7 +434,7 @@ def get_all_files_in_dir_tree(base_path):
     return found_files
 
 
-def get_changed_files(path, branch="dev"):
+def get_changed_files(path, branch="origin/dev"):
     """Get a list of files changed compared to specified branch.
     Deleted files are not included.
 
@@ -482,7 +482,7 @@ def parse_arguments():
     parser.add_argument(
         "-b",
         "--branch",
-        default="dev",
+        default="origin/dev",
         help="The branch to compare current branch with. Used to determine changed files.",
     )
     parser.add_argument(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR updates dependencyfinder.py's default branch name for comparisons to `origin/dev`, this will work more reliably than `dev` which was previously used.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request