### PR TITLE
Update common code used to obtain job content such it is not trucated by the unrelated record count

### DIFF
--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -304,7 +304,6 @@ Say '-----NO JOBS FOUND-----'
 end
 else do
 do ix=1 to isfrows
-    linecount = 0
 
     Say '-----START OF JOB-----'
     Say 'job_id'||':'||value('JOBID'||"."||ix)
@@ -335,14 +334,10 @@ do ix=1 to isfrows
         Say '-----START OF CONTENT-----'
         Address SDSF "ISFBROWSE ST TOKEN('"token.ix"')"
         do kx=1 to isfline.0
-            linecount = linecount + 1
             Say isfline.kx
         end
         Say '-----END OF CONTENT-----'
         Say '-----END OF DD-----'
-        end
-        else do
-            linecount = linecount + JDS_RECCNT.jx
         end
     end
     Say '-----END OF DD NAMES-----'
@@ -478,7 +473,6 @@ Say '-----NO JOBS FOUND-----'
 end
 else do
 do ix=1 to isfrows
-    linecount = 0
     if ix<>1 then do
     end
     Say '-----START OF JOB-----'

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -334,9 +334,7 @@ do ix=1 to isfrows
         Say 'byte_count'||':'||value('JDS_BYTECNT'||"."||jx)
         Say '-----START OF CONTENT-----'
         Address SDSF "ISFBROWSE ST TOKEN('"token.ix"')"
-        untilline = linecount + JDS_RECCNT.jx
-        startingcount = linecount + 1
-        do kx=linecount+1 to  untilline
+        do kx=1 to isfline.0
             linecount = linecount + 1
             Say isfline.kx
         end


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>
##### SUMMARY
This commit fixes the bug such that when Job content is returned by the `zos_job_output` module (or any module using the jobs.py code to return job content) its not truncated by the incorrect use of of the record count variable. 

Record count does not equate to the lines in job content, the job content is 1 entry with regard to records from the record count, the job content just have its own iterator. No maximum has been set for this as I don't feel we don't have the justification to limit this and would rather the customer receive the full ouput. Should we ever need to limit you can set a REXX limiter like so `isflinelim = 500` , more on REXX and isfline [here](https://www-01.ibm.com/servers/resourcelink/svc00100.nsf/pages/zOSV2R3sc279028/$file/isfa600_v2r3.pdf) , [here](https://www.ibm.com/docs/en/zos/2.3.0?topic=isflog-special-variables-use-command) and [here](https://www.ibm.com/docs/en/zos/2.2.0?topic=panels-job-data-set-panel-jds)

No new tests cases need to be created, this was also a fixtest being evaluated by @th365thli

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_output module
jobs.py common utility

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

