### PR TITLE
Fixes #226: Support for showing list elements in module return values

### DIFF
--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -135,6 +135,7 @@ See Also
 {%     set _description  = results[entry].description %}
 {%     set _returned     = results[entry].returned %}
 {%     set _type         = results[entry].type %}
+{%     set _elements     = results[entry].elements %}
 {%     set _contains     = results[entry].contains %}
 {%     set _sample       = results[entry].sample %}
 
@@ -152,6 +153,9 @@ See Also
   {{ "  " * level }}| **returned**: {{ _returned }}
 {%     endif %}
   {{ "  " * level }}| **type**: {{ _type }}
+{%     if _elements %}
+  {{ "  " * level }}| **elements**: {{ _elements }}
+{%     endif %}
 {%     if _sample %}
 {%       if _type != 'str' and _type != 'int' %}
   {{ "  " * level }}| **sample**:

--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -55,7 +55,6 @@ Synopsis
   {{ "  " * level }}{{ para | rst_ify }}
 
 {%     endfor %}
-
   {{ "  " * level }}| **required**: {{ spec.required | default("False") }}
   {{ "  " * level }}| **type**: {{ spec.type | default("str") }}
 {%     if spec.elements %}
@@ -132,56 +131,51 @@ See Also
 {# ------------------------------------------------------------- #}
 
 {% macro result_generation(results, level) %}
+{%   for entry in results %}
+{%     set _description  = results[entry].description %}
+{%     set _returned     = results[entry].returned %}
+{%     set _type         = results[entry].type %}
+{%     set _contains     = results[entry].contains %}
+{%     set _sample       = results[entry].sample %}
 
-   {% for entry in results %}
+{{ "  " * level }}{{ entry }}
+{%     if _description is iterable and _description is not string %}
+{%       for _para in _description %}
+  {{ "  " * level }}{{ _para | rst_ify }}
 
-      {%  set _description  = results[entry].description %}
-      {%  set _returned     = results[entry].returned %}
-      {%  set _type         = results[entry].type %}
-      {%  set _contains     = results[entry].contains %}
-      {%  set _sample       = results[entry].sample %}
+{%       endfor %}
+{%     else %}
+  {{ "  " * level }}{{ _description | rst_ify }}
 
-      {{ entry | indent(level, True) }}
-      {% if _description is iterable and _description is not string %}
-{{ "  " * (level) }}| {{ _description[0] }}
-      {% else %}
-{{ "  " * (level) }}| {{ _description }}
-      {% endif %}
+{%     endif %}
+{%     if _returned %}
+  {{ "  " * level }}| **returned**: {{ _returned }}
+{%     endif %}
+  {{ "  " * level }}| **type**: {{ _type }}
+{%     if _sample %}
+{%       if _type != 'str' and _type != 'int' %}
+  {{ "  " * level }}| **sample**:
 
-      {% if _returned %}
-{{ "  " * level }}| **returned**: {{ _returned }}
-      {% endif %}
-{{ "  " * level }}| **type**: {{ _type  }}
+  {{ "  " * level }}  .. code-block::
 
-      {%- if _sample -%}
-      {% if _type != 'str' and _type != 'int' %}
+  {{ "  " * level }}      {{ _sample | tojson }}
+{%       else %}
+  {{ "  " * level }}| **sample**: {{ _sample }}
+{%       endif %}
+{%     endif %}
+{%     if _contains %}
+{{ result_generation(_contains, level + 1) }}
+{%     endif %}
+{%   endfor %}
+{% endmacro %}
 
-      {{ "  " * level }}| **sample**:
-
-              .. code-block::
-
-                       {{ _sample | tojson }}
-      {% else %}
-
-      {{ "  " * level }}| **sample**: {{ _sample }}
-
-      {% endif %}
-      {% endif %}
-
-      {% if _contains %}
-        {{ result_generation(_contains, level + 1) }}
-      {% endif %}
-
-      {% endfor  %}
-  {% endmacro %}
 {# ------------------------------------------------------------- #}
 {# Generate the return values doc                                #}
 {# ------------------------------------------------------------- #}
 
-{% if returndocs -%}
+{% if returndocs %}
 Return Values
 -------------
 
-{{ result_generation(returndocs,1) }}
+{{ result_generation(returndocs, 0) }}
 {% endif %}
-


### PR DESCRIPTION
##### SUMMARY

Fixes #226: 

Currently, the module.rst.j2 template does not show the 'elements' attribute for return value properties. It does show it for input parameters.

This change adds support for showing the 'elements' attribute for return value properties, if specified.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

* docs/templates/module.rst.j2

##### ADDITIONAL INFORMATION

**Note:** This PR is on top of PR #223 to avoid merge effort.