### PR TITLE
Enh5832

### DIFF
--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -61,6 +61,7 @@ options:
     description:
     - The text to insert inside the marker lines.
     - Multi-line can be separated by '\n'.
+    - Any double-quotation marks will be removed.
     required: false
     type: str
     default: ''

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -328,7 +328,7 @@ def quotedString(string):
     # add escape if string was quoted
     if not isinstance(string, str):
         return string
-    return string.replace('"', '\\\"')
+    return string.replace('"', "")
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
Changed the QuotedString routine to remove quotation marks instead of escaping them.
Added a line to the 'block' documentation to note that quotations would be removed.
Fixes 5832, where errors came from quotation marks in the block data.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zos_blockinfile.py

##### ADDITIONAL INFORMATION
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- name: 1b Add to /test/profile.tmp quoted
      zos_blockinfile:
        src: "/test/profile.tmp"
        insertafter: "EOF"
        block: |
          "test text line 1b"
          "test text line 2b"
      register: result

The entry above, in a playbook, would crash out the run.  Doing it without the quotation marks, or with apostrophes works fine.  The issue is downstream, inside zoau or the command call chain.  It was easier to simply remove the quotation marks.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
old routine, run against quotes would generate:
Module invocation had junk after the JSON data: ����@����@������KKK����@����@������KKK

and/or fail to run completely.  Anything returned would be invalid json, cause an error exit.

```
