### PR TITLE
Bug fix not propagating non zero return codes and under certain cases job_name is null for operator action query

### DIFF
--- a/plugins/modules/zos_operator_action_query.py
+++ b/plugins/modules/zos_operator_action_query.py
@@ -373,8 +373,6 @@ def parse_result_b(result):
         re.MULTILINE,
     )
 
-    # In some cases where no job is involved such as in a WTOR dump there will
-    # be no job_name so we should clean it up
     for match in match_iter:
         dict_temp = {
             "number": match.group(1),
@@ -382,8 +380,8 @@ def parse_result_b(result):
             "message_id": match.group(3),
         }
 
-        # Sometimes jobname will be null because the operator action is a
-        # WTOR like in a dump command so removing None
+        # Sometimes 'job_name' will be null because the operator action is a
+        # WTOR like in a dump command so remove keys with None types
         dict_temp_result = {
             k: v for k, v in dict_temp.items() if (v is not None)}
         list.append(dict_temp_result)
@@ -416,10 +414,24 @@ class ValidationError(Error):
 
 
 class OperatorQueryResult:
-    def __init__(self, rc, stdout, stderr):
+    def __init__(
+        self,
+        rc,
+        stdout,
+        stderr
+    ):
+        """Response object class to manage the result from executing a command
+        to query for actionable messages. Class will also generate a message
+        by concatinating stdout and stderr
+
+        Arguments:
+            rc {str} -- The return code
+            stdout {str} -- The standard out of the command run
+            stderr {str} -- The standard error of the command run
+        """
         self.rc = rc
         self.stdout = stdout
-        self.stderr = rc
+        self.stderr = stderr
         self.message = stdout + " " + stderr
 
 

--- a/plugins/modules/zos_operator_action_query.py
+++ b/plugins/modules/zos_operator_action_query.py
@@ -218,7 +218,7 @@ def run_module():
                 rc=cmd_result_b.rc,
                 stdout_lines=cmd_result_b.stdout.splitlines() if cmd_result_b.stdout else None,
                 stderr_lines=cmd_result_b.stderr.splitlines() if cmd_result_b.stderr else None,
-                cmd="d r,a,s",
+                cmd="d r,a,jn",
             )
 
         merged_list = create_merge_list(cmd_result_a.message, cmd_result_b.message)
