### PR TITLE
Remove deprecated ansible_metadata blocks from all modules per Ansible…

### DIFF
--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -7,9 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'comminuty'}
 
 DOCUMENTATION = r'''
 ---

--- a/plugins/modules/zos_backup_restore.py
+++ b/plugins/modules/zos_backup_restore.py
@@ -7,12 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "community",
-}
-
 
 DOCUMENTATION = r"""
 module: zos_backup_restore

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -7,9 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['stableinterface'],
-                    'supported_by': 'comminuty'}
 
 DOCUMENTATION = r'''
 ---

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -7,11 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["stableinterface"],
-    "supported_by": "community",
-}
 
 DOCUMENTATION = r"""
 ---

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["stableinterface"],
-    "supported_by": "community",
-}
 
 DOCUMENTATION = r"""
 module: zos_data_set

--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["stableinterface"],
-    "supported_by": "community",
-}
 
 DOCUMENTATION = r"""
 module: zos_encode

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -7,12 +7,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["stableinterface"],
-    "supported_by": "community",
-}
-
 
 DOCUMENTATION = r"""
 ---

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -7,9 +7,6 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['stableinterface'],
-                    'supported_by': 'community'}
 
 DOCUMENTATION = r"""
 ---

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["stableinterface"],
-    "supported_by": "community",
-}
 
 DOCUMENTATION = r"""
 ---

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["stableinterface"],
-    "supported_by": "community",
-}
 
 DOCUMENTATION = r"""
 ---

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["stableinterface"],
-    "supported_by": "community",
-}
 
 DOCUMENTATION = r"""
 module: zos_job_submit

--- a/plugins/modules/zos_lineinfile.py
+++ b/plugins/modules/zos_lineinfile.py
@@ -8,10 +8,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 
 DOCUMENTATION = r"""
 ---

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["stableinterface"],
-    "supported_by": "community",
-}
 
 DOCUMENTATION = r"""
 module: zos_mvs_raw

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["stableinterface"],
-    "supported_by": "community",
-}
 
 DOCUMENTATION = r"""
 ---

--- a/plugins/modules/zos_operator_action_query.py
+++ b/plugins/modules/zos_operator_action_query.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["stableinterface"],
-    "supported_by": "community",
-}
 
 DOCUMENTATION = r"""
 ---

--- a/plugins/modules/zos_ping.rexx
+++ b/plugins/modules/zos_ping.rexx
@@ -5,9 +5,7 @@
 /* Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0) */
 
 /*
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+
 
 DOCUMENTATION = '''
 ---

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -8,11 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "community",
-}
 
 DOCUMENTATION = r"""
 module: zos_tso_command


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
When following the noted JIRAs below, Ansible decided that **ANSIBLE_METADATA** is no longer required.

Today, the `ansible-sanity` tests permit the inclusion of **ANSIBLE_METADATA**  but in the future it may not be permitted. To prepare for future restrictions, we will remove them now. 

Adheres to changing direction in related issues [57](https://github.com/ansible-collections/overview/issues/57) and [69454](https://github.com/ansible/ansible/pull/69454)

##### ISSUE TYPE
- Update Module Pull Request

