### PR TITLE
Enhancement/3729

### DIFF
--- a/docs/scripts/role-sample-gen.sh
+++ b/docs/scripts/role-sample-gen.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 ################################################################################
 # © Copyright IBM Corporation 2020
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -497,7 +497,7 @@ class BetterArgHandler(object):
             IGNORECASE,
         ):
             content_path = str(contents)
-            if content_path.startswith('~'):
+            if content_path.startswith("~"):
                 content_path = path.expanduser(content_path)
 
             if not path.isabs(content_path):
@@ -520,7 +520,7 @@ class BetterArgHandler(object):
         Returns:
             str -- The arguments contents after any necessary operations.
         """
-        if not fullmatch(r"^[A-Z0-9-]{2,}$", str(contents), IGNORECASE):
+        if not fullmatch(r"^[A-Z0-9-_.]{2,}$", str(contents), IGNORECASE):
             raise ValueError(
                 'Invalid argument "{0}" for type "encoding".'.format(contents)
             )

--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -520,7 +520,7 @@ class BetterArgHandler(object):
         Returns:
             str -- The arguments contents after any necessary operations.
         """
-        if not fullmatch(r"^[A-Z0-9-_.]{2,}$", str(contents), IGNORECASE):
+        if not fullmatch(r"^[A-Z0-9-]{2,}$", str(contents), IGNORECASE):
             raise ValueError(
                 'Invalid argument "{0}" for type "encoding".'.format(contents)
             )

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -191,8 +191,6 @@ def parse_params(params):
 
 
 def run_operator_command(params):
-    ## remove reset sequence... the value resets when the script ends.
-
     # Usage: (rexfile) delay reset command [parameters] [-v] [-d] [-s]
     #       -v: print out verbose security information
     #       -d: print out debug messages

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -171,7 +171,7 @@ def run_module():
         result["rc"] = rc_message.get("rc")
         result["content"] = rc_message.get("message").split("\n")
         if result["rc"] == 0:
-          if( len(result["content"] > 2 ):
+          if( len(result["content"] > 2 )):
               if "INVALID" not in result["content"][2]:
                   if "ERROR" note in result["content"][2]:
                     result["changed"] = True

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -171,10 +171,10 @@ def run_module():
         result["rc"] = rc_message.get("rc")
         result["content"] = rc_message.get("message").split("\n")
         if result["rc"] == 0:
-          if( len(result["content"] > 2 )):
-              if "INVALID" not in result["content"][2]:
-                  if "ERROR" note in result["content"][2]:
-                    result["changed"] = True
+            if len(result["content"] > 2):
+                if "INVALID" not in result["content"][2]:
+                    if "ERROR" not in result["content"][2]:
+                        result["changed"] = True
     except Error as e:
         module.fail_json(msg=repr(e), **result)
     except Exception as e:

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -37,7 +37,8 @@ options:
     default: false
   wait_time_s:
     description:
-      - Set maximum time in seconds to wait for the commands to execute. 0=use defailt.
+      - Set maximum time in seconds to wait for the commands to execute.
+      - When set to 0, the system default is used.
       - This option is helpful on a busy system needing more time to execute commands.
       - Setting I(wait) can instruct if execution should wait the full I(wait_time_s).
     type: int

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -194,8 +194,9 @@ def run_operator_command(params):
     script="""/*rexx*/
 Address 'TSO'
 IsfRC = isfcalls( "ON" )
-if __argv.0 < 3 then
+if __argv.0 < 4 then
   do
+    say "locount"
     call usage
   end
 dumpit = 0
@@ -222,23 +223,29 @@ do ix = 5 to 8
           end
 
         otherwise
+          say "c = " c
           call usage
         end
     end
 end
 ISFDELAY=__argv.2
-resetval=__argv.3
-
-if POS(',', __argv.4 ) > 0 then
+sdsfcmd = False
+fwd = WORD(__argv.4, 1)
+ffwd = translate(fwd)
+if( ffwd == 'QUERY' | ffwd == 'SET' | ffwd == 'WHO') then
   do
-    address SDSF "ISFEXEC '/"__argv.4"'" verbose
+    sdsfcmd = True
   end
-else
+if sdsfcmd == True then
   do
     address SDSF "ISFEXEC " __argv.4 verbose
   end
+else
+  do
+    address SDSF "ISFEXEC '/"__argv.4"'" verbose
+  end
 saverc = rc
-ISFDELAY=resetval
+ISFDELAY=__argv.3
 IsfRC = isfcalls( "OFF" )
 trace Off
 SAY "===================="
@@ -274,7 +281,7 @@ if dumpit > 0 then
 EXIT saverc
 
 usage:
-    say "Usage: " __argv.1 " delay command [parameters] [-v] [-d] [-s]"
+    say "Usage: " __argv.1 " delay reset command [parameters] [-v] [-d] [-s]"
     say "       -v: print out verbose security information"
     say "       -d: print out debug messages"
     say "       -s: pass (verbose) to the sdsf command"

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -29,9 +29,12 @@ options:
     required: true
   verbose:
     description:
-      - Return diagnostic messages that lists and describes the execution of the operator commands.
-      - Return security trace messages that help you understand and diagnose the execution of the operator commands
-      - Return trace instructions displaying how the the command's operation is read, evaluated and executed.
+      - Return diagnostic messages that lists and describes the execution of the
+        operator commands.
+      - Return security trace messages that help you understand and diagnose the
+        execution of the operator commands
+      - Return trace instructions displaying how the the command's operation is
+        read, evaluated and executed.
     type: bool
     required: false
     default: false
@@ -39,15 +42,19 @@ options:
     description:
       - Set maximum time in seconds to wait for the commands to execute.
       - When set to 0, the system default is used.
-      - This option is helpful on a busy system needing more time to execute commands.
-      - Setting I(wait) can instruct if execution should wait the full I(wait_time_s).
+      - This option is helpful on a busy system needing more time to execute
+        commands.
+      - Setting I(wait) can instruct if execution should wait the
+        full I(wait_time_s).
     type: int
     required: false
     default: 0
   wait:
     description:
-      - Specify to wait the full I(wait_time_s) interval before retrieving responses.
-      - This option is recommended to ensure the responses are accessible and captured by logging facilities and the I(verbose) option.
+      - Specify to wait the full I(wait_time_s) interval before retrieving
+        responses.
+      - This option is recommended to ensure the responses are accessible and
+        captured by logging facilities and the I(verbose) option.
       - I(delay=True) waits the full I(wait_time_s) interval.
       - I(delay=False) returns as soon as the first command executes.
     type: bool

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -175,6 +175,21 @@ def run_module():
                 if "INVALID" not in result["content"][3]:
                     if "ERROR" not in result["content"][3]:
                         result["changed"] = True
+                    else:
+                        module.fail_json(
+                            msg="Error detected: " + result["content"][3], **result
+                        )
+                else:
+                    module.fail_json(
+                        msg="Invalid detected: " + result["content"][3], **result
+                    )
+            else:
+                module.fail_json(msg="Too little response text", **result)
+        else:
+            module.fail_json(
+                msg="Non-0 response from launch script: " + str(result["rc"]), **result
+            )
+
     except Error as e:
         module.fail_json(msg=repr(e), **result)
     except Exception as e:

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -176,16 +176,20 @@ def run_module():
                     if "ERROR" not in result["content"][3]:
                         result["changed"] = True
                     else:
+                        result["exception"] = "Error detected: " + result["content"][3]
                         module.fail_json(
                             msg="Error detected: " + result["content"][3], **result
                         )
                 else:
+                    result["exception"] = "Invalid detected: " + result["content"][3]
                     module.fail_json(
                         msg="Invalid detected: " + result["content"][3], **result
                     )
             else:
+                result["exception"] = "Too little response text"
                 module.fail_json(msg="Too little response text", **result)
         else:
+            result["exception"] = "Non-0 response from launch script"
             module.fail_json(
                 msg="Non-0 response from launch script: " + str(result["rc"]), **result
             )

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -172,19 +172,16 @@ def run_module():
         result["content"] = rc_message.get("message").split("\n")
         if result["rc"] == 0:
             if len(result["content"]) > 3:
-                if "INVALID" not in result["content"][3]:
-                    if "ERROR" not in result["content"][3]:
+                respline = result["content"][2]
+                if "INVALID" not in respline:
+                    if "ERROR" not in respline:
                         result["changed"] = True
                     else:
-                        result["exception"] = "Error detected: " + result["content"][3]
-                        module.fail_json(
-                            msg="Error detected: " + result["content"][3], **result
-                        )
+                        result["exception"] = "Error detected: " + respline
+                        module.fail_json(msg="Error detected: " + respline, **result)
                 else:
-                    result["exception"] = "Invalid detected: " + result["content"][3]
-                    module.fail_json(
-                        msg="Invalid detected: " + result["content"][3], **result
-                    )
+                    result["exception"] = "Invalid detected: " + respline
+                    module.fail_json(msg="Invalid detected: " + respline, **result)
             else:
                 result["exception"] = "Too little response text"
                 module.fail_json(msg="Too little response text", **result)
@@ -324,7 +321,7 @@ EXIT saverc
 
     rc, stdout, stderr = module.run_command(tmp_file.name + fulline)
 
-    message = "running " + fulline + "\n" + stdout + stderr
+    message = stdout + stderr + "\n" + "Ran " + fulline + "\n"
 
     if rc > 0:
         raise OperatorCmdError(fulline, rc, message.split("\n") if message else message)

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -171,7 +171,10 @@ def run_module():
         result["rc"] = rc_message.get("rc")
         result["content"] = rc_message.get("message").split("\n")
         if result["rc"] == 0:
-            result["changed"] = True
+          if( len(result["content"] > 2 ):
+              if "INVALID" not in result["content"][2]:
+                  if "ERROR" note in result["content"][2]:
+                    result["changed"] = True
     except Error as e:
         module.fail_json(msg=repr(e), **result)
     except Exception as e:

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -191,7 +191,7 @@ def parse_params(params):
 
 
 def run_operator_command(params):
-    script="""/*rexx*/
+    script = """/*rexx*/
 Address 'TSO'
 IsfRC = isfcalls( "ON" )
 if __argv.0 < 4 then
@@ -295,11 +295,11 @@ usage:
     fulline += "\"" + params.get("cmd") + "\""
 
     if params.get("verbose"):
-      fulline += " -v"
+        fulline += " -v"
     if params.get("debug"):
-      fulline += " -d"
+        fulline += " -d"
     if params.get("security"):
-      fulline += " -s"
+        fulline += " -s"
 
     delete_on_close = True
     tmp_file = NamedTemporaryFile(delete=delete_on_close)

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -170,13 +170,15 @@ def run_module():
         rc_message = run_operator_command(new_params)
         result["rc"] = rc_message.get("rc")
         result["content"] = rc_message.get("message").split("\n")
+        if result["rc"] == 0:
+            result["changed"] = True
     except Error as e:
         module.fail_json(msg=repr(e), **result)
     except Exception as e:
         module.fail_json(
             msg="An unexpected error occurred: {0}".format(repr(e)), **result
         )
-    result["changed"] = True
+
     module.exit_json(**result)
 
 
@@ -301,7 +303,6 @@ EXIT saverc
     rc, stdout, stderr = module.run_command(tmp_file.name + fulline)
 
     message = "running " + fulline + "\n" + stdout + stderr
-    rc = 0
 
     if rc > 0:
         raise OperatorCmdError(fulline, rc, message.split("\n") if message else message)

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -171,9 +171,9 @@ def run_module():
         result["rc"] = rc_message.get("rc")
         result["content"] = rc_message.get("message").split("\n")
         if result["rc"] == 0:
-            if len(result["content"]) > 2:
-                if "INVALID" not in result["content"][2]:
-                    if "ERROR" not in result["content"][2]:
+            if len(result["content"]) > 3:
+                if "INVALID" not in result["content"][3]:
+                    if "ERROR" not in result["content"][3]:
                         result["changed"] = True
     except Error as e:
         module.fail_json(msg=repr(e), **result)

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -183,10 +183,8 @@ def run_module():
                     result["exception"] = "Invalid detected: " + respline
                     module.fail_json(msg="Invalid detected: " + respline, **result)
             else:
-                result["exception"] = "Too little response text"
                 module.fail_json(msg="Too little response text", **result)
         else:
-            result["exception"] = "Non-0 response from launch script"
             module.fail_json(
                 msg="Non-0 response from launch script: " + str(result["rc"]), **result
             )

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -43,15 +43,15 @@ options:
     type: int
     required: false
     default: 0
-    wait:
-      description:
-        - Specify to wait the full I(wait_time_s) interval before retrieving responses.
-        - This option is recommended to ensure the responses are accessible and captured by logging facilities and the I(verbose) option.
-        - I(delay=True) waits the full I(wait_time_s) interval.
-        - I(delay=False) returns as soon as the first command executes.
-      type: bool
-      required: false
-      default: true
+  wait:
+    description:
+      - Specify to wait the full I(wait_time_s) interval before retrieving responses.
+      - This option is recommended to ensure the responses are accessible and captured by logging facilities and the I(verbose) option.
+      - I(delay=True) waits the full I(wait_time_s) interval.
+      - I(delay=False) returns as soon as the first command executes.
+    type: bool
+    required: false
+    default: true
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -171,7 +171,7 @@ def run_module():
         result["rc"] = rc_message.get("rc")
         result["content"] = rc_message.get("message").split("\n")
         if result["rc"] == 0:
-            if len(result["content"] > 2):
+            if len(result["content"]) > 2:
                 if "INVALID" not in result["content"][2]:
                     if "ERROR" not in result["content"][2]:
                         result["changed"] = True

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -195,7 +195,11 @@ def run_operator_command(params):
     #       -n: nowait
 
     script = """/*rexx*/
-arg wait_time command verbosemode nowait
+wait_time = __argv.2
+command = __argv.3
+verbosemode = __argv.4
+nowait = __argv.5
+
 Address 'TSO'
 IsfRC = isfcalls( "ON" )
 showoutput = 0
@@ -206,10 +210,14 @@ if nowait == "NOWAIT" then do
 
 verbose = ""
 if verbosemode == "VERB" then do
-  say "Showing Security and Verbose Messages"
   showoutput = 1
   ISFSECTRACE="ON"
   verbose = "( VERBOSE" waitmsg ")"
+  end
+else do
+  if waitmsg == " WAIT" then do
+    verbose = "( WAIT )"
+    end
   end
 
 if wait_time > 0 then do
@@ -217,10 +225,6 @@ if wait_time > 0 then do
   end
 
 sdsfcmd = False
-
-if verbose == "" and waitmsg == " WAIT" then do
-  verbose = "( WAIT )"
-  end
 
 fwd = WORD(command, 1)
 ffwd = translate(fwd)
@@ -240,20 +244,16 @@ saverc = rc
 
 IsfRC = isfcalls( "OFF" )
 trace Off
-if isfresp.0 > 0 then
-  do
-    say ""
-    say "Responses"
-    do ix=1 to isfresp.0
-      say isfresp.ix
-    end
-  end
 if isfulog.0 > 0 then
   do
-    say ""
-    say "Log Output"
     do ix=1 to isfulog.0
       say isfulog.ix
+    end
+  end
+if isfresp.0 > 0 then
+  do
+    do ix=1 to isfresp.0
+      say isfresp.ix
     end
   end
 if showoutput > 0 then

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -25,7 +25,7 @@ def test_zos_operator_various_command(ansible_zos_module):
         ("k s", 0, True),
         ("d r,l", 0, True),
         ("d parmlib", 0, True),
-        ("SEND 'list ready',NOW", 0, True)
+        ("SEND 'list ready',NOW", 0, True),
     ]
     for item in test_data:
         command = item[0]
