### PR TITLE
Bugfix/8779 8780/zos copy cleanup bugs for v1.3.1.1

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,7 +6,7 @@
 Releases
 ========
 
-Version 1.3.2
+Version 1.3.3
 =============
 
 What's New

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,47 @@
 Releases
 ========
 
+Version 1.3.2
+=============
+
+What's New
+----------
+
+* Bug Fixes
+
+  * Modules
+
+    * ``zos_copy`` was updated to correct deletion of all temporary files and
+      unwarranted deletes.
+
+        * When the module would complete, a cleanup routine did not take into
+          account that other processes had open temporary files and thus would
+          error when trying to remove them.
+        * When the module would copy a directory (source) from USS to another
+          USS directory (destination), any files currently in the destination
+          would be deleted.
+          The modules behavior has changed such that files are no longer deleted
+          unless the ``force`` option is set to ``true``. When ``force=true``,
+          copying files or a directory to a USS destination will continue if it
+          encounters existing files or directories and overwrite any
+          corresponding files.
+
+Availability
+------------
+
+* `Automation Hub`_
+* `Galaxy`_
+* `GitHub`_
+
+Reference
+---------
+
+* Supported by `z/OS V2R3`_ or later
+* Supported by the `z/OS® shell`_
+* Supported by `IBM Open Enterprise SDK for Python`_ 3.8.2 or later
+* Supported by IBM `Z Open Automation Utilities 1.1.0`_ and
+  `Z Open Automation Utilities 1.1.1`_
+
 Version 1.3.1
 =============
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -30,6 +30,11 @@ What's New
           copying files or a directory to a USS destination will continue if it
           encounters existing files or directories and overwrite any
           corresponding files.
+    * ``zos_job_query`` was updated to correct a boolean condition that always
+      evaluated to "CANCELLED".
+
+        * When querying jobs that are either **CANCELLED** or have **FAILED**,
+        they were always treated as **CANCELLED**.
 
 Availability
 ------------

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -34,7 +34,7 @@ What's New
       evaluated to "CANCELLED".
 
         * When querying jobs that are either **CANCELLED** or have **FAILED**,
-        they were always treated as **CANCELLED**.
+          they were always treated as **CANCELLED**.
 
 Availability
 ------------

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,25 +6,17 @@ namespace: ibm
 name: ibm_zos_core
 
 # The collection version
-version: 1.3.1
+version: 1.3.2
 
 # Collection README file
 readme: README.md
 
 # Contributors
 authors:
-  - Asif Mahmud <asif.mahmud@ibm.com>
-  - Blake Becker <blake.becker@ibm.com>
-  - Xiao Yuan Ma <bjmaxy@cn.ibm.com>
   - Demetrios Dimatos <ddimatos@us.ibm.com>
-  - Jack Ho <jack.ho@ibm.com>
-  - Lu Zhao <zlbjlu@cn.ibm.com>
-  - Ping Xiao <xiaoping@cn.ibm.com>
-  - Behnam Al Kajbaf <behnam@ibm.com>
-  - Andrew Nguyen <andy.nguyen@ibm.com>
-  - Radha Varadachari <radha.varadachari@ibm.com>
   - Rich Parker <richp@ibm.com>
   - Ketan Kelkar <ketan.kelkar@ibm.com>
+  - Ivan Moreno <ivan.moreno.soto@ibm.com
 
 # Description
 description: The IBM z/OS core collection includes connection plugins, action plugins, modules, filters, sample playbooks and ansible-doc to automate tasks on z/OS.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -41,6 +41,7 @@ tags:
     jcl,
     uss,
     mvs,
+    infrastructure,
   ]
 
 # Collections that this collection requires to be installed for it to be usable.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: ibm
 name: ibm_zos_core
 
 # The collection version
-version: 1.3.2
+version: 1.3.3
 
 # Collection README file
 readme: README.md

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.9.6'

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.6'
+requires_ansible: '>=2.9.10,>=2.11,<2.12'

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -125,10 +125,10 @@ class ActionModule(ActionBase):
         if src is None or dest is None:
             msg = "Source and destination are required"
         elif not isinstance(src, string_types):
