### PR TITLE
Fixes #224: Support for multiple samples in module return properties

### DIFF
--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -55,7 +55,6 @@ Synopsis
   {{ "  " * level }}{{ para | rst_ify }}
 
 {%     endfor %}
-
   {{ "  " * level }}| **required**: {{ spec.required | default("False") }}
   {{ "  " * level }}| **type**: {{ spec.type | default("str") }}
 {%     if spec.elements %}
@@ -132,56 +131,51 @@ See Also
 {# ------------------------------------------------------------- #}
 
 {% macro result_generation(results, level) %}
+{%   for entry in results %}
+{%     set _description  = results[entry].description %}
+{%     set _returned     = results[entry].returned %}
+{%     set _type         = results[entry].type %}
+{%     set _contains     = results[entry].contains %}
+{%     set _sample       = results[entry].sample %}
 
-   {% for entry in results %}
+{{ "  " * level }}{{ entry }}
+{%     if _description is iterable and _description is not string %}
+{%       for _para in _description %}
+  {{ "  " * level }}{{ _para | rst_ify }}
 
-      {%  set _description  = results[entry].description %}
-      {%  set _returned     = results[entry].returned %}
-      {%  set _type         = results[entry].type %}
-      {%  set _contains     = results[entry].contains %}
-      {%  set _sample       = results[entry].sample %}
+{%       endfor %}
+{%     else %}
+  {{ "  " * level }}{{ _description | rst_ify }}
 
-      {{ entry | indent(level, True) }}
-      {% if _description is iterable and _description is not string %}
-{{ "  " * (level) }}| {{ _description[0] }}
-      {% else %}
-{{ "  " * (level) }}| {{ _description }}
-      {% endif %}
+{%     endif %}
+{%     if _returned %}
+  {{ "  " * level }}| **returned**: {{ _returned }}
+{%     endif %}
+  {{ "  " * level }}| **type**: {{ _type }}
+{%     if _sample %}
+{%       if _type != 'str' and _type != 'int' %}
+  {{ "  " * level }}| **sample**:
 
-      {% if _returned %}
-{{ "  " * level }}| **returned**: {{ _returned }}
-      {% endif %}
-{{ "  " * level }}| **type**: {{ _type  }}
+  {{ "  " * level }}  .. code-block::
 
-      {%- if _sample -%}
-      {% if _type != 'str' and _type != 'int' %}
+  {{ "  " * level }}      {{ _sample | tojson }}
+{%       else %}
+  {{ "  " * level }}| **sample**: {{ _sample }}
+{%       endif %}
+{%     endif %}
+{%     if _contains %}
+{{ result_generation(_contains, level + 1) }}
+{%     endif %}
+{%   endfor %}
+{% endmacro %}
 
-      {{ "  " * level }}| **sample**:
-
-              .. code-block::
-
-                       {{ _sample | tojson }}
-      {% else %}
-
-      {{ "  " * level }}| **sample**: {{ _sample }}
-
-      {% endif %}
-      {% endif %}
-
-      {% if _contains %}
-        {{ result_generation(_contains, level + 1) }}
-      {% endif %}
-
-      {% endfor  %}
-  {% endmacro %}
 {# ------------------------------------------------------------- #}
 {# Generate the return values doc                                #}
 {# ------------------------------------------------------------- #}
 
-{% if returndocs -%}
+{% if returndocs %}
 Return Values
 -------------
 
-{{ result_generation(returndocs,1) }}
+{{ result_generation(returndocs, 0) }}
 {% endif %}
-

--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -153,14 +153,30 @@ See Also
 {%     endif %}
   {{ "  " * level }}| **type**: {{ _type }}
 {%     if _sample %}
-{%       if _type != 'str' and _type != 'int' %}
+{%       if _sample.sample1 %}
+  {{ "  " * level }}| **sample**:
+{%         for _samplex in _sample %}
+{%           if _type != 'str' and _type != 'int' %}
+
+  {{ "  " * level }}  .. code-block::
+
+  {{ "  " * level }}      {{ _sample[_samplex] | tojson }}
+{%           else %}
+
+  {{ "  " * level }}  {{ _sample[_samplex] }}
+{%           endif %}
+{%         endfor %}
+
+{%       else %}
+{%         if _type != 'str' and _type != 'int' %}
   {{ "  " * level }}| **sample**:
 
   {{ "  " * level }}  .. code-block::
 
   {{ "  " * level }}      {{ _sample | tojson }}
-{%       else %}
+{%         else %}
   {{ "  " * level }}| **sample**: {{ _sample }}
+{%         endif %}
 {%       endif %}
 {%     endif %}
 {%     if _contains %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #224:

The module.rst.j2 template supported only a single sample in the 'sample' attribute of a return property. This change adds support for multiple samples by specifying child attributes 'sample1', 'sample2', etc under the 'sample' attribute. This is consistent with how the ibm_zosmf collection supports it, but the solution in addition takes care to distinguish str/int types and complex types consistent with how it is done for single samples.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

* docs/templates/module.rst.j2

##### ADDITIONAL INFORMATION

**Note:** This PR is on top of PR #223 to avoid merge effort.
