### PR TITLE
Bugfix/7525/changed default value for dds in zos_mvs_raw

### DIFF
--- a/changelogs/fragments/336-update-zos_copy-uss-to-pdse.yml
+++ b/changelogs/fragments/336-update-zos_copy-uss-to-pdse.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >
+    zos_mvs_raw - module was updated to correct a bug when no DD statements
+    were provided. The module when no option was provided for `dds` would
+    error, a default was provided to correct this behavior.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/327)

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1936,6 +1936,7 @@ def parse_and_validate_args(params):
         dds=dict(
             type="list",
             elements="dict",
+            default=[],
             options=dict(
                 dd_data_set=dd_data_set,
                 dd_unix=dd_unix,

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -23,6 +23,22 @@ import argparse
 
 
 class ArtifactManager(object):
+    """
+    Dependency analyzer will review modules and action plugin changes and then
+    discover which tests should be run. It addition to mapping a test suite,
+    whether it is functional or unit, it will also see if the module/plugin
+    is used in test cases. In the even a module is used in another test suite
+    unrelated to the modules test suite, it will also be returned. This ensures
+    that a module changes don't break test suites dependent on a module.
+
+    Usage (minimal) example:
+        python dependencyfinder.py -p .. -b origin/dev -m
+
+    Note: It is possible that only test cases are modified only, without a module
+    or modules, in that case without a module pairing no test cases will be
+    returned. Its best to run full regression in that case until this can be
+    updated to support detecting only test cases.
+    """
     artifacts = []
 
     def __init__(self, artifacts=None):
@@ -197,6 +213,14 @@ class Artifact(object):
         self.path = path
         if dependencies:
             self.dependencies = dependencies
+
+    def __str__(self):
+        """
+        Print the Artifact class instance variables in a pretty manor.
+        """
+        return "name: {0},\nsource: {1},\npath: {2}\n".format(self.name,
+                                                              self.source,
+                                                              self.path)
 
     @classmethod
     def from_path(cls, path):
@@ -473,6 +497,39 @@ def get_changed_files(path, branch="origin/dev"):
     return changed_files
 
 
+def get_changed_plugins(path, branch="origin/dev"):
+    """Get a list of modules or plugins in a specific branch.
+
+    Args:
+        branch (str, optional): The branch to compare to. Defaults to "dev".
+
+    Raises:
+        RuntimeError: When git request-pull fails.
+
+    Returns:
+        list[str]: A list of changed file paths.
+    """
+    changed_plugins_modules = []
+    get_diff_pr = subprocess.Popen(
+        ["git", "request-pull", branch, "./"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=path,
+    )
+
+    stdout, stderr = get_diff_pr.communicate()
+    stdout = stdout.decode("utf-8")
+
+    if get_diff_pr.returncode > 0:
+        raise RuntimeError("Could not acquire change list")
+    if stdout:
+        for line in stdout.split("\n"):
+            if "plugins/action/" in line or "plugins/modules/" in line:
+                changed_plugins_modules.append(line.split("|", 1)[0].strip())
+
+    return changed_plugins_modules
+
+
 def parse_arguments():
     """Parse and return command line arguments.
 
@@ -511,6 +568,14 @@ def parse_arguments():
         action="store_true",
         help="Print one test per line to stdout. Default behavior prints all tests on same line.",
     )
+    parser.add_argument(
+        "-m",
+        "--minimum",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Detect only the changes from the branch request-pull.",
+    )
     args = parser.parse_args()
     return args
 
@@ -525,7 +590,10 @@ if __name__ == "__main__":
     artifacts = build_artifacts_from_collection(args.path)
     all_artifact_manager = ArtifactManager(artifacts)
 
-    changed_files = get_changed_files(args.path, args.branch)
+    if args.minimum:
+        changed_files = get_changed_plugins(args.path, args.branch)
+    else:
+        changed_files = get_changed_files(args.path, args.branch)
 
     changed_artifacts = []
     for file in changed_files:

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2025,7 +2025,7 @@ def test_copy_multiple_data_set_members(ansible_zos_module):
             assert v_cp.get("rc") == 0
             stdout = v_cp.get("stdout")
             assert stdout is not None
-            assert(len(stdout.splitlines())) == 2
+            assert len(stdout.splitlines()) == 2
 
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -1756,7 +1756,6 @@ def test_unauthorized_program_run_unauthorized(ansible_zos_module):
     results = hosts.all.zos_mvs_raw(
         program_name="IEFBR14",
         auth=False,
-        dds=[],
     )
     hosts.all.zos_data_set(name=DEFAULT_DATA_SET, state="absent")
     for result in results.contacted.values():

--- a/tests/helpers/zos_blockinfile_helper.py
+++ b/tests/helpers/zos_blockinfile_helper.py
@@ -57,7 +57,7 @@ def set_ds_test_env(test_name, hosts, test_env):
     results = hosts.all.shell(cmd='hlq')
     for result in results.contacted.values():
         hlq = result.get("stdout")
-    if(len(hlq) > 8):
+    if len(hlq) > 8:
         hlq = hlq[:8]
     test_env["DS_NAME"] = hlq + "." + test_name.upper() + "." + test_env["DS_TYPE"]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes item 7525 on Jira by changing the way the argument parser treats the default value for the `dds` parameter in the `zos_mvs_raw` module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`zos_mvs_raw`

##### ADDITIONAL INFORMATION
This bug was reported to happen while trying to run the `IEFBR14` command in a playbook without specifying any DD statements. The command by itself doesn't need any DD statements but the module nonetheless throws an exception if you don't specify at least a dummy dataset. Additionally, the documentation states that the `dds` parameter is optional, so the argument parser was changed accordingly.
