### PR TITLE
Bugfix/3687

### DIFF
--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -125,6 +125,11 @@ def _parse_jobs(output_str):
                 job["ret_code"]["code"] = _get_return_code_num(ret_code_msg)
                 job["ret_code"]["msg_code"] = _get_return_code_str(ret_code_msg)
                 job["ret_code"]["msg_txt"] = ""
+                if "JCL ERROR" in ret_code_msg:
+                    job["ret_code"][
+                        "msg_txt"
+                    ] = "JCL Error detected.  Check the data dumps for more information."
+
                 if ret_code_msg == "":
                     job["ret_code"]["msg"] = "AC"
 
@@ -454,12 +459,9 @@ def _get_return_code_num(rc_str):
     """
 
     rc = None
-    if "JCL ERROR" in rc_str:
-        rc = 16
-    else:
-        match = re.search(r"\s*CC\s*([0-9]+)", rc_str)
-        if match:
-            rc = int(match.group(1))
+    match = re.search(r"\s*CC\s*([0-9]+)", rc_str)
+    if match:
+        rc = int(match.group(1))
     return rc
 
 

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -445,10 +445,14 @@ def _get_return_code_num(rc_str):
     Returns:
         Union[int, NoneType] -- Returns integer RC if possible, if not returns NoneType
     """
+
     rc = None
-    match = re.search(r"\s*CC\s*([0-9]+)", rc_str)
-    if match:
-        rc = int(match.group(1))
+    if "JCL ERROR" in rc_str:
+        rc = 16
+    else:
+        match = re.search(r"\s*CC\s*([0-9]+)", rc_str)
+        if match:
+            rc = int(match.group(1))
     return rc
 
 

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -467,7 +467,9 @@ def _get_return_code_str(rc_str):
         Union[str, NoneType] -- Returns string RC or ABEND code if possible, if not returns NoneType
     """
     rc = None
-    match = re.search(r"(?:\s*CC\s*([0-9]+))|(?:ABEND\s*((?:S|U)[0-9]+))", rc_str)
+    match = re.search(
+        r"(?:\s*CC\s*([0-9]+))|(?:ABEND\s*((?:S|U)[0-9]+)|(?:JCL ERROR)))", rc_str
+    )
     if match:
         rc = match.group(1) or match.group(2)
     return rc

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -468,7 +468,7 @@ def _get_return_code_str(rc_str):
     """
     rc = None
     match = re.search(
-        r"(?:\s*CC\s*([0-9]+))|(?:ABEND\s*((?:S|U)[0-9]+)|(?:JCL ERROR)))", rc_str
+        r"(?:\s*CC\s*([0-9]+))|(?:ABEND\s*((?:S|U)[0-9]+)|(?:JCL ERROR))", rc_str
     )
     if match:
         rc = match.group(1) or match.group(2)

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -704,12 +704,21 @@ def run_module():
             **result
         )
 
-    callstr = "loc: " + location + "..wait: " + str(wait) + "..src: " + src + "..wts: " = str(wait_time_s)
+    callstr = (
+        "loc: "
+        + str(location)
+        + "..wait: "
+        + str(wait)
+        + "..src: "
+        + src
+        + "..wts: "
+        + str(wait_time_s)
+    )
     if temp_file:
         callstr = callstr + "f1: " + str(temp_file.name)
     if temp_file_2:
         callstr = callstr + "f2: " + str(temp_file_2.name)
-    result["call_set"]  = callstr
+    result["call_set"] = callstr
 
     DSN_REGEX = r"^(?:(?:[A-Z$#@]{1}[A-Z0-9$#@-]{0,7})(?:[.]{1})){1,21}[A-Z$#@]{1}[A-Z0-9$#@-]{0,7}(?:\([A-Z$#@]{1}[A-Z0-9$#@]{0,7}\)){0,1}$"
     try:
@@ -735,11 +744,11 @@ def run_module():
             # added -c to iconv to try and prevent \r from mis-mapping as invalid char to EBCDIC
             to_encoding = encoding.get("to")
             conv_str = "iconv -c -f {0} -t {1} {2} > {3}".format(
-                    from_encoding,
-                    to_encoding,
-                    quote(temp_file),
-                    quote(temp_file_2.name),
-                )
+                from_encoding,
+                to_encoding,
+                quote(temp_file),
+                quote(temp_file_2.name),
+            )
             result["conv_str"] = conv_str
             (conv_rc, stdout, stderr) = module.run_command(
                 conv_str,

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -515,7 +515,7 @@ else:
 POLLING_INTERVAL = 1
 POLLING_COUNT = 60
 
-JOB_COMPLETION_MESSAGES = ["CC", "ABEND", "SEC", "JCL\sERROR"]
+JOB_COMPLETION_MESSAGES = ["CC", "ABEND", "SEC", "JCL ERROR"]
 
 
 def submit_pds_jcl(src, module):

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -847,7 +847,7 @@ def run_module():
                 "stderr": "Submit succeeded, but job failed: " + foundissue
             }
             result["failed"] = True
-            module.fail_json("JCL error", **result)
+            module.fail_json(msg=result["message"], **result)
         else:
             result["message"] = {"stdout": "Submit JCL operation succeeded."}
 

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -13,21 +13,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import, division, print_function
-from ansible.module_utils.six import PY3
-from stat import S_IEXEC, S_IREAD, S_IWRITE
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.encode import (
-    Defaults,
-)
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
-    BetterArgParser,
-)
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import job_output
-from timeit import default_timer as timer
-import re
-from tempfile import NamedTemporaryFile
-from os import chmod, path, remove, stat
-from time import sleep
-from ansible.module_utils.basic import AnsibleModule
 
 __metaclass__ = type
 
@@ -506,6 +491,22 @@ EXAMPLES = r"""
     wait_time_s: 30
 """
 
+from ansible.module_utils.six import PY3
+from stat import S_IEXEC, S_IREAD, S_IWRITE
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.encode import (
+    Defaults,
+)
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
+    BetterArgParser,
+)
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import job_output
+from timeit import default_timer as timer
+import re
+from tempfile import NamedTemporaryFile
+from os import chmod, path, remove, stat
+from time import sleep
+from ansible.module_utils.basic import AnsibleModule
+
 
 if PY3:
     from shlex import quote
@@ -566,8 +567,7 @@ SAY X
     if "Error" in stdout:
         raise SubmitJCLError("SUBMIT JOB FAILED: " + stdout)
     elif "" == stdout:
-        raise SubmitJCLError(
-            "SUBMIT JOB FAILED, NO JOB ID IS RETURNED : " + stdout)
+        raise SubmitJCLError("SUBMIT JOB FAILED, NO JOB ID IS RETURNED : " + stdout)
     jobId = stdout.replace("\n", "").strip()
     return jobId
 
@@ -580,8 +580,7 @@ def copy_rexx_and_run(script, src, vol, module):
     chmod(tmp_file.name, S_IEXEC | S_IREAD | S_IWRITE)
     pathName = path.dirname(tmp_file.name)
     scriptName = path.basename(tmp_file.name)
-    rc, stdout, stderr = module.run_command(
-        ["./" + scriptName, src, vol], cwd=pathName)
+    rc, stdout, stderr = module.run_command(["./" + scriptName, src, vol], cwd=pathName)
     return rc, stdout, stderr
 
 
@@ -664,8 +663,7 @@ def run_module():
             default="DATA_SET",
             choices=["DATA_SET", "USS", "LOCAL"],
         ),
-        from_encoding=dict(arg_type="encoding",
-                           default=Defaults.DEFAULT_ASCII_CHARSET),
+        from_encoding=dict(arg_type="encoding", default=Defaults.DEFAULT_ASCII_CHARSET),
         to_encoding=dict(
             arg_type="encoding", default=Defaults.DEFAULT_EBCDIC_USS_CHARSET
         ),
@@ -784,8 +782,7 @@ def run_module():
             if bool(jot_retcode):
                 job_msg = jot_retcode.get("msg")
                 if re.search(
-                    "^(?:{0})".format(
-                        "|".join(JOB_COMPLETION_MESSAGES)), job_msg
+                    "^(?:{0})".format("|".join(JOB_COMPLETION_MESSAGES)), job_msg
                 ):
                     loopdone = True
                     # if the message doesn't have a CC, it is an improper completion (error/abend)