-            msg = "Invalid type supplied for 'source' option, " "it must be a string"
+            msg = "Invalid type supplied for 'source' option, value must be a string"
         elif not isinstance(dest, string_types):
             msg = (
-                "Invalid type supplied for 'destination' option, " "it must be a string"
+                "Invalid type supplied for 'destination' option, value must be a string"
             )
         elif len(src) < 1 or len(dest) < 1:
             msg = "Source and destination parameters must not be empty"

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1486,9 +1486,8 @@ def cleanup(src_list):
     dir_list = glob.glob(tmp_dir + "/ansible-zos-copy-payload*")
     conv_list = glob.glob(tmp_dir + "/converted*")
     tmp_list = glob.glob(tmp_dir + "/{0}*".format(tmp_prefix))
-    tmp_ds = glob.glob(tmp_dir + "/*.*.*.*")
 
-    for file in (dir_list + conv_list + tmp_list + tmp_ds + src_list):
+    for file in (dir_list + conv_list + tmp_list + src_list):
         try:
             if file and os.path.exists(file):
                 if os.path.isfile(file):
@@ -1600,6 +1599,7 @@ def run_module(module, arg_def):
             if copy_member:
                 dest_exists = dest_exists and dest_du.member_exists(dest_member)
             dest_ds_type = dest_du.ds_type()
+
         if temp_path or "/" in src:
             src_ds_type = "USS"
         else:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -27,7 +27,10 @@ description:
     remote machine to a location on the remote machine.
   - Use the M(zos_fetch) module to copy files or data sets from remote
     locations to the local machine.
-author: "Asif Mahmud (@asifmahmud)"
+author:
+  - "Asif Mahmud (@asifmahmud)"
+  - "Ivan Moreno (@rexemin)"
+  - "Demetrios Dimatos (@ddimatos)"
 options:
   backup:
     description:
@@ -119,6 +122,9 @@ options:
   force:
     description:
       - If set to C(true), the remote file or data set will be overwritten.
+      - If set to C(true), when copying files or a directory to a USS
+        destination, the copying operation will continue if it encounters
+        existing files or directories and overwrite any corresponding files.
       - If set to C(true) and the user is copying a directory to a destination in USS
         that already has content in it, the files will be appended to the destination.
       - If set to C(false), the file or data set will only be copied if the destination

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -20,7 +20,7 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: zos_copy
-version_added: '2.9'
+version_added: '1.0.0'
 short_description: Copy data to z/OS
 description:
   - The M(zos_copy) module copies a file or data set from a local or a

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -119,6 +119,8 @@ options:
   force:
     description:
       - If set to C(true), the remote file or data set will be overwritten.
+      - If set to C(true) and the user is copying a directory to a destination in USS
+        that already has content in it, the files will be appended to the destination.
       - If set to C(false), the file or data set will only be copied if the destination
         does not exist.
       - If set to C(false) and destination exists, the module exits with a note to
@@ -912,7 +914,8 @@ class USSCopyHandler(CopyHandler):
         temp_path,
         src_ds_type,
         src_member,
-        member_name
+        member_name,
+        force
     ):
         """Copy a file or data set to a USS location
 
@@ -925,6 +928,7 @@ class USSCopyHandler(CopyHandler):
             src_ds_type {str} -- Type of source
             src_member {bool} -- Whether src is a data set member
             member_name {str} -- The name of the source data set member
+            force {bool} -- Whether to copy files to an already existing directory
 
         Returns:
             {str} -- Destination where the file was copied to
@@ -937,7 +941,7 @@ class USSCopyHandler(CopyHandler):
             if os.path.isfile(temp_path or conv_path or src):
                 dest = self._copy_to_file(src, dest, conv_path, temp_path)
             else:
-                dest = self._copy_to_dir(src, dest, conv_path, temp_path)
+                dest = self._copy_to_dir(src, dest, conv_path, temp_path, force)
 
         if self.common_file_args is not None:
             mode = self.common_file_args.get("mode")
@@ -984,7 +988,7 @@ class USSCopyHandler(CopyHandler):
             )
         return dest
 
-    def _copy_to_dir(self, src_dir, dest_dir, conv_path, temp_path):
+    def _copy_to_dir(self, src_dir, dest_dir, conv_path, temp_path, force):
         """Helper function to copy a USS directory to another USS directory
 
         Arguments:
@@ -993,21 +997,15 @@ class USSCopyHandler(CopyHandler):
             temp_path {str} -- Path to the location where the control node
                                transferred data to
             conv_path {str} -- Path to the converted source directory
+            force {bool} -- Whether to copy files to an already existing directory
 
         Returns:
             {str} -- Destination where the directory was copied to
         """
         new_src_dir = temp_path or conv_path or src_dir
-        if os.path.exists(dest_dir):
-            try:
-                shutil.rmtree(dest_dir)
-            except Exception as err:
-                self.fail_json(
-                    msg="Unable to delete pre-existing directory {0}".format(dest_dir),
-                    stdout=str(err),
-                )
+
         try:
-            shutil.copytree(new_src_dir, dest_dir)
+            shutil.copytree(new_src_dir, dest_dir, dirs_exist_ok=force)
         except Exception as err:
             self.fail_json(
                 msg="Error while copying data to destination directory {0}".format(
@@ -1555,6 +1553,7 @@ def run_module(module, arg_def):
     alloc_size = module.params.get('size')
     src_member = module.params.get('src_member')
     copy_member = module.params.get('copy_member')
+    force = module.params.get('force')
 
     # ********************************************************************
     # When copying to and from a data set member, 'dest' or 'src' will be
@@ -1723,7 +1722,8 @@ def run_module(module, arg_def):
             temp_path,
             src_ds_type,
             src_member,
-            member_name
+            member_name,
+            force
         )
         res_args['size'] = os.stat(dest).st_size
         remote_checksum = dest_checksum = None

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -23,7 +23,7 @@ short_description: Manage data sets
 description:
   - Create, delete and set attributes of data sets.
   - When forcing data set replacement, contents will not be preserved.
-version_added: "2.9"
+version_added: "1.3.0"
 author: "Blake Becker (@blakeinate)"
 options:
   name:
@@ -34,7 +34,7 @@ options:
       - Required if I(type=MEMBER) or I(state!=present) and not using I(batch).
     type: str
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
   state:
     description:
       - The final state desired for specified data set.
@@ -89,7 +89,7 @@ options:
       - absent
       - cataloged
       - uncataloged
-    version_added: "2.9"
+    version_added: "1.3.0"
   type:
     description:
       - The data set type to be used when creating a data set. (e.g C(pdse))
@@ -112,7 +112,7 @@ options:
       - HFS
       - ZFS
     default: PDS
-    version_added: "2.9"
+    version_added: "1.3.0"
   space_primary:
     description:
       - The amount of primary space to allocate for the dataset.
@@ -120,7 +120,7 @@ options:
     type: int
     required: false
     default: 5
-    version_added: "2.9"
+    version_added: "1.3.0"
   space_secondary:
     description:
       - The amount of secondary space to allocate for the dataset.
@@ -128,7 +128,7 @@ options:
     type: int
     required: false
     default: 3
-    version_added: "2.9"
+    version_added: "1.3.0"
   space_type:
     description:
       - The unit of measurement to use when defining primary and secondary space.
@@ -142,7 +142,7 @@ options:
       - TRK
     required: false
     default: M
-    version_added: "2.9"
+    version_added: "1.3.0"
   record_format:
     description:
       - The format of the data set. (e.g C(FB))
@@ -156,7 +156,7 @@ options:
       - U
     default: FB
     type: str
-    version_added: "2.9"
+    version_added: "1.3.0"
   sms_storage_class:
     description:
       - The storage class for an SMS-managed dataset.
@@ -165,7 +165,7 @@ options:
       - Note that all non-linear VSAM datasets are SMS-managed.
     type: str
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
   sms_data_class:
     description:
       - The data class for an SMS-managed dataset.
@@ -174,7 +174,7 @@ options:
       - Note that all non-linear VSAM datasets are SMS-managed.
     type: str
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
   sms_management_class:
     description:
       - The management class for an SMS-managed dataset.
@@ -183,7 +183,7 @@ options:
       - Note that all non-linear VSAM datasets are SMS-managed.
     type: str
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
   record_length:
     description:
       - The length, in bytes, of each record in the data set.
@@ -191,19 +191,19 @@ options:
       - "Defaults vary depending on format: If FB/FBA 80, if VB/VBA 137, if U 0."
     type: int
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
   block_size:
     description:
       - The block size to use for the data set.
     type: int
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
   directory_blocks:
     description:
       - The number of directory blocks to allocate to the data set.
     type: int
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
   key_offset:
     description:
       - The key offset to use when creating a KSDS data set.
@@ -211,7 +211,7 @@ options:
       - I(key_offset) should only be provided when I(type=KSDS)
     type: int
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
   key_length:
     description:
       - The key length to use when creating a KSDS data set.
@@ -219,7 +219,7 @@ options:
       - I(key_length) should only be provided when I(type=KSDS)
     type: int
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
   volumes:
     description:
       - >
@@ -238,7 +238,7 @@ options:
       - Accepts a string when using a single volume and a list of strings when using multiple.
     type: raw
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
     aliases:
       - volume
   replace:
@@ -252,14 +252,14 @@ options:
     type: bool
     required: false
     default: false
-    version_added: "2.9"
+    version_added: "1.3.0"
   batch:
     description:
       - Batch can be used to perform operations on multiple data sets in a single module call.
     type: list
     elements: dict
     required: false
-    version_added: "2.9"
+    version_added: "1.3.0"
     suboptions:
       name:
         description:
@@ -269,7 +269,7 @@ options:
           - Required if I(type=MEMBER) or I(state!=present)
         type: str
         required: false
-        version_added: "2.9"
+        version_added: "1.3.0"
       state:
         description:
           - The final state desired for specified data set.
@@ -324,7 +324,7 @@ options:
           - absent
           - cataloged
           - uncataloged
-        version_added: "2.9"
+        version_added: "1.3.0"
       type:
         description:
           - The data set type to be used when creating a data set. (e.g C(pdse))
@@ -347,7 +347,7 @@ options:
           - HFS
           - ZFS
         default: PDS
-        version_added: "2.9"
+        version_added: "1.3.0"
       space_primary:
         description:
           - The amount of primary space to allocate for the dataset.
@@ -355,7 +355,7 @@ options:
         type: int
         required: false
         default: 5
-        version_added: "2.9"
+        version_added: "1.3.0"
       space_secondary:
         description:
           - The amount of secondary space to allocate for the dataset.
@@ -363,7 +363,7 @@ options:
         type: int
         required: false
         default: 3
-        version_added: "2.9"
+        version_added: "1.3.0"
       space_type:
         description:
           - The unit of measurement to use when defining primary and secondary space.
@@ -377,7 +377,7 @@ options:
           - TRK
         required: false
         default: M
-        version_added: "2.9"
+        version_added: "1.3.0"
       record_format:
         description:
           - The format of the data set. (e.g C(FB))
@@ -391,7 +391,7 @@ options:
           - U
         default: FB
         type: str
-        version_added: "2.9"
+        version_added: "1.3.0"
       sms_storage_class:
         description:
           - The storage class for an SMS-managed dataset.
@@ -400,7 +400,7 @@ options:
           - Note that all non-linear VSAM datasets are SMS-managed.
         type: str
         required: false
-        version_added: "2.9"
+        version_added: "1.3.0"
       sms_data_class:
         description:
           - The data class for an SMS-managed dataset.
@@ -409,7 +409,7 @@ options:
           - Note that all non-linear VSAM datasets are SMS-managed.
         type: str
         required: false
-        version_added: "2.9"
+        version_added: "1.3.0"
       sms_management_class:
         description:
           - The management class for an SMS-managed dataset.
@@ -418,7 +418,7 @@ options:
           - Note that all non-linear VSAM datasets are SMS-managed.
         type: str
         required: false
-        version_added: "2.9"
+        version_added: "1.3.0"
       record_length:
         description:
           - The length, in bytes, of each record in the data set.
@@ -426,19 +426,19 @@ options:
           - "Defaults vary depending on format: If FB/FBA 80, if VB/VBA 137, if U 0."
         type: int
         required: false
-        version_added: "2.9"
+        version_added: "1.3.0"
       block_size:
         description:
           - The block size to use for the data set.
         type: int
         required: false
-        version_added: "2.9"
+        version_added: "1.3.0"
       directory_blocks:
         description:
           - The number of directory blocks to allocate to the data set.
         type: int
         required: false
-        version_added: "2.9"
+        version_added: "1.3.0"
       key_offset:
         description:
           - The key offset to use when creating a KSDS data set.
@@ -446,7 +446,7 @@ options:
           - I(key_offset) should only be provided when I(type=KSDS)
         type: int
         required: false
-        version_added: "2.9"
+        version_added: "1.3.0"
       key_length:
         description:
           - The key length to use when creating a KSDS data set.
@@ -454,7 +454,7 @@ options:
           - I(key_length) should only be provided when I(type=KSDS)
         type: int
         required: false
-        version_added: "2.9"
+        version_added: "1.3.0"
       volumes:
         description:
           - >
@@ -473,7 +473,7 @@ options:
           - Accepts a string when using a single volume and a list of strings when using multiple.
         type: raw
         required: false
-        version_added: "2.9"
+        version_added: "1.3.0"
         aliases:
           - volume
       replace:
@@ -487,7 +487,7 @@ options:
         type: bool
         required: false
         default: false
-        version_added: "2.9"
+        version_added: "1.3.0"
 
 """
 EXAMPLES = r"""

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -20,7 +20,7 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: zos_fetch
-version_added: "2.9"
+version_added: "1.1.0"
 short_description: Fetch data from z/OS
 description:
   - This module fetches a UNIX System Services (USS) file,

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -20,7 +20,7 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: zos_find
-version_added: "2.9"
+version_added: "1.3.0"
 short_description: Find matching data sets
 description:
   - Return a list of data sets based on specific criteria.

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -33,7 +33,7 @@ description:
     like "*".
   - If there is no ddname, or if ddname="?", output of all the ddnames under
     the given job will be displayed.
-version_added: "2.9"
+version_added: "1.0.0"
 author: "Jack Ho (@jacklotusho)"
 options:
   job_id:

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -235,7 +235,7 @@ def parsing_jobs(jobs_raw):
         elif "ABENDU" in status_raw:
             # status = 'Ended abnormally'
             ret_code = {"msg": status_raw, "code": job.get("ret_code").get("code")}
-        elif "CANCELED" or "JCLERR" in status_raw:
+        elif "CANCELED" in status_raw or "JCLERR" in status_raw:
             # status = status_raw
             ret_code = {"msg": status_raw, "code": None}
         else:

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -26,7 +26,7 @@ description:
     - Submit a job and optionally monitor for its execution.
     - Optionally wait for the job output until the job finishes.
     - For the uncataloged dataset, specify the volume serial number.
-version_added: "2.9"
+version_added: "1.0.0"
 options:
   src:
     required: true

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -27,7 +27,7 @@ description:
   - Run a z/OS program.
   - This is analogous to a job step in JCL.
   - Defaults will be determined by underlying API if value not provided.
-version_added: "2.9"
+version_added: "1.1.0"
 options:
   program_name:
     description:

--- a/plugins/modules/zos_ping.py
+++ b/plugins/modules/zos_ping.py
@@ -15,7 +15,7 @@
 DOCUMENTATION = r"""
 ---
 module: zos_ping