@@ -34,13 +34,13 @@ def test_zos_operator_various_command(ansible_zos_module):
         hosts = ansible_zos_module
         results = hosts.all.zos_operator(cmd=command)
         for result in results.contacted.values():
-            assert result['rc'] == expected_rc
+            assert result["rc"] == expected_rc
             assert result.get("changed") is changed
 
 
 def test_zos_operator_invalid_command(ansible_zos_module):
     hosts = ansible_zos_module
-    results = hosts.all.zos_operator(cmd='invalid,command', verbose=False, debug=False)
+    results = hosts.all.zos_operator(cmd="invalid,command", verbose=False, debug=False)
     for result in results.contacted.values():
         assert result.get("changed") is False
         assert result.get("exception") is not None
@@ -48,35 +48,35 @@ def test_zos_operator_invalid_command(ansible_zos_module):
 
 def test_zos_operator_positive_path(ansible_zos_module):
     hosts = ansible_zos_module
-    results = hosts.all.zos_operator(cmd='d u,all', verbose=False, debug=False)
+    results = hosts.all.zos_operator(cmd="d u,all", verbose=False)
     for result in results.contacted.values():
-        assert result['rc'] == 0
+        assert result["rc"] == 0
         assert result.get("changed") is True
         assert result.get("content") is not None
 
 
 def test_zos_operator_positive_path_verbose(ansible_zos_module):
     hosts = ansible_zos_module
