### PR TITLE
Changes made for module zos_ping to support doc generation

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,54 @@
 Releases
 ========
 
+Version 1.3.1
+=============
+
+What's New
+----------
+
+* Bug Fixes
+
+  * Modules
+
+    * Connection plugin ``zos_ssh`` was updated to prioritize the execution of
+      modules written in REXX over other implementations such is the case for
+      ``zos_ping``.
+    * ``zos_ping`` was updated to support Automation Hub documentation
+      generation.
+
+Availability
+------------
+
+* `Automation Hub`_
+* `Galaxy`_
+* `GitHub`_
+
+Reference
+---------
+
+* Supported by `z/OS V2R3`_ or later
+* Supported by the `z/OS® shell`_
+* Supported by `IBM Open Enterprise SDK for Python`_ 3.8.2 or later
+* Supported by IBM `Z Open Automation Utilities 1.1.0`_ and
+  `Z Open Automation Utilities 1.1.1`_
+
+Known issues
+------------
+
+* Modules
+
+  * When executing programs using ``zos_mvs_raw``, you may encounter errors
+    that originate in the implementation of the programs. Two such known issues
+    are noted below of which one has been addressed with an APAR.
+
+    #. ``zos_mvs_raw`` module execution fails when invoking
+       Database Image Copy 2 Utility or Database Recovery Utility in conjunction
+       with FlashCopy or Fast Replication.
+    #. ``zos_mvs_raw`` module execution fails when invoking DFSRRC00 with parm
+       "UPB,PRECOMP", "UPB, POSTCOMP" or "UPB,PRECOMP,POSTCOMP". This issue is
+       addressed by APAR PH28089.
+
 Version 1.3.0
 =============
 
@@ -101,7 +149,6 @@ What's New
 Availability
 ------------
 
-* `Automation Hub`_
 * `Galaxy`_
 * `GitHub`_
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -24,6 +24,7 @@ authors:
   - Andrew Nguyen <andy.nguyen@ibm.com>
   - Radha Varadachari <radha.varadachari@ibm.com>
   - Rich Parker <richp@ibm.com>
+  - Ketan Kelkar <ketan.kelkar@ibm.com>
 
 # Description
 description: The IBM z/OS core collection includes connection plugins, action plugins, modules, filters, sample playbooks and ansible-doc to automate tasks on z/OS.

--- a/meta/ibm_zos_core_meta.yml
+++ b/meta/ibm_zos_core_meta.yml
@@ -1,5 +1,5 @@
 name: ibm_zos_core
-version: "1.3.0"
+version: "1.3.1"
 managed_requirements:
     -
         name: "IBM Open Enterprise SDK for Python"


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
This change supports the doc generation that happens on Automation Hub and provides a fix such that the tooling can not have a python based module to extract doc from instead of a REXX based module (zos_ping). 
This also changes the execution order such that REXX based modules are prioritized over other such as python.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