-version_added: 2.9
+version_added: "1.1.0"
 short_description: Ping z/OS and check dependencies.
 description:
   - M(zos_ping) verifies the presence of z/OS Web Client Enablement Toolkit,

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1597,7 +1597,7 @@ def test_ensure_tmp_cleanup(ansible_zos_module):
             cmd="ls -l", executable=SHELL_EXECUTABLE, chdir="/tmp"
         )
         file_count_post = len(list(stat_dir.contacted.values())[0].get("stdout_lines"))
-        assert file_count_post <= file_count_pre
+        assert file_count_post == file_count_pre + 1
 
     finally:
         hosts.all.file(path=dest_path, state="absent")
@@ -1909,7 +1909,6 @@ def test_backup_vsam_user_backup_path(ansible_zos_module):
         copy_res = hosts.all.zos_copy(
             src=src, dest=dest, backup=True, remote_src=True, backup_name=backup_name
         )
-        print(vars(copy_res))
 
         for result in copy_res.contacted.values():
             assert result.get("msg") is None

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1481,6 +1481,69 @@ def test_copy_to_existing_dest_not_forced(ansible_zos_module):
         hosts.all.file(path=dest_path, state="absent")
 
 
+def test_copy_dir_to_existing_uss_dir_not_forced(ansible_zos_module):
+    hosts = ansible_zos_module
+    dest_new_dir = "/tmp/new_dir"
+    dest_path = "{0}/profile".format(dest_new_dir)
+    dest_parent_dir = "/tmp/test_dir"
+    dest_old_dir = "{0}/old_dir".format(dest_parent_dir)
+
+    try:
+        hosts.all.file(path=dest_new_dir, state="directory")
+        hosts.all.file(path=dest_path, state="touch")
+        hosts.all.file(path=dest_old_dir, state="directory")
+
+        copy_result = hosts.all.zos_copy(
+            src=dest_new_dir,
+            dest=dest_parent_dir,
+            remote_src=True,
+            force=False
+        )
+
+        for result in copy_result.contacted.values():
+            assert result.get("msg") is not None
+            assert "Error" in result.get("msg")
+            assert "EDC5117I" in result.get("stdout")
+    finally:
+        hosts.all.file(path=dest_parent_dir, state="absent")
+        hosts.all.file(path=dest_new_dir, state="absent")
+
+
+def test_copy_dir_to_existing_uss_dir_forced(ansible_zos_module):
+    hosts = ansible_zos_module
+    dest_new_dir = "/tmp/new_dir/"
+    dest_path = "{0}profile".format(dest_new_dir)
+    dest_parent_dir = "/tmp/test_dir"
+    dest_old_dir = "{0}/old_dir".format(dest_parent_dir)
+    dest_dir = "{0}/profile".format(dest_parent_dir)
+
+    try:
+        hosts.all.file(path=dest_new_dir, state="directory")
+        hosts.all.file(path=dest_path, state="touch")
+        hosts.all.file(path=dest_old_dir, state="directory")
+
+        copy_result = hosts.all.zos_copy(
+            src=dest_new_dir,
+            dest=dest_parent_dir,
+            remote_src=True,
+            force=True
+        )
+
+        stat_old_dir_res = hosts.all.stat(path=dest_old_dir)
+        stat_new_dir_res = hosts.all.stat(path=dest_dir)
+        for result in copy_result.contacted.values():
+            assert result.get("msg") is None
+        for result in stat_old_dir_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is True
+        for result in stat_new_dir_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+
+    finally:
+        hosts.all.file(path=dest_parent_dir, state="absent")
+        hosts.all.file(path=dest_new_dir, state="absent")
+
+
 def test_copy_local_symlink_to_uss_file(ansible_zos_module):
     hosts = ansible_zos_module
     src_lnk = "/tmp/etclnk"

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -240,8 +240,8 @@ def test_find_data_sets_in_volume(ansible_zos_module):
     )
     print(vars(find_res))
     for val in find_res.contacted.values():
-        assert len(val.get('data_sets')) == 5
-        assert val.get('matched') == 5
+        assert len(val.get('data_sets')) >= 1
+        assert val.get('matched') >= 1
 
 
 def test_find_vsam_pattern(ansible_zos_module):

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -27,6 +27,5 @@ plugins/modules/zos_fetch.py validate-modules:undocumented-parameter # Passing a
 plugins/modules/zos_backup_restore.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-spec # We use our own argument parser for advanced conditional and dependent arguments.
 plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-docs/source/modules/zos_apf.rst rstcheck!skip #Inline emphasis start-string without end-string
 tests/dependencyfinder.py pylint:global-at-module-level # Ignore for test helper
 tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.


### PR DESCRIPTION
##### SUMMARY

Fixes both JIRA-8779 and JIRA-8780, bugs reported by clients about the temporary files and cleanup of the zos_copy module. Branched out from the v1.3.1 tag to create a patch for that version.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
zos_copy

##### ADDITIONAL INFORMATION

JIRA-8779 fixes the deletion of files already in a directory when Ansible is trying to copy new files into it.
JIRA-8780 fixes when Ansible is trying to clean up temporary files that are not from the zos_copy module at the end of execution.

