### PR TITLE
[zos_copy] Copy subdirectories when copying into USS

### DIFF
--- a/changelogs/fragments/339-copy-sub-directories.yml
+++ b/changelogs/fragments/339-copy-sub-directories.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >
+    zos_copy - fixes a bug that would not copy subdirectories. If the source
+    is a directory with sub directories, all sub directories will now be copied.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/339)
+

--- a/changelogs/fragments/339-copy-sub-directories.yml
+++ b/changelogs/fragments/339-copy-sub-directories.yml
@@ -3,4 +3,3 @@ bugfixes:
     zos_copy - fixes a bug that would not copy subdirectories. If the source
     is a directory with sub directories, all sub directories will now be copied.
     (https://github.com/ansible-collections/ibm_zos_core/pull/339)
-

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -151,7 +151,9 @@ class ActionModule(ActionBase):
             else:
                 if is_src_dir:
                     path, dirs, files = next(os.walk(src))
-                    if dirs:
+                    # It should only fail preemptively when the src has subdirectories if
+                    # the module is trying to copy into a dataset.
+                    if dirs and not is_uss:
                         result["msg"] = "Subdirectory found inside source directory"
                         result.update(
                             dict(src=src, dest=dest, changed=False, failed=True)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1745,6 +1745,8 @@ def run_module(module, arg_def):
             res_args["changed"] = (
                 res_args.get("changed") or remote_checksum != dest_checksum
             )
+        elif dest_exists and force:
+            res_args["changed"] = True
 
     # ------------------------------- o -----------------------------------
     # Copy to sequential data set

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1595,7 +1595,7 @@ def test_copy_local_nested_dir_to_existing_uss_dir_forced(ansible_zos_module):
 
         hosts.all.file(path=dest_path, state="directory")
         copy_result = hosts.all.zos_copy(
-            src=source_path, 
+            src=source_path,
             dest=dest_path,
             force=True
         )
@@ -1687,7 +1687,7 @@ def test_copy_uss_nested_dir_to_existing_uss_dir_forced(ansible_zos_module):
         hosts.all.file(path=dest_path, state="directory")
 
         copy_result = hosts.all.zos_copy(
-            src=source_path, 
+            src=source_path,
             dest=dest_path,
             remote_src=True,
             force=True
@@ -1724,7 +1724,7 @@ def test_copy_uss_nested_dir_to_pdse(ansible_zos_module):
         hosts.all.file(path=subdir_b_path, state="directory")
 
         copy_result = hosts.all.zos_copy(
-            src=source_path, 
+            src=source_path,
             dest=dest_path,
             remote_src=True
         )

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1605,6 +1605,7 @@ def test_copy_local_nested_dir_to_existing_uss_dir_forced(ansible_zos_module):
 
         for result in copy_result.contacted.values():
             assert result.get("msg") is None
+            assert result.get("changed") is True
         for result in stat_subdir_a_res.contacted.values():
             assert result.get("stat").get("exists") is True
             assert result.get("stat").get("isdir") is True
@@ -1697,6 +1698,7 @@ def test_copy_uss_nested_dir_to_existing_uss_dir_forced(ansible_zos_module):
 
         for result in copy_result.contacted.values():
             assert result.get("msg") is None
+            assert result.get("changed") is True
         for result in stat_subdir_a_res.contacted.values():
             assert result.get("stat").get("exists") is True
             assert result.get("stat").get("isdir") is True

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1693,8 +1693,8 @@ def test_copy_uss_nested_dir_to_existing_uss_dir_forced(ansible_zos_module):
             force=True
         )
 
-        stat_subdir_a_res = hosts.all.stat(path="{0}/subdir_a".format(dest_path, source_path))
-        stat_subdir_b_res = hosts.all.stat(path="{0}/subdir_b".format(dest_path, source_path))
+        stat_subdir_a_res = hosts.all.stat(path="{0}/subdir_a".format(dest_path))
+        stat_subdir_b_res = hosts.all.stat(path="{0}/subdir_b".format(dest_path))
 
         for result in copy_result.contacted.values():
             assert result.get("msg") is None

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1544,6 +1544,103 @@ def test_copy_dir_to_existing_uss_dir_forced(ansible_zos_module):
         hosts.all.file(path=dest_new_dir, state="absent")
 
 
+def test_copy_local_nested_dir_to_uss(ansible_zos_module):
+    hosts = ansible_zos_module
+    dest_path = "/tmp/new_dir"
+
+    source_path = tempfile.mkdtemp()
+    source_parent_dir = source_path.split("/")[-1]
+    subdir_a_path = "{0}/subdir_a".format(source_path)
+    subdir_b_path = "{0}/subdir_b".format(source_path)
+
+    try:
+        # Creating a nested temp directory to copy.
+        os.mkdir(subdir_a_path)
+        os.mkdir(subdir_b_path)
+        populate_dir(subdir_a_path)
+        populate_dir(subdir_b_path)
+
+        copy_result = hosts.all.zos_copy(src=source_path, dest=dest_path)
+
+        stat_subdir_a_res = hosts.all.stat(path="{0}/{1}/subdir_a".format(dest_path, source_parent_dir))
+        stat_subdir_b_res = hosts.all.stat(path="{0}/{1}/subdir_b".format(dest_path, source_parent_dir))
+
+        for result in copy_result.contacted.values():
+            assert result.get("msg") is None
+        for result in stat_subdir_a_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is True
+        for result in stat_subdir_b_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is True
+
+    finally:
+        hosts.all.file(path=dest_path, state="absent")
+        shutil.rmtree(source_path)
+
+
+def test_copy_local_nested_dir_to_existing_uss_dir_forced(ansible_zos_module):
+    hosts = ansible_zos_module
+    dest_path = "/tmp/new_dir"
+
+    source_path = tempfile.mkdtemp()
+    source_parent_dir = source_path.split("/")[-1]
+    subdir_a_path = "{0}/subdir_a".format(source_path)
+    subdir_b_path = "{0}/subdir_b".format(source_path)
+
+    try:
+        # Creating a nested temp directory to copy.
+        os.mkdir(subdir_a_path)
+        os.mkdir(subdir_b_path)
+        populate_dir(subdir_a_path)
+        populate_dir(subdir_b_path)
+
+        hosts.all.file(path=dest_path, state="directory")
+        copy_result = hosts.all.zos_copy(
+            src=source_path, 
+            dest=dest_path,
+            force=True
+        )
+
+        stat_subdir_a_res = hosts.all.stat(path="{0}/{1}/subdir_a".format(dest_path, source_parent_dir))
+        stat_subdir_b_res = hosts.all.stat(path="{0}/{1}/subdir_b".format(dest_path, source_parent_dir))
+
+        for result in copy_result.contacted.values():
+            assert result.get("msg") is None
+        for result in stat_subdir_a_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is True
+        for result in stat_subdir_b_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is True
+
+    finally:
+        hosts.all.file(path=dest_path, state="absent")
+        shutil.rmtree(source_path)
+
+
+def test_copy_local_nested_dir_to_pdse(ansible_zos_module):
+    hosts = ansible_zos_module
+    dest_path = "USER.TEST.DIR"
+
+    source_path = tempfile.mkdtemp()
+    subdir_a_path = "{0}/subdir_a".format(source_path)
+    subdir_b_path = "{0}/subdir_b".format(source_path)
+
+    try:
+        # Creating a nested temp directory to copy.
+        os.mkdir(subdir_a_path)
+        os.mkdir(subdir_b_path)
+
+        copy_result = hosts.all.zos_copy(src=source_path, dest=dest_path)
+
+        for result in copy_result.contacted.values():
+            assert result.get("msg") is not None
+    finally:
+        hosts.all.zos_data_set(name=dest_path, state="absent")
+        shutil.rmtree(source_path)
+
+
 def test_copy_local_symlink_to_uss_file(ansible_zos_module):
     hosts = ansible_zos_module
     src_lnk = "/tmp/etclnk"


### PR DESCRIPTION
##### SUMMARY

Addresses a client's issue when trying to copy a local directory that has multiple subdirectories in its root into USS.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zos_copy

##### ADDITIONAL INFORMATION

The module already validates that the user is not trying to copy subdirectories into a PDSE, but this validation also affects trying to copy into USS. Since its possible to copy a complex tree structure into USS (and, in fact, the module already does this when using a remote source), the module now allows to copy subdirectories into USS from a local source.

When using `force=true` in the module parameters while copying a directory into USS, the module now returns `changed=true`.