-    results = hosts.all.zos_operator(cmd='d u,all', verbose=True, debug=False)
+    results = hosts.all.zos_operator(cmd="d u,all", verbose=True)
     for result in results.contacted.values():
-        assert result['rc'] == 0
+        assert result["rc"] == 0
         assert result.get("changed") is True
         assert result.get("content") is not None
 
 
-def test_zos_operator_positive_with_debug(ansible_zos_module):
+def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
     hosts = ansible_zos_module
-    results = hosts.all.zos_operator(cmd='d u,all', verbose=False, debug=True)
+    results = hosts.all.zos_operator(cmd="d u,all", verbose=True, delay=5, rapid=False)
     for result in results.contacted.values():
-        assert result['rc'] == 0
+        assert result["rc"] == 0
         assert result.get("changed") is True
         assert result.get("content") is not None
 
 
-def test_zos_operator_positive_with_debug_verbose(ansible_zos_module):
+def test_zos_operator_positive_verbose_with_quick_delay(ansible_zos_module):
     hosts = ansible_zos_module
-    results = hosts.all.zos_operator(cmd='d u,all', verbose=True, debug=True)
+    results = hosts.all.zos_operator(cmd="d u,all", verbose=True, delay=8, rapid=True)
     for result in results.contacted.values():
-        assert result['rc'] == 0
+        assert result["rc"] == 0
         assert result.get("changed") is True
         assert result.get("content") is not None

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -10,6 +10,7 @@ __metaclass__ = type
 import os
 import sys
 import warnings