@@ -422,7 +422,7 @@ class OperatorQueryResult:
     ):
         """Response object class to manage the result from executing a command
         to query for actionable messages. Class will also generate a message
-        by concatinating stdout and stderr
+        by concatenating stdout and stderr
 
         Arguments:
             rc {str} -- The return code
@@ -432,7 +432,7 @@ class OperatorQueryResult:
         self.rc = rc
         self.stdout = stdout
         self.stderr = stderr
-        self.message = stdout + " " + stderr
+        self.message = stdout
 
 
 def main():

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -240,8 +240,8 @@ def test_find_data_sets_in_volume(ansible_zos_module):
     )
     print(vars(find_res))
     for val in find_res.contacted.values():
-        assert len(val.get('data_sets')) == 5
-        assert val.get('matched') == 5
+        assert len(val.get('data_sets')) >= 1
+        assert val.get('matched') >= 1
 
 
 def test_find_vsam_pattern(ansible_zos_module):


### PR DESCRIPTION
##### SUMMARY
The operator action query module operates by running two hard coded commands (`d r,a,s` , `d r,a,jn`) which are executed by the ZOAU opercmd dependency. 

In some queries for an operator action if they are not job related , the job name would come back null since obviously its unrelated to a WTO which has no associated job name, this update removes the property from the response. 

The second issue was reported and unpronounceable by the client and our development but the source of the issue could be aided for future occurrences by propagating the return code coming from the command execution. The two commands used are hard coded and not the issue, the customer was able to run them after the error and they were not the source nor likely on a 55 yr old OS :-). I double checked all the regular expressions with the raw output of the command and they were not the source, they functioned as written. Since the issue originated as `OperatorCmdError` that could only happen as a non-zero return code coming from ZOAU's `opercmd`, re-iterating not likely from the two hard coded query commands. Likely the cause is the cause could be **special characters** in the result that `opercmd` received   (**STC28008 @58 DFHPA1909**) that resulted in the non-zero RC. 

Sine there is no way to reproduce this, I have statically changed the two commands to invalid to test and forced a non-zero RC to ensure our failure path captures the values we need for possible future occurrences. See additional information below. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zos_operator_action_query

##### ADDITIONAL INFORMATION
Original error:
```
"Module":"zos_operator_action_query"{
   "_ansible_no_log":false,
   "invocation":{
      "module_args":{
         "system":null,
         "job_name":"IMD1CTL",
         "message_id":null
      }
   },
   "changed":false,
   "msg":"OperatorCmdError(\"ZH104TD1  2021168  08:27:13.88             ISF031I CONSOLE ANSIMS ACTIVATED\\nZH104TD1  2021168  08:27:13.88            -D R,A,S\\nZH104TD1  2021168  08:27:13.88             IEE112I 08.27.13 PENDING REQUESTS 876\\n                                           RM=4    IM=0     CEM=0     EM=0     RU=0    IR=0    NOAMRF\\n                                           ID:R/K     T SYSNAME  JOB ID   MESSAGE TEXT\\n                                                   59 R ZH104TD1 STC28046 *59 DFS810A IMS READY\\n                                                                          21168/0827026 IMD1CTL .IMD1CTL    IMD1\\n                                                   58 R ZH104TD1 STC28008 @58 DFHPA1909 CICSZSA4 DATA INVALID FOR\\n                                                                           'USSHOME'. RESPECIFY KEYWORD AND DATA\\n                                                                          OR BYPASS WITH '.END': '/usr/lpp/cicsts\\n                                                                          /cicsts55\\n                                                   82 R ZH104TD2          *82 DSI802A ZTD2A    REPLY WITH VALID\\n                                                                          NCCF SYSTEM OPERATOR COMMAND\\n                                                   65 R ZH104TD1          *65 DSI802A ZTD1A    REPLY WITH VALID\\n                                                                          NCCF SYSTEM OPERATOR COMMAND\\n \")"
}
```

Running one of the two hard coded commands on the operator console yields no error:
```
D R,A,S                                                                
IEE112I 08.27.13 PENDING REQUESTS 876                                  
RM=4    IM=0     CEM=0     EM=0     RU=0    IR=0    NOAMRF             
ID:R/K     T SYSNAME  JOB ID   MESSAGE TEXT                            
        59 R ZH104TD1 STC28046 *59 DFS810A IMS READY                   
                               21168/0827026 IMD1CTL .IMD1CTL    IMD1  
        58 R ZH104TD1 STC28008 @58 DFHPA1909 CICSZSA4 DATA INVALID FOR 
                                'USSHOME'. RESPECIFY KEYWORD AND DATA  
                               OR BYPASS WITH '.END': '/usr/lpp/cicsts 
                               /cicsts55                               
        82 R ZH104TD2          *82 DSI802A ZTD2A    REPLY WITH VALID   
                               NCCF SYSTEM OPERATOR COMMAND            
        65 R ZH104TD1          *65 DSI802A ZTD1A    REPLY WITH VALID   
                               NCCF SYSTEM OPERATOR COMMAND    
```

Regex
```
^\s*([0-9]{2,})\s([A-Z]{1})\s([A-Z0-9]{1,8})\s+((?:[A-Z0-9]{1,8})?)\s*[&*]?[0-9]+(.*)
```

Regex101 try it:
https://regex101.com/r/rpWtqr/1/

Regex evaluated
![image](https://user-images.githubusercontent.com/25803172/126046006-c5015f8f-dcf2-42c6-9494-ea03230d440d.png)
![image](https://user-images.githubusercontent.com/25803172/126046012-b6730b70-1eda-4030-9de1-991382d1652e.png)

Regex on special char `@` has no issues:
<img width="1630" alt="image" src="https://user-images.githubusercontent.com/25803172/126046045-b15f807e-3542-42ab-be77-0753ffe77280.png">

Since this can not be recreated I forced a non-zero RC to ensure the failure pat works:
```
{
   "changed":false,
   "cmd":"d r,a,s",
   "msg":"A non-zero return code was received while querying the operator.",
   "rc":5,
   "stderr":"",
   "stderr_lines":null,
   "stdout":"EC33017A  2021198  10:30:01.57             ISF031I CONSOLE OMVSADM ACTIVATED\nEC33017A  2021198  10:30:01.57            -D R,A,S\nEC33017A  2021198  10:30:01.57             IEE112I 10.30.01 PENDING REQUESTS 145\n                                           RM=9    IM=0     CEM=0     EM=0     RU=0    IR=0    AMRF\n                                           ID:R/K     T SYSNAME  JOB ID   MESSAGE TEXT\n                                                   20 R EC33017A          *20 IEE094D SPECIFY OPERAND(S) FOR DUMP\n                                                                           COMMAND\n                                                   19 R EC33017A          *19 IEE094D SPECIFY OPERAND(S) FOR DUMP\n                                                                           COMMAND\n                                                   18 R EC33017A          *18 IEE094D SPECIFY OPERAND(S) FOR DUMP\n                                                                           COMMAND\n                                                   17 R EC33017A          *17 IEE094D SPECIFY OPERAND(S) FOR DUMP\n                                                                           COMMAND\n                                                   16 R EC33017A          *16 IEA793A NO DUMP DATA SETS AVAILABLE\n                                                                           FOR DUMPID=007 BY JOB (*MASTER*). USE\n                                                                          THE DUMPDS COMMAND OR REPLY D TO DELETE\n                                                                           THE DUMP\n                                                   14 R EC33017A          *14 IEA793A NO DUMP DATA SETS AVAILABLE\n                                                                           FOR DUMPID=006 BY JOB (*MASTER*). USE\n                                                                          THE DUMPDS COMMAND OR REPLY D TO DELETE\n                                                                           THE DUMP\n                                                   12 R EC33017A          *12 IEA793A NO DUMP DATA SETS AVAILABLE\n                                                                           FOR DUMPID=005 BY JOB (*MASTER*). USE\n                                                                          THE DUMPDS COMMAND OR REPLY D TO DELETE\n                                                                           THE DUMP\n                                                   10 R EC33017A          *10 IEA793A NO DUMP DATA SETS AVAILABLE\n                                                                           FOR DUMPID=004 BY JOB (*MASTER*). USE\n                                                                          THE DUMPDS COMMAND OR REPLY D TO DELETE\n                                                                           THE DUMP\n                                                   08 R EC33017A          *08 IEA793A NO DUMP DATA SETS AVAILABLE\n                                                                           FOR DUMPID=003 BY JOB (*MASTER*). USE\n                                                                          THE DUMPDS COMMAND OR REPLY D TO DELETE\n                                                                           THE DUMP\n",
   "stdout_lines":[
      "EC33017A  2021198  10:30:01.57             ISF031I CONSOLE OMVSADM ACTIVATED",
      "EC33017A  2021198  10:30:01.57            -D R,A,S",
      "EC33017A  2021198  10:30:01.57             IEE112I 10.30.01 PENDING REQUESTS 145",
      "                                           RM=9    IM=0     CEM=0     EM=0     RU=0    IR=0    AMRF",
      "                                           ID:R/K     T SYSNAME  JOB ID   MESSAGE TEXT",
      "                                                   20 R EC33017A          *20 IEE094D SPECIFY OPERAND(S) FOR DUMP",
      "                                                                           COMMAND",
      "                                                   19 R EC33017A          *19 IEE094D SPECIFY OPERAND(S) FOR DUMP",
      "                                                                           COMMAND",
      "                                                   18 R EC33017A          *18 IEE094D SPECIFY OPERAND(S) FOR DUMP",
      "                                                                           COMMAND",
      "                                                   17 R EC33017A          *17 IEE094D SPECIFY OPERAND(S) FOR DUMP",
      "                                                                           COMMAND",
      "                                                   16 R EC33017A          *16 IEA793A NO DUMP DATA SETS AVAILABLE",
      "                                                                           FOR DUMPID=007 BY JOB (*MASTER*). USE",
      "                                                                          THE DUMPDS COMMAND OR REPLY D TO DELETE",
      "                                                                           THE DUMP",
      "                                                   14 R EC33017A          *14 IEA793A NO DUMP DATA SETS AVAILABLE",
      "                                                                           FOR DUMPID=006 BY JOB (*MASTER*). USE",
      "                                                                          THE DUMPDS COMMAND OR REPLY D TO DELETE",
      "                                                                           THE DUMP",
      "                                                   12 R EC33017A          *12 IEA793A NO DUMP DATA SETS AVAILABLE",
      "                                                                           FOR DUMPID=005 BY JOB (*MASTER*). USE",
      "                                                                          THE DUMPDS COMMAND OR REPLY D TO DELETE",
      "                                                                           THE DUMP",
      "                                                   10 R EC33017A          *10 IEA793A NO DUMP DATA SETS AVAILABLE",
      "                                                                           FOR DUMPID=004 BY JOB (*MASTER*). USE",
      "                                                                          THE DUMPDS COMMAND OR REPLY D TO DELETE",
      "                                                                           THE DUMP",
      "                                                   08 R EC33017A          *08 IEA793A NO DUMP DATA SETS AVAILABLE",
      "                                                                           FOR DUMPID=003 BY JOB (*MASTER*). USE",
      "                                                                          THE DUMPDS COMMAND OR REPLY D TO DELETE",
      "                                                                           THE DUMP"
   ]
}
```

When I force and invalid command (not one of the two we have hard coded), we still get a ZERO return code from opercmd because I believe the RC returned by opercmd is the RC of the script its actually executing and even though it executes an invalid command it does not fail (unlike in the case of the special chars), notice the invalid command just resulted in no actions thus a RC 0 came back (this won't be our case as I noted commands are hard coded).

```
ok: [zvm] => {
    "msg": {
        "actions": [],
        "changed": false,
        "failed": false
    }
   ```
}

Pipe line tests 100% success:
http://sprinkles1.fyre.ibm.com:8080/job/zosAnsible/463/console

```
[Pipeline] echo
============================= test session starts ==============================
platform linux -- Python 3.7.10, pytest-5.3.0, py-1.10.0, pluggy-0.13.1
ansible: 2.9.6
rootdir: /var/lib/jenkins/workspace/zosAnsible@2/ibm_zos_core/tests, inifile: pytest.ini
plugins: ansible-2.2.2, mock-1.12.1
collected 35 items

unit/test_zos_operator_action_query_unit.py .........                    [ 25%]
functional/modules/test_zos_operator_action_query_func.py .............. [ 65%]
............                                                             [100%]

```

```
23.89s teardown functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_invalid_option_job_name
9.28s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_no_options
5.93s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_system_regex
5.89s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_system_regex_and_message_id[*]
5.88s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_system_regex_and_message_id[IEE*]
5.81s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_system_regex_and_message_id[IEE094D]
5.17s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_message_id
5.00s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_message_id_regex[*]
4.97s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_message_id_regex[IEE*]
4.94s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_message_id_invalid_abbreviation
4.09s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_system
3.99s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_system_and_message_id[IEE094D]
3.84s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_system_invalid_abbreviation
3.84s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_system_and_message_id[IEE*]
3.81s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_option_system_and_message_id[*]
1.29s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_valid_option_system_invalid_option_message_id
0.61s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_valid_message_id_invalid_option_system[*]
0.61s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_invalid_option_system[]
0.60s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_valid_message_id_invalid_option_system[IEE*]
0.60s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_invalid_option_message_id[]
0.59s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_invalid_option_system[invalid-system]
0.58s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_invalid_option_message_id[invalid-message]
0.58s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_invalid_option_system[--BADNM]
0.58s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_invalid_option_message_id[--BADNM]
0.58s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_invalid_option_system[OVER8CHARS]
0.57s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_invalid_option_job_name
0.56s call     functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_valid_message_id_invalid_option_system[IEE094D]
0.12s setup    functional/modules/test_zos_operator_action_query_func.py::test_zos_operator_action_query_no_options
0.06s setup    unit/test_zos_operator_action_query_unit.py::test_zos_operator_action_query_various_args[args0-True]
0.01s call     unit/test_zos_operator_action_query_unit.py::test_zos_operator_action_query_various_args[args0-True]
0.01s call     unit/test_zos_operator_action_query_unit.py::test_zos_operator_action_query_various_args[args4-True]
0.01s call     unit/test_zos_operator_action_query_unit.py::test_zos_operator_action_query_various_args[args1-True]
0.01s call     unit/test_zos_operator_action_query_unit.py::test_zos_operator_action_query_various_args[args2-True]
0.01s call     unit/test_zos_operator_action_query_unit.py::test_zos_operator_action_query_various_args[args5-True]
0.01s call     unit/test_zos_operator_action_query_unit.py::test_zos_operator_action_query_various_args[args3-True]
0.01s call     unit/test_zos_operator_action_query_unit.py::test_zos_operator_action_query_various_args[args6-False]
0.01s call     unit/test_zos_operator_action_query_unit.py::test_zos_operator_action_query_various_args[args7-False]
0.01s call     unit/test_zos_operator_action_query_unit.py::test_zos_operator_action_query_various_args[args8-False]
```
```
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
Finished: SUCCESS
```
<img width="1040" alt="image" src="https://user-images.githubusercontent.com/25803172/126046497-b21f31e3-cd2c-4ef5-a6bd-0083c37bc288.png">
