### PR TITLE
Enh5832

### DIFF
--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -61,6 +61,7 @@ options:
     description:
     - The text to insert inside the marker lines.
     - Multi-line can be separated by '\n'.
+    - Any double-quotation marks will be removed.
     required: false
     type: str
     default: ''

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -328,7 +328,7 @@ def quotedString(string):
     # add escape if string was quoted
     if not isinstance(string, str):
         return string
-    return string.replace('"', '\\\"')
+    return string.replace('"', "")
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
Addresses Jira 5832
The short solution: If quotation marks (") are found, they are removed from the incoming data stream.
This is because the quotes get mangled by zoau, which passes them to a command-line, so the function returns failure.
Previously, it would result and error and halt of playbook.

Side note: I removed this from PR last week, because I thought I found a way to address the issue, but I was wrong.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
zos_blockinfile.py

##### ADDITIONAL INFORMATION
1: Create a folder of /temp on the target, add a text-flagged file (profile.tmp) in that folder.
2: Put some text in the file, then run this playbook:
  a - on old code, this will crash and burn
  b - on this code, this playbook will run
The only downside is that the double-quotes are lost in the process.

   - name: 1b Add to /test/profile.tmp quoted
      zos_blockinfile:
        src: "/test/profile.tmp"
        insertafter: "EOF"
        block: |
          "test text line 1b"
          "test text line 2b"
      register: result

    - name: ab Response
      debug:
        msg: "{{ result }}"

