### PR TITLE
Fixes #228: Support for multi-line JSON samples in module template

### DIFF
--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -55,7 +55,6 @@ Synopsis
   {{ "  " * level }}{{ para | rst_ify }}
 
 {%     endfor %}
-
   {{ "  " * level }}| **required**: {{ spec.required | default("False") }}
   {{ "  " * level }}| **type**: {{ spec.type | default("str") }}
 {%     if spec.elements %}
@@ -132,56 +131,51 @@ See Also
 {# ------------------------------------------------------------- #}
 
 {% macro result_generation(results, level) %}
+{%   for entry in results %}
+{%     set _description  = results[entry].description %}
+{%     set _returned     = results[entry].returned %}
+{%     set _type         = results[entry].type %}
+{%     set _contains     = results[entry].contains %}
+{%     set _sample       = results[entry].sample %}
 
-   {% for entry in results %}
+{{ "  " * level }}{{ entry }}
+{%     if _description is iterable and _description is not string %}
+{%       for _para in _description %}
+  {{ "  " * level }}{{ _para | rst_ify }}
 
-      {%  set _description  = results[entry].description %}
-      {%  set _returned     = results[entry].returned %}
-      {%  set _type         = results[entry].type %}
-      {%  set _contains     = results[entry].contains %}
-      {%  set _sample       = results[entry].sample %}
+{%       endfor %}
+{%     else %}
+  {{ "  " * level }}{{ _description | rst_ify }}
 
-      {{ entry | indent(level, True) }}
-      {% if _description is iterable and _description is not string %}
-{{ "  " * (level) }}| {{ _description[0] }}
-      {% else %}
-{{ "  " * (level) }}| {{ _description }}
-      {% endif %}
+{%     endif %}
+{%     if _returned %}
+  {{ "  " * level }}| **returned**: {{ _returned }}
+{%     endif %}
+  {{ "  " * level }}| **type**: {{ _type }}
+{%     if _sample %}
+{%       if _type != 'str' and _type != 'int' %}
+  {{ "  " * level }}| **sample**:
 
-      {% if _returned %}
-{{ "  " * level }}| **returned**: {{ _returned }}
-      {% endif %}
-{{ "  " * level }}| **type**: {{ _type  }}
+  {{ "  " * level }}  .. code-block::
 
-      {%- if _sample -%}
-      {% if _type != 'str' and _type != 'int' %}
+  {{ "  " * level }}      {{ _sample | tojson }}
+{%       else %}
+  {{ "  " * level }}| **sample**: {{ _sample }}
+{%       endif %}
+{%     endif %}
+{%     if _contains %}
+{{ result_generation(_contains, level + 1) }}
+{%     endif %}
+{%   endfor %}
+{% endmacro %}
 
-      {{ "  " * level }}| **sample**:
-
-              .. code-block::
-
-                       {{ _sample | tojson }}
-      {% else %}
-
-      {{ "  " * level }}| **sample**: {{ _sample }}
-
-      {% endif %}
-      {% endif %}
-
-      {% if _contains %}
-        {{ result_generation(_contains, level + 1) }}
-      {% endif %}
-
-      {% endfor  %}
-  {% endmacro %}
 {# ------------------------------------------------------------- #}
 {# Generate the return values doc                                #}
 {# ------------------------------------------------------------- #}
 
-{% if returndocs -%}
+{% if returndocs %}
 Return Values
 -------------
 
-{{ result_generation(returndocs,1) }}
+{{ result_generation(returndocs, 0) }}
 {% endif %}
-

--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -153,14 +153,30 @@ See Also
 {%     endif %}
   {{ "  " * level }}| **type**: {{ _type }}
 {%     if _sample %}
-{%       if _type != 'str' and _type != 'int' %}
+{%       if _sample.sample1 %}
+  {{ "  " * level }}| **sample**:
+{%         for _samplex in _sample %}
+{%           if _type != 'str' and _type != 'int' %}
+
+  {{ "  " * level }}  .. code-block::
+
+  {{ "  " * level }}      {{ _sample[_samplex] | tojson }}
+{%           else %}
+
+  {{ "  " * level }}  {{ _sample[_samplex] }}
+{%           endif %}
+{%         endfor %}
+
+{%       else %}
+{%         if _type != 'str' and _type != 'int' %}
   {{ "  " * level }}| **sample**:
 
   {{ "  " * level }}  .. code-block::
 
   {{ "  " * level }}      {{ _sample | tojson }}
-{%       else %}
+{%         else %}
   {{ "  " * level }}| **sample**: {{ _sample }}
+{%         endif %}
 {%       endif %}
 {%     endif %}
 {%     if _contains %}

--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -158,9 +158,9 @@ See Also
 {%         for _samplex in _sample %}
 {%           if _type != 'str' and _type != 'int' %}
 
-  {{ "  " * level }}  .. code-block::
+  {{ "  " * level }}  .. code-block:: json
 
-  {{ "  " * level }}      {{ _sample[_samplex] | tojson }}
+  {{ "  " * level }}      {{ _sample[_samplex] | tojson(4) | indent(2*level+8) }}
 {%           else %}
 
   {{ "  " * level }}  {{ _sample[_samplex] }}
@@ -171,9 +171,9 @@ See Also
 {%         if _type != 'str' and _type != 'int' %}
   {{ "  " * level }}| **sample**:
 
-  {{ "  " * level }}  .. code-block::
+  {{ "  " * level }}  .. code-block:: json
 
-  {{ "  " * level }}      {{ _sample | tojson }}
+  {{ "  " * level }}      {{ _sample | tojson(4) | indent(2*level+8) }}
 {%         else %}
   {{ "  " * level }}| **sample**: {{ _sample }}
 {%         endif %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #228:

The current module template generates long single-line JSON representations of sample values of return value properties. This change formats them as multi-line JSOn with an indentation of 4.
    
The code-block used for these JSOn samples is marked up to have json content, producing a nicer coloring of the samples.
 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

* docs/templates/module.rst.j2

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

**Note:** This PR is on top of PR #225 to avoid merge conflicts.