@@ -801,7 +798,8 @@ def run_module():
                     "stdout": "Submit JCL operation succeeded but it is a long running job, exceeding the timeout of "
                     + str(wait_time_s)
                     + " seconds.  JobID is "
-                    + str(jobId) + ".  Consider using module zos_job_query to poll for long running jobs."
+                    + str(jobId)
+                    + ".  Consider using module zos_job_query to poll for long running jobs."
                 }
             else:
                 sleep(0.5)
@@ -829,7 +827,8 @@ def run_module():
             "stdout": "Submit JCL operation succeeded but it is a long running job, exceeding the timeout of "
             + str(wait_time_s)
             + " seconds.  JobID is "
-            + str(jobId) + ".  Consider using module zos_job_query to poll for long running jobs."
+            + str(jobId)
+            + ".  Consider using module zos_job_query to poll for long running jobs."
         }
     else:
         if foundissue is not None:
@@ -841,7 +840,10 @@ def run_module():
             module.fail_json(msg=result["message"], **result)
         else:
             result["message"] = {
-                "stdout": "Submit JCL operation succeeded with id of " + str(jobId) + "."}
+                "stdout": "Submit JCL operation succeeded with id of "
+                + str(jobId)
+                + "."
+            }
 
     module.exit_json(**result)
 
@@ -852,8 +854,7 @@ class Error(Exception):
 
 class SubmitJCLError(Error):
     def __init__(self, jobs):
-        self.msg = 'An error occurred during submission of jobs "{0}"'.format(
-            jobs)
+        self.msg = 'An error occurred during submission of jobs "{0}"'.format(jobs)
 
 
 def main():

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -221,10 +221,11 @@ jobs:
           description:
              Returns additional information related to the job.
           type: str
-          sample: "No job can be located with this job name: HELLO"
+          sample: "JCL Error detected.  Check the data dumps for more information."
         code:
           description:
              Return code converted to integer value (when possible).
+             For JCL ERRORs, this will be None.
           type: int
           sample: 00
       sample:

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -704,22 +704,6 @@ def run_module():
             **result
         )
 
-    callstr = (
-        "loc: "
-        + str(location)
-        + "..wait: "
-        + str(wait)
-        + "..src: "
-        + src
-        + "..wts: "
-        + str(wait_time_s)
-    )
-    if temp_file:
-        callstr = callstr + "f1: " + str(temp_file)
-    if temp_file_2:
-        callstr = callstr + "f2: " + str(temp_file_2.name)
-    result["call_set"] = callstr
-
     DSN_REGEX = r"^(?:(?:[A-Z$#@]{1}[A-Z0-9$#@-]{0,7})(?:[.]{1})){1,21}[A-Z$#@]{1}[A-Z0-9$#@-]{0,7}(?:\([A-Z$#@]{1}[A-Z0-9$#@]{0,7}\)){0,1}$"
     try:
         if location == "DATA_SET":
@@ -749,7 +733,6 @@ def run_module():
                 quote(temp_file),
                 quote(temp_file_2.name),
             )
-            result["conv_str"] = conv_str
             (conv_rc, stdout, stderr) = module.run_command(
                 conv_str,
                 use_unsafe_shell=True,

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -715,7 +715,7 @@ def run_module():
         + str(wait_time_s)
     )
     if temp_file:
-        callstr = callstr + "f1: " + str(temp_file.name)
+        callstr = callstr + "f1: " + str(temp_file)
     if temp_file_2:
         callstr = callstr + "f2: " + str(temp_file_2.name)
     result["call_set"] = callstr

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -515,7 +515,7 @@ else:
 POLLING_INTERVAL = 1
 POLLING_COUNT = 60
 
-JOB_COMPLETION_MESSAGES = ["CC", "ABEND", "SEC", "JCL ERROR"]
+JOB_COMPLETION_MESSAGES = ["CC", "ABEND", "SEC ERROR", "JCL ERROR"]
 
 
 def submit_pds_jcl(src, module):
@@ -749,7 +749,7 @@ def run_module():
     except SubmitJCLError as e:
         module.fail_json(msg=repr(e), **result)
     if jobId is None or jobId == "":
-        result["job_id"] = "-blank-"
+        result["job_id"] = ""
         module.fail_json(
             msg="JOB ID RETURNED IS None. PLEASE CHECK WHETHER THE JCL IS CORRECT.",
             **result

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -704,6 +704,13 @@ def run_module():
             **result
         )
 
+    callstr = "loc: " + location + "..wait: " + str(wait) + "..src: " + src + "..wts: " = str(wait_time_s)
+    if temp_file:
+        callstr = callstr + "f1: " + str(temp_file.name)
+    if temp_file_2:
+        callstr = callstr + "f2: " + str(temp_file_2.name)
+    result["call_set"]  = callstr
+
     DSN_REGEX = r"^(?:(?:[A-Z$#@]{1}[A-Z0-9$#@-]{0,7})(?:[.]{1})){1,21}[A-Z$#@]{1}[A-Z0-9$#@-]{0,7}(?:\([A-Z$#@]{1}[A-Z0-9$#@]{0,7}\)){0,1}$"
     try:
         if location == "DATA_SET":
@@ -727,13 +734,15 @@ def run_module():
 
             # added -c to iconv to try and prevent \r from mis-mapping as invalid char to EBCDIC
             to_encoding = encoding.get("to")
-            (conv_rc, stdout, stderr) = module.run_command(
-                "iconv -c -f {0} -t {1} {2} > {3}".format(
+            conv_str = "iconv -c -f {0} -t {1} {2} > {3}".format(
                     from_encoding,
                     to_encoding,
                     quote(temp_file),
                     quote(temp_file_2.name),
-                ),
+                )
+            result["conv_str"] = conv_str
+            (conv_rc, stdout, stderr) = module.run_command(
+                conv_str,
                 use_unsafe_shell=True,
             )
             if conv_rc == 0:
@@ -748,7 +757,7 @@ def run_module():
     except SubmitJCLError as e:
         module.fail_json(msg=repr(e), **result)
     if jobId is None or jobId == "":
-        result["job_id"] = jobId
+        result["job_id"] = "-blank-"
         module.fail_json(
             msg="JOB ID RETURNED IS None. PLEASE CHECK WHETHER THE JCL IS CORRECT.",
             **result

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -828,8 +828,6 @@ def run_module():
 
     if temp_file:
         remove(temp_file)
-    if temp_file_2:
-        remove(temp_file_2)
 
     checktime = timer()
     duration = round(checktime - starttime)

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -849,6 +849,7 @@ def run_module():
                 "stderr": "Submit succeeded, but job failed: " + foundissue
             }
             result["failed"] = True
+            module.fail_json("JCL error", **result)
         else:
             result["message"] = {"stdout": "Submit JCL operation succeeded."}
 

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -513,7 +513,7 @@ else:
 POLLING_INTERVAL = 1
 POLLING_COUNT = 60
 
-JOB_COMPLETION_MESSAGES = ["CC", "ABEND", "SEC"]
+JOB_COMPLETION_MESSAGES = ["CC", "ABEND", "SEC", "JCL ERROR"]
 
 
 def submit_pds_jcl(src, module):
@@ -612,7 +612,7 @@ def query_jobs_status(module, jobId):
             )
     if not output and timeout == 0:
         raise SubmitJCLError(
-            "THE JOB CAN NOT BE QUERIED FROM JES (TIMEOUT=10s). PLEASE CHECK THE ZOS SYSTEM. IT IS SLOW TO RESPONSE."
+            "THE JOB CAN NOT BE QUERIED FROM JES (TIMEOUT=10s). PLEASE CHECK THE ZOS SYSTEM. IT IS SLOW TO RESPOND."
         )
     return output
 

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -139,7 +139,6 @@ def test_job_submit_LOCAL(ansible_zos_module):
     results = hosts.all.zos_job_submit(src=tmp_file.name, location="LOCAL", wait=True)
 
     for result in results.contacted.values():
-        print("localgood:{0}".format(result))
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
         assert result.get("jobs")[0].get("ret_code").get("code") == 0
 
@@ -154,7 +153,6 @@ def test_job_submit_LOCAL_extraR(ansible_zos_module):
     results = hosts.all.zos_job_submit(src=tmp_file.name, location="LOCAL", wait=True)
 
     for result in results.contacted.values():
