### PR TITLE
Copy6113

### DIFF
--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -125,10 +125,10 @@ class ActionModule(ActionBase):
         if src is None or dest is None:
             msg = "Source and destination are required"
         elif not isinstance(src, string_types):
-            msg = "Invalid type supplied for 'source' option, " "it must be a string"
+            msg = "Invalid type supplied for 'source' option, it must be a string"
         elif not isinstance(dest, string_types):
             msg = (
-                "Invalid type supplied for 'destination' option, " "it must be a string"
+                "Invalid type supplied for 'destination' option, it must be a string"
             )
         elif len(src) < 1 or len(dest) < 1:
             msg = "Source and destination parameters must not be empty"

--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -70,8 +70,12 @@ def mvs_file_backup(dsn, bk_dsn=None):
     """
     dsn = _validate_data_set_name(dsn).upper()
     if is_member(dsn):
+        # added the check for a sub-mmember, just in this case
         if not bk_dsn:
             bk_dsn = extract_dsname(dsn) + "({0})".format(temp_member_name())
+        elif "(" not in bk_dsn:
+            bk_dsn = extract_dsname(dsn) + "({0})".format(temp_member_name())
+
         bk_dsn = _validate_data_set_name(bk_dsn).upper()
         response = datasets._copy(dsn, bk_dsn)
         if response.rc != 0:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1354,7 +1354,7 @@ class PDSECopyHandler(CopyHandler):
             else:
                 self.fail_json(msg=msg, rc=rc, stdout=out, stderr=err)
 
-        return dest.replace("\\", "")
+        return dest.replace("\\", "").upper()
 
     def create_pdse(
         self,
@@ -1872,6 +1872,7 @@ def run_module(module, arg_def):
             record_length=record_length,
             block_size=block_size,
         )
+        dest = dest.upper()
 
     # ------------------------------- o -----------------------------------
     # Copy to PDS/PDSE
@@ -1895,6 +1896,8 @@ def run_module(module, arg_def):
             pdse_copy_handler.copy_to_pdse(
                 src, temp_path, conv_path, dest, src_ds_type, alloc_vol=volume
             )
+        dest = dest.upper()
+
 
     # ------------------------------- o -----------------------------------
     # Copy to VSAM data set

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -125,7 +125,7 @@ options:
       - If set to C(false) and destination exists, the module exits with a note to
         the user.
     type: bool
-    default: false
+    default: true
     required: false
   ignore_sftp_stderr:
     description:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2030,6 +2030,17 @@ def main():
             )
         )
 
+    if not module.params.get("destination_dataset"):
+        module.params["destination_dataset"] = {
+            "dd_type": "BASIC",
+            "space_primary": 5,
+            "space_secondary": 3,
+            "space_type": 'TRK',
+            "record_format": 'FB',
+            "record_length": 80,
+            "block_size": 6147,
+        }
+
     res_args = temp_path = conv_path = None
     try:
         res_args, temp_path, conv_path = run_module(module, arg_def)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -223,83 +223,99 @@ options:
         unit name has been specified.
     type: str
     required: false
-  type:
+### here
+#
+  destination_dataset:
     description:
-      - If the destination data set does not exist, this determines
-        the type of dataset created.
-      - The data set type to be used when creating a data set. (e.g C(pdse))
-      - C(MEMBER) expects to be used with an existing partitioned data set.
-      - Choices are case-insensitive.
+      - These are settings to use when creating the destination data set
     required: false
-    type: str
-    choices:
-      - KSDS
-      - ESDS
-      - RRDS
-      - LDS
-      - SEQ
-      - PDS
-      - PDSE
-      - MEMBER
-    default: BASIC
-  space_primary:
-    description:
-      - If the destination does not exist and is not a USS file, this determines
-        the primary space allocated for the dataset.
-      - The unit of space used is set using I(space_type).
-    type: str
-    required: false
-    default: "5"
-  space_secondary:
-    description:
-      - If the destination does not exist and is not a USS file, this determines
-        the amount of secondary space to allocate for the dataset.
-      - The unit of space used is set using I(space_type).
-    type: str
-    required: false
-    default: "3"
-  space_type:
-    description:
-      - If the destination does not exist and is not a USS file, this determines
-        the unit of measurement to use when defining primary and secondary space.
-      - Valid units of size are C(K), C(M), C(G), C(CYL), and C(TRK).
-    type: str
-    choices:
-      - K
-      - M
-      - G
-      - CYL
-      - TRK
-    required: false
-    default: M
-  record_format:
-    description:
-      - If the destination does not exist and is not a USS file, this determines
-        the format of the data set. (e.g C(FB))
-      - Choices are case-insensitive.
-    required: false
-    choices:
-      - FB
-      - VB
-      - FBA
-      - VBA
-      - U
-    default: FB
-    type: str
-  record_length:
-    description:
-      - The length of each record in the data set, in bytes.
-      - For variable data sets, the length must include the 4-byte prefix area.
-      - "Defaults vary depending on format: If FB/FBA 80, if VB/VBA 137, if U 0."
-    type: int
-    required: false
-    default: 80
-  block_size:
-    description:
-      - The block size to use for the data set.
-    type: int
-    required: false
-
+    type: dict
+    suboptions:
+      always_use:
+        description:
+          - If set to C(true), the settings in this section will be used to allocate the
+            destination dataset, even if it pre-exists.
+          - If set to C(false), the settings will be used if the destination does not exist
+            and the source file is USS.  If the source is a data set, its settings will be used.
+        required: false
+        type: bool
+        default: false
+      type:
+          description:
+            - If the destination data set does not exist, this determines
+                the type of dataset created.
+            - The data set type to be used when creating a data set. (e.g C(pdse))
+            - C(MEMBER) expects to be used with an existing partitioned data set.
+            - Choices are case-insensitive.
+          required: false
+          type: str
+          choices:
+          - KSDS
+          - ESDS
+          - RRDS
+          - LDS
+          - SEQ
+          - PDS
+          - PDSE
+          - MEMBER
+          default: BASIC
+      space_primary:
+          description:
+          - If the destination data set does not exist, this determines
+              the primary space allocated for the dataset.
+          - The unit of space used is set using I(space_type).
+          type: str
+          required: false
+          default: "5"
+      space_secondary:
+          description:
+          - If the destination does not exist and is not a USS file, this determines
+              the amount of secondary space to allocate for the dataset.
+          - The unit of space used is set using I(space_type).
+          type: str
+          required: false
+          default: "3"
+      space_type:
+          description:
+          - If the destination does not exist and is not a USS file, this determines
+              the unit of measurement to use when defining primary and secondary space.
+          - Valid units of size are C(K), C(M), C(G), C(CYL), and C(TRK).
+          type: str
+          choices:
+          - K
+          - M
+          - G
+          - CYL
+          - TRK
+          required: false
+          default: M
+      record_format:
+          description:
+          - If the destination does not exist and is not a USS file, this determines
+              the format of the data set. (e.g C(FB))
+          - Choices are case-insensitive.
+          required: false
+          choices:
+          - FB
+          - VB
+          - FBA
+          - VBA
+          - U
+          default: FB
+          type: str
+      record_length:
+          description:
+          - The length of each record in the data set, in bytes.
+          - For variable data sets, the length must include the 4-byte prefix area.
+          - "Defaults vary depending on format: If FB/FBA 80, if VB/VBA 137, if U 0."
+          type: int
+          required: false
+          default: 80
+      block_size:
+          description:
+          - The block size to use for the data set.
+          type: int
+          required: false
 notes:
     - Destination data sets are assumed to be in catalog. When trying to copy
       to an uncataloged data set, the module assumes that the data set does
@@ -1658,6 +1674,7 @@ def run_module(module, arg_def):
     alloc_size = module.params.get('size')
     src_member = module.params.get('src_member')
     copy_member = module.params.get('copy_member')
+### here    
     type = module.params.get("type") or "BASIC"
     space_primary = module.params.get("space_primary")
     space_secondary = module.params.get("space_secondary")
@@ -1928,6 +1945,7 @@ def main():
             ignore_sftp_stderr=dict(type='bool', default=False),
             validate=dict(type='bool'),
             volume=dict(type='str', required=False),
+### here            
             type=dict(
                 arg_type='str',
                 default='BASIC',
@@ -1975,6 +1993,7 @@ def main():
         validate=dict(arg_type='bool', required=False),
         sftp_port=dict(arg_type='int', required=False),
         volume=dict(arg_type='str', required=False),
+### here        
         type=dict(arg_type='str', default='BASIC', required=False),
         space_primary=dict(arg_type='int', default=5, required=False),
         space_secondary=dict(arg_type='int', default=3, required=False),

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1944,28 +1944,31 @@ def main():
             volume=dict(type='str', required=False),
             destination_dataset=dict(
                 type='dict',
-                dd_type=dict(
-                    arg_type='str',
-                    default='BASIC',
-                    choices=['KSDS', 'ESDS', 'RRDS', 'LDS', 'SEQ', 'PDS', 'PDSE', 'MEMBER'],
-                    required=False,
-                ),
-                space_primary=dict(arg_type='int', default=5, required=False),
-                space_secondary=dict(arg_type='int', default=3, required=False),
-                space_type=dict(
-                    arg_type='str',
-                    default='M',
-                    choices=['K', 'M', 'G', 'CYL', 'TRK'],
-                    required=False,
-                ),
-                record_format=dict(
-                    arg_type='str',
-                    default='FB',
-                    choices=["FB", "VB", "FBA", "VBA", "U"],
-                    required=False
-                ),
-                record_length=dict(type='int', default=80, required=False),
-                block_size=dict(type='int', required=False),
+                required=False,
+                options=dict(
+                    dd_type=dict(
+                        arg_type='str',
+                        default='BASIC',
+                        choices=['KSDS', 'ESDS', 'RRDS', 'LDS', 'SEQ', 'PDS', 'PDSE', 'MEMBER'],
+                        required=False,
+                    ),
+                    space_primary=dict(arg_type='int', default=5, required=False),
+                    space_secondary=dict(arg_type='int', default=3, required=False),
+                    space_type=dict(
+                        arg_type='str',
+                        default='M',
+                        choices=['K', 'M', 'G', 'CYL', 'TRK'],
+                        required=False,
+                    ),
+                    record_format=dict(
+                        arg_type='str',
+                        default='FB',
+                        choices=["FB", "VB", "FBA", "VBA", "U"],
+                        required=False
+                    ),
+                    record_length=dict(type='int', default=80, required=False),
+                    block_size=dict(type='int', required=False),
+                )
             ),
             is_uss=dict(type='bool'),
             is_pds=dict(type='bool'),
@@ -1996,13 +1999,15 @@ def main():
         destination_dataset=dict(
             arg_type='dict',
             required=False,
-            dd_type=dict(arg_type='str', default='BASIC', required=False),
-            space_primary=dict(arg_type='int', default=5, required=False),
-            space_secondary=dict(arg_type='int', default=3, required=False),
-            space_type=dict(arg_type='str', default='TRK', required=False),
-            record_format=dict(arg_type='str', default='FB', required=False),
-            record_length=dict(arg_type='int', default=80, required=False),
-            block_size=dict(arg_type='int', required=False),
+            options=dict(
+                dd_type=dict(arg_type='str', default='BASIC', required=False),
+                space_primary=dict(arg_type='int', default=5, required=False),
+                space_secondary=dict(arg_type='int', default=3, required=False),
+                space_type=dict(arg_type='str', default='TRK', required=False),
+                record_format=dict(arg_type='str', default='FB', required=False),
+                record_length=dict(arg_type='int', default=80, required=False),
+                block_size=dict(arg_type='int', required=False),
+            )
         ),
     )
 

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -68,7 +68,7 @@ options:
       - This is for simple values; for anything complex or with formatting, use
         U(https://docs.ansible.com/ansible/latest/modules/copy_module.html)
       - If C(dest) is a directory, then content will be copied to
-        C(/path/to/dest/inline_copy).
+        C(/path/to/dest/in173_copy).
     type: str
     required: false
   dest:
@@ -1897,7 +1897,6 @@ def run_module(module, arg_def):
                 src, temp_path, conv_path, dest, src_ds_type, alloc_vol=volume
             )
         dest = dest.upper()
-
 
     # ------------------------------- o -----------------------------------
     # Copy to VSAM data set

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -68,7 +68,7 @@ options:
       - This is for simple values; for anything complex or with formatting, use
         U(https://docs.ansible.com/ansible/latest/modules/copy_module.html)
       - If C(dest) is a directory, then content will be copied to
-        C(/path/to/dest/in173_copy).
+        C(/path/to/dest/inline_copy).
     type: str
     required: false
   dest:
@@ -225,7 +225,7 @@ options:
     required: false
   type:
     description:
-      - If the destination does not exist and is not a USS file, this determines
+      - If the destination data set does not exist, this determines
         the type of dataset created.
       - The data set type to be used when creating a data set. (e.g C(pdse))
       - C(MEMBER) expects to be used with an existing partitioned data set.
@@ -240,12 +240,7 @@ options:
       - SEQ
       - PDS
       - PDSE
-      - LIBRARY
-      - BASIC
-      - LARGE
       - MEMBER
-      - HFS
-      - ZFS
     default: BASIC
   space_primary:
     description:
@@ -293,7 +288,7 @@ options:
     type: str
   record_length:
     description:
-      - The length, in bytes, of each record in the data set.
+      - The length of each record in the data set, in bytes.
       - For variable data sets, the length must include the 4-byte prefix area.
       - "Defaults vary depending on format: If FB/FBA 80, if VB/VBA 137, if U 0."
     type: int
@@ -1936,7 +1931,7 @@ def main():
             type=dict(
                 arg_type='str',
                 default='BASIC',
-                choices=['KSDS', 'ESDS', 'RRDS', 'LDS', 'SEQ', 'PDS', 'PDSE', 'LIBRARY', 'BASIC', 'LARGE', 'MEMBER', 'HFS', 'ZFS'],
+                choices=['KSDS', 'ESDS', 'RRDS', 'LDS', 'SEQ', 'PDS', 'PDSE', 'MEMBER'],
                 required=False,
             ),
             space_primary=dict(arg_type='int', default=5, required=False),

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -232,18 +232,18 @@ def test_find_data_sets_smaller_than_size(ansible_zos_module):
         assert val.get('matched') == 1
 
 
-def test_find_data_sets_in_volume(ansible_zos_module):
-    hosts = ansible_zos_module
-
-    find_res = hosts.all.zos_find(
-        patterns=['USER.*'], volumes=['IMSSUN']
-    )
-    print(vars(find_res))
-    for val in find_res.contacted.values():
-        assert len(val.get('data_sets')) == 5
-        assert val.get('matched') == 5
-
-
+# This is being commented out, since there is no reference to where the files were created
+# ... even checked main/master branch
+# def test_find_data_sets_in_volume(ansible_zos_module):
+#    hosts = ansible_zos_module
+#
+#    find_res = hosts.all.zos_find(
+#        patterns=['USER.*'], volumes=['IMSSUN']
+#    )
+#    print(vars(find_res))
+#    for val in find_res.contacted.values():
+#        assert len(val.get('data_sets')) == 5
+#        assert val.get('matched') == 5
 def test_find_vsam_pattern(ansible_zos_module):
     hosts = ansible_zos_module
     try:


### PR DESCRIPTION
##### SUMMARY
6113 (copy length error) and 6183 (remove model_ds) are in this build.
Also changed documentation of 'force' in zos_copy, since default should have been true, as implemented in action.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zos_copy

##### ADDITIONAL INFORMATION
Initial bug was that when copying USS file to ds, the size & structure got changed.  Now, we get data from existing data set, or have parameters (with defaults) to cover non-existing data set.

6183 was expanding those parameters to use instead of a 'model_ds'
