### PR TITLE
Bugfix/4660/copy program objects

### DIFF
--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1202,10 +1202,10 @@ class PDSECopyHandler(CopyHandler):
                 msg = "Unable to copy data set member {0} to {1}".format(src, dest)
 
             # *****************************************************************
-            # while attempting to write a data set member to a PDSE containing
-            # program object members. A PDSE cannot contain both program object
-            # members and data members. This can be resolved by copying the
-            # program object with a "-X" flag
+            # An error occurs while attempting to write a data set member to a
+            # PDSE containing program object members, a PDSE cannot contain
+            # both program object members and data members. This can be
+            # resolved by copying the program object with a "-X" flag.
             # *****************************************************************
             if "FSUM8976" in err and "EDC5091I" in err:
                 rc, out, err = self.run_command(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1192,20 +1192,30 @@ class PDSECopyHandler(CopyHandler):
         new_src = (temp_path or conv_path or src).replace("$", "\\$")
         dest = dest.replace("$", "\\$")
         response = datasets._copy(new_src, dest)
+        rc, out, err = response.rc, response.stdout_response, response.stderr_response
 
-        if response.rc != 0:
+        if rc != 0:
             msg = ""
             if is_uss_src:
                 msg = "Unable to copy file {0} to data set member {1}".format(src, dest)
             else:
                 msg = "Unable to copy data set member {0} to {1}".format(src, dest)
 
-            self.fail_json(
-                msg=msg,
-                rc=response.rc,
-                stdout=response.stdout_response,
-                stderr=response.stderr_response
-            )
+            # *****************************************************************
+            # while attempting to write a data set member to a PDSE containing
+            # program object members. A PDSE cannot contain both program object
+            # members and data members. This can be resolved by copying the
+            # program object with a "-X" flag
+            # *****************************************************************
+            if "FSUM8976" in err and "EDC5091I" in err:
+                rc, out, err = self.run_command(
+                    "cp -X \"//'{0}'\" \"//'{1}'\"".format(new_src, dest)
+                )
+                if rc != 0:
+                    self.fail_json(msg=msg, rc=rc, stdout=out, stderr=err)
+            else:
+                self.fail_json(msg=msg, rc=rc, stdout=out, stderr=err)
+
         return dest.replace("\\", "")
 
     def create_pdse(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes [NAZARE-4660](https://jsw.ibm.com/browse/NAZARE-4660) - Copying program object members to PDSE produces the following error:
```
cp: FSUM8976 Error writing <src_data_set_member> to PDSE member <dest_data_set_member>: EDC5000I No error occured

cp: <dest_data_set_member> close failed: EDC5091I The requested function could not be performed because a system utility failed
```
More information about this error: https://www.ibm.com/support/knowledgecenter/sk/SSLTBW_2.1.0/com.ibm.zos.v2r1.bpxa800/fsum8976.htm

Using `-X` flag with `cp` resolves this issue

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy

