### PR TITLE
update ping module with empty options as newest ansible-doc-extrator …

### DIFF
--- a/plugins/modules/zos_ping.rexx
+++ b/plugins/modules/zos_ping.rexx
@@ -31,6 +31,7 @@ description:
 author:
   - "Vijay Katoch"
   - "Blake Becker (@blakeinate)"
+options: {}
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
…requires it

Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
The latest ansible-doc-extractor errors on modules with no options in the ansible doc. Although odd, there are cases this is valid such as in a ping module which has no options. This change adds an empty `option: {}` entry to the module docs to adhere to the requirements. 

##### ISSUE TYPE
- Docs Pull Request