-        print("localexr:{0}".format(result))
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
         assert result.get("jobs")[0].get("ret_code").get("code") == 0
 
@@ -169,7 +167,6 @@ def test_job_submit_LOCAL_BADJCL(ansible_zos_module):
     results = hosts.all.zos_job_submit(src=tmp_file.name, location="LOCAL", wait=True)
 
     for result in results.contacted.values():
-        print("badjcl:{0}".format(result))
 
         assert result.get("changed") is False
 

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -169,7 +169,7 @@ def test_job_submit_LOCAL_BADJCL(ansible_zos_module):
     results = hosts.all.zos_job_submit(src=tmp_file.name, location="LOCAL", wait=True)
 
     for result in results.contacted.values():
-        print(result)
+        print("badjcl:{0}".format(result))
 
         assert result.get("changed") is False
         assert result.get("failed", False) is True

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -139,7 +139,7 @@ def test_job_submit_LOCAL(ansible_zos_module):
     results = hosts.all.zos_job_submit(src=tmp_file.name, location="LOCAL", wait=True)
 
     for result in results.contacted.values():
-        print(result)
+        print("localgood:{0}".format(result))
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
         assert result.get("jobs")[0].get("ret_code").get("code") == 0
 
@@ -154,7 +154,7 @@ def test_job_submit_LOCAL_extraR(ansible_zos_module):
     results = hosts.all.zos_job_submit(src=tmp_file.name, location="LOCAL", wait=True)
 
     for result in results.contacted.values():
-        print(result)
+        print("localexr:{0}".format(result))
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
         assert result.get("jobs")[0].get("ret_code").get("code") == 0
 
@@ -172,7 +172,6 @@ def test_job_submit_LOCAL_BADJCL(ansible_zos_module):
         print("badjcl:{0}".format(result))
 
         assert result.get("changed") is False
-        assert result.get("failed", False) is True
 
 
 # * currently don't have volume support from ZOAU python API, so this will not be reproduceable

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -49,6 +49,18 @@ HELLO, WORLD
 //SYSUT2   DD SYSOUT=*
 //
 """
+JCL_FILE_CONTENTS_BAD = """//HELLO    JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,
+//             MSGCLASS=X,MSGLEVEL=1,NOTIFY=S0JM
+//STEP0001 EXEC PGM=IEBGENER
+//SYSIN    DD DUMMY
+//SYSPRINT DD SYSOUT=*!!
+//SYSUT1   DD *
+HELLO, WORLD
+/*
+//SYSUT2   DD SYSOUT=*
+//
+"""
+
 
 TEMP_PATH = "/tmp/ansible/jcl"
 DATA_SET_NAME = "imstestl.ims1.test05"
@@ -147,6 +159,20 @@ def test_job_submit_LOCAL_extraR(ansible_zos_module):
         assert result.get("jobs")[0].get("ret_code").get("code") == 0
 
         assert result.get("changed") is True
+
+
+def test_job_submit_LOCAL_BADJCL(ansible_zos_module):
+    tmp_file = tempfile.NamedTemporaryFile(delete=True)
+    with open(tmp_file.name, "w") as f:
+        f.write(JCL_FILE_CONTENTS_BAD)
+    hosts = ansible_zos_module
+    results = hosts.all.zos_job_submit(src=tmp_file.name, location="LOCAL", wait=True)
+
+    for result in results.contacted.values():
+        print(result)
+
+        assert result.get("changed") is False
+        assert result.get("failed", False) is True
 
 
 # * currently don't have volume support from ZOAU python API, so this will not be reproduceable


### PR DESCRIPTION
##### SUMMARY
3687 and 5406: JCL error failing fast, and changing response code to fail for both "jcl error", "abend", and "sec" issues.
The search for JCL error was added, and the timing loop cleaned up to 'fail fast'.
Also, test for bad JCL (good jcl plus an exclamation point in a dd line) has been added.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- 
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_submit

##### ADDITIONAL INFORMATION
Running a JCL job that contained character-level errors would be treated as a successful but long running job
System would run the entire provided time gap and not conclude, even though JCL error was issued in < 1 second.
Updated module will fail fast, and will return as changed=False, failed=True

