### PR TITLE
Fixes #219: Support for choosing parm odering in module template

### DIFF
--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -48,7 +48,9 @@ Synopsis
 {# ------------------------------------------------------------------------ #}
 
 {% macro option_generation(opts, level) %}
-{%   for name, spec in opts | dictsort recursive %}
+{# Control the order of options: true: ordered by name; false: keep source order #}
+{%   set sorted = false %}
+{%   for name, spec in (opts | dictsort if sorted else opts.items()) %}
 
 {{ "  " * level }}{{ name }}
 {%     for para in spec.description %}
@@ -184,4 +186,3 @@ Return Values
 
 {{ result_generation(returndocs,1) }}
 {% endif %}
-


### PR DESCRIPTION
This PR addresses issue #219.
For details, see the commit message.