+import time
 
 import ansible.constants
 import ansible.errors
@@ -40,7 +41,7 @@ def test_zos_operator_various_command(ansible_zos_module):
 
 def test_zos_operator_invalid_command(ansible_zos_module):
     hosts = ansible_zos_module
-    results = hosts.all.zos_operator(cmd="invalid,command", verbose=False, debug=False)
+    results = hosts.all.zos_operator(cmd="invalid,command", verbose=False)
     for result in results.contacted.values():
         assert result.get("changed") is False
         assert result.get("exception") is not None
@@ -66,7 +67,13 @@ def test_zos_operator_positive_path_verbose(ansible_zos_module):
 
 def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
     hosts = ansible_zos_module
-    results = hosts.all.zos_operator(cmd="d u,all", verbose=True, delay=5, rapid=False)
+    startmod = time.time()
+    results = hosts.all.zos_operator(
+        cmd="d u,all", verbose=True, wait_time_s=5, wait=True
+    )
+    endmod = time.time()
+    timediff = endmod - startmod
+    assert timediff > 4
     for result in results.contacted.values():
         assert result["rc"] == 0
         assert result.get("changed") is True
@@ -75,7 +82,13 @@ def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
 
 def test_zos_operator_positive_verbose_with_quick_delay(ansible_zos_module):
     hosts = ansible_zos_module
