### PR TITLE
Update template to support complex list with elements

### DIFF
--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -49,16 +49,6 @@ Synopsis
 
 {% macro option_generation(opts, level) %}
 {%   for name, spec in opts | dictsort recursive %}
-{%     set req = "required" if spec.required else "optional" %}
-
-{# if its a boolean we need to convert to a string for html #}
-{% if spec.type == 'bool' %}
-     {% set default_str = (spec.default | string | lower ) %}
-{% elif spec.type == 'int' %}
-     {% set default_str = (spec.default | string ) %}
-{% else %}
-     {% set default = ", default: " + spec.default if spec.default else "" %}
-{% endif %}
 
 {{ "  " * level }}{{ name }}
 {%     for para in spec.description %}
@@ -68,6 +58,9 @@ Synopsis
 
   {{ "  " * level }}| **required**: {{ spec.required | default("False") }}
   {{ "  " * level }}| **type**: {{ spec.type | default("str") }}
+{%     if spec.elements %}
+  {{ "  " * level }}| **elements**: {{ spec.elements }}
+{%     endif %}
 {%     if spec.default %}
   {{ "  " * level }}| **default**: {{ spec.default }}
 {%     endif %}
@@ -162,7 +155,7 @@ See Also
 
       {%- if _sample -%}
       {% if _type != 'str' and _type != 'int' %}
-      
+
       {{ "  " * level }}| **sample**:
 
               .. code-block::


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
This was encountered with when we were on-boarding zHMC where they had a module option that spanned a range. I saw nothing technically incorrect in this option spec and found that our Jinja template would error on a default case when it encountered a default as such below.

```
    type: list
    elements: int
    required: false
    default: [0,-1]
```
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
