### PR TITLE
Add support to template to skip options that begin with an underscore

### DIFF
--- a/docs/templates/module.rst.j2
+++ b/docs/templates/module.rst.j2
@@ -50,7 +50,7 @@ Synopsis
 {% macro option_generation(opts, level) %}
 {# Control the order of options: true: ordered by name; false: keep source order #}
 {%   set sorted = false %}
-{%   for name, spec in (opts | dictsort if sorted else opts.items()) %}
+{%   for name, spec in (opts | dictsort if sorted else opts.items()) if not name.startswith('_') %}
 
 {{ "  " * level }}{{ name }}
 {%     for para in spec.description %}


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
This update allows for documentation on options to be skipped such that no documentation is generated for a module. This can come in handy in cases where we want to avoid displaying an option in our HTML docs. Although, this does nothing in terms of ansible_doc as the option will still show up with `ansible-doc` but we predict that most if not all of our users are using our online docs and not the command line. 

##### ISSUE TYPE
- Docs Pull Request