-    results = hosts.all.zos_operator(cmd="d u,all", verbose=True, delay=8, rapid=True)
+    startmod = time.time()
+    results = hosts.all.zos_operator(
+        cmd="d u,all", verbose=True, wait_time_s=8, wait=False
+    )
+    endmod = time.time()
+    timediff = endmod - startmod
+    assert timediff < 5
     for result in results.contacted.values():
         assert result["rc"] == 0
         assert result.get("changed") is True

--- a/tests/unit/test_zos_operator_unit.py
+++ b/tests/unit/test_zos_operator_unit.py
@@ -31,9 +31,7 @@ dummy_dict3 = {"cmd": "d u,all"}
 
 dummy_dict4 = {"cmd": "d u,all", "verbose": True}
 
-dummy_dict5 = {
-    "cmd": "d u,all",
-}
+dummy_dict5 = {"cmd": "d u,all", "verbose": "NotTrueOrFalse"}
 
 dummy_return_dict1 = {"rc": 0, "message": "good result"}
 

--- a/tests/unit/test_zos_operator_unit.py
+++ b/tests/unit/test_zos_operator_unit.py
@@ -13,52 +13,38 @@ import sys
 from mock import call
 
 # Used my some mock modules, should match import directly below
-IMPORT_NAME = 'ibm_zos_core.plugins.modules.zos_operator'
+IMPORT_NAME = "ibm_zos_core.plugins.modules.zos_operator"
 
 
 # * Tests for zos_operator
 
 dummy_dict1 = {
-    'verbose': False,
-    'debug': True
+    "verbose": False,
 }
 
 dummy_dict2 = {
-    'cmd': 123,
-    'verbose': True,
-    'debug': False
+    "cmd": 123,
+    "verbose": True,
 }
 
-dummy_dict3 = {
-    'cmd': 'd u,all'
-}
+dummy_dict3 = {"cmd": "d u,all"}
 
-dummy_dict4 = {
-    'cmd': 'd u,all',
-    'verbose': True
-}
+dummy_dict4 = {"cmd": "d u,all", "verbose": True}
 
 dummy_dict5 = {
-    'cmd': 'd u,all',
-    'debug': 123
+    "cmd": "d u,all",
 }
 
-dummy_return_dict1 = {
-    'rc': 0,
-    'message': 'good result'
-}
+dummy_return_dict1 = {"rc": 0, "message": "good result"}
 
-dummy_return_dict2 = {
-    'rc': 1,
-    'message': None
-}
+dummy_return_dict2 = {"rc": 1, "message": None}
 
 test_data = [
     (dummy_dict1, False),
     (dummy_dict2, False),
     (dummy_dict3, True),
     (dummy_dict4, True),
-    (dummy_dict5, False)
+    (dummy_dict5, False),
 ]
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This was changing the zos_operator to use a rexx sript, so it could follow an optionally provided delay time.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_operator

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Execute operator command to show jobs. Wait for 7 seconds, then reset delay to 2 seconds
  zos_operator:
    cmd: 'd u,all'
    delay: 7
    reset: 2
```
