### PR TITLE
Updated build_ignore for Ansible 2.10 readiness and additional updates

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: ibm
 name: ibm_zos_core
 
 # The collection version
-version: 1.3.0-beta.1
+version: 1.3.0-beta.2
 
 # Collection README file
 readme: README.md
@@ -23,6 +23,7 @@ authors:
   - Behnam Al Kajbaf <behnam@ibm.com>
   - Andrew Nguyen <andy.nguyen@ibm.com>
   - Radha Varadachari <radha.varadachari@ibm.com>
+  - Rich Parker <richp@ibm.com>
 
 # Description
 description: The IBM z/OS core collection includes connection plugins, action plugins, modules, filters, sample playbooks and ansible-doc to automate tasks on z/OS.
@@ -66,8 +67,10 @@ issues: https://github.com/ansible-collections/ibm_zos_core/issues
 
 # Ignore files and directories matching the following patterns
 build_ignore:
-  - Dockerfile
-  - Jenkinsfile
-  - yamllint.yaml
   - ansible.cfg
   - .gitignore
+  - .github
+  - '*.tar.gz'
+  - tests
+  - docs
+  - collections


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
Ansible 2.10 adoption will only be a matter of time; this change leverages the upcoming build_ignore for directories and files, long anticipated. This update will not impact builds performed on ansible 2.9. 

This update will not benefit collections built with Ansible 2.9.x but as the pull request states, it is 'readiness' for Ansible 2.10.

Our Ansible Z collections for both Galaxy and Hub are **currently built on 2.9.x** to **remain compatible** with Ansible Hub requirements. 

**NOTE**: We have been seeing this warning since we began using build_ignore to exclude files for a year now. The warning causes no issues for builds done with Ansible 2.9.x which is when it appears and my guess it is because build_ignore is officially supported in Ansible 2.10.

```
[WARNING]: Found unknown keys in collection galaxy.yml at '/Users/ddimatos/git/github/ibm_zos_core/galaxy.yml': build_ignore
```
##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION
For further validation:
- I have left the prior collection archive and built a new one, the `*.tar.gz` omitting is working.
- I have omitted directories:
   `.github`
   `tests`
   `docs`
   `collections`
- I have omitted files:
    `ansible.cfg`
    `.gitignore`
    `*.tar.gz`

In the prior builds, `ibm-ibm_zos_core-1.3.0-beta.1` you will see the the omitted folders were distributed in the release:
<img width="494" alt="image" src="https://user-images.githubusercontent.com/25803172/102644768-363d3900-4116-11eb-81e5-0a28ada48be9.png">

In new builds using Ansible 2.10 and this updated galaxy.yml you will see that the older *.tar.gz and the omitted directories were not included in the galaxy archive (desirable results):
<img width="547" alt="image" src="https://user-images.githubusercontent.com/25803172/102644891-700e3f80-4116-11eb-975f-88ada4953f7b.png">

Note: Omitted **directories** and **files** will still appear if built on  Ansible 2.9.x even if you identify directories to be omitted, its officially supported in Ansbile 2.10. 

##### SCENARIOS TESTED:

**Build with 2.10.4 and force install:**
```
(venv) ansible-galaxy collection build
Created collection for ibm.ibm_zos_core at /Users/ddimatos/git/github/ibm_zos_core/ibm-ibm_zos_core-1.3.0-beta.2.tar.gz
(venv) ansible-galaxy collection install -f ibm-ibm_zos_core-1.3.0-beta.2.tar.gz
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Installing 'ibm.ibm_zos_core:1.3.0-beta.2' to '/Users/ddimatos/.ansible/collections/ansible_collections/ibm/ibm_zos_core'
ibm.ibm_zos_core (1.3.0-beta.2) was installed successfully
````
1. Built `ibm_zos_core` with **Ansbile 2.10.4** and **ran** playbooks with controller **Ansible 2.9.6** - **SUCCESS**
   - `ansible-playbook -i inventory zos-collection-sample-v2-v110.yaml`
<img width="998" alt="image" src="https://user-images.githubusercontent.com/25803172/102647925-72bf6380-411b-11eb-8a10-8b30571dfe87.png">

2. Built `ibm_zos_core` with **Ansbile 2.10.4** and **ran** playbooks with controller **Ansible 2.10.4** - **SUCCESS**
<img width="910" alt="image" src="https://user-images.githubusercontent.com/25803172/102648792-fded2900-411c-11eb-83c5-f23601951a5a.png">

**Build with 2.9.6 and force install:**
```
ddimatos:[ ~/git/github/ibm_zos_core ]ansible --version
ansible 2.9.6
  config file = /Users/ddimatos/git/github/ibm_zos_core/ansible.cfg
  configured module search path = [u'/Users/ddimatos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.16 (default, Feb 29 2020, 01:55:37) [GCC 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.29.20) (-macos10.15-objc-
ddimatos:[ ~/git/github/ibm_zos_core ]ansible-galaxy collection build
[WARNING]: Found unknown keys in collection galaxy.yml at '/Users/ddimatos/git/github/ibm_zos_core/galaxy.yml': build_ignore
Created collection for ibm.ibm_zos_core at /Users/ddimatos/git/github/ibm_zos_core/ibm-ibm_zos_core-1.3.0-beta.2.tar.gz
ddimatos:[ ~/git/github/ibm_zos_core ] ansible-galaxy collection install -f ibm-ibm_zos_core-1.3.0-beta.2.tar.gz
Process install dependency map
Starting collection install process
Installing 'ibm.ibm_zos_core:1.3.0-beta.2' to '/Users/ddimatos/.ansible/collections/ansible_collections/ibm/ibm_zos_core'
ddimatos:[ ~/git/github/ibm_zos_core ]
```
3. Built `ibm_zos_core` with **Ansbile 2.9.6** and **ran** playbooks with controller **Ansible 2.9.6**  - **SUCCESS**
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/25803172/102650779-4528e900-4120-11eb-8158-36e764ba2d90.png">

4. Built `ibm_zos_core` with **Ansbile 2.9.6** and **ran** playbooks with controller **Ansible 2.10.4**  - **SUCCESS**
<img width="921" alt="image" src="https://user-images.githubusercontent.com/25803172/102649927-e878fe80-411e-11eb-9881-b59adde7f136.png">




