### PR TITLE
fix newline print if nothing found

### DIFF
--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -579,4 +579,5 @@ if __name__ == "__main__":
                 skip_pattern, test.path, re.IGNORECASE
             ):
                 to_print += test.path + " "
-        print(to_print.rstrip())
+        if to_print:
+            print(to_print.rstrip())


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a small bug in dependencyfinder.py which prints a newline when no tests are found, this would cause some unexpected behavior when checking if any tests need to run.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

