### PR TITLE
Update to support job id up to 7 numeric positions

### DIFF
--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -44,7 +44,9 @@ options:
   job_id:
     description:
       - The job number that has been assigned to the job. These normally begin
-        with STC, JOB, TSU and are followed by 5 digits.
+        with STC, JOB, TSU and are followed by 5 digits. When job are
+        potentially greather than 99,999, the job number format will begin with
+        S, J, T and are followed by 7 digits.
     type: str
     required: False
 """
@@ -187,7 +189,7 @@ def validate_arguments(params):
             else:
                 raise RuntimeError("Failed to validate the job name: " + job_name_in)
         if job_id:
-            job_id_pattern = re.compile("(JOB|TSU|STC)[0-9]{5}$")
+            job_id_pattern = re.compile("(JOB|TSU|STC)[0-9]{5}|(J|T|S)[0-9]{7}$")
             if not job_id_pattern.search(job_id):
                 raise RuntimeError("Failed to validate the job id: " + job_id)
     else:


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
This change supports both 5 and 7 digit job IDs. 
JobIDs can come in one of two formats:
`<3 chars><5 digits>` or <1 chart><7 digits>` depending on the number of jobs in JES2 and the systems configuration. 

More on [JES2](https://www.ibm.com/support/knowledgecenter/SSLTBW_2.1.0/com.ibm.zos.v2r1.ieaa600/iea3a6_Obtaining_a_job_identifier.htm) be sure to note the section:
```
"When job numbers are potentially greater than 99,999, the format for job numbers is as follows: if the maximum allowed job number (high value of the JOBDEF RANGE= statement) is above 99,999, the job number format is J0nnnnnn." 
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
**zos_job_query**

##### ADDITIONAL INFORMATION
Pretty straight forward change, simple regex and doc update. 
Waiting on a fixtest before merging.
Unable to validate so its being tested as a fixtest. 
There are no updated test cases because there appears to be no systems to test this on and short of forcing a fake JobID which then have no matching job data for the querry, no test exists. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
