### PR TITLE
zos_ssh - rename retries setting

### DIFF
--- a/plugins/connection/zos_ssh.py
+++ b/plugins/connection/zos_ssh.py
@@ -141,7 +141,7 @@ DOCUMENTATION = """
             - key: ssh_extra_args
               section: ssh_connection
               version_added: '2.7'
-      retries:
+      reconnection_retries:
           # constant: ANSIBLE_SSH_RETRIES
           description: Number of attempts to connect.
           default: 3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

There was a bug in Ansible that would result in task retries overriding the connection retries. Using a different name for the connection retries setting avoids this issue on versions of Ansible that are missing the bug fix.<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`plugins/connection/zos_ssh.py`

##### ADDITIONAL INFORMATION
Related to https://github.com/ansible/ansible/pull/75155.
