### PR TITLE
Added Jenkinsfile to the ignore to exclude from collection builds

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -67,6 +67,7 @@ issues: https://github.com/ansible-collections/ibm_zos_core/issues
 
 # Ignore files and directories matching the following patterns
 build_ignore:
+  - Jenkinsfile
   - ansible.cfg
   - .gitignore
   - .github


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
Updating the galaxy.yml to ensure the Jenkinsfile is not included in our collection builds. Note; this will only be true if we build with Ansible 2.10 were `build_ignore` is supported. 

##### ISSUE TYPE
- Docs Pull Request
