### PR TITLE
Changed the encoding options to suboptions

### DIFF
--- a/changelogs/fragments/345-update-encoding-options.yml
+++ b/changelogs/fragments/345-update-encoding-options.yml
@@ -1,0 +1,6 @@
+deprecated_features:
+  - >
+    zos_encode - deprecates the module options `from_encoding` and
+    `to_encoding` to use suboptions `from` and `to` in order to remain
+    consistent with all other modules.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/345).

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -23,6 +23,22 @@ import argparse
 
 
 class ArtifactManager(object):
+    """
+    Dependency analyzer will review modules and action plugin changes and then
+    discover which tests should be run. It addition to mapping a test suite,
+    whether it is functional or unit, it will also see if the module/plugin
+    is used in test cases. In the even a module is used in another test suite
+    unrelated to the modules test suite, it will also be returned. This ensures
+    that a module changes don't break test suites dependent on a module.
+
+    Usage (minimal) example:
+        python dependencyfinder.py -p .. -b origin/dev -m
+
+    Note: It is possible that only test cases are modified only, without a module
+    or modules, in that case without a module pairing no test cases will be
+    returned. Its best to run full regression in that case until this can be
+    updated to support detecting only test cases.
+    """
     artifacts = []
 
     def __init__(self, artifacts=None):
@@ -197,6 +213,14 @@ class Artifact(object):
         self.path = path
         if dependencies:
             self.dependencies = dependencies
+
+    def __str__(self):
+        """
+        Print the Artifact class instance variables in a pretty manor.
+        """
+        return "name: {0},\nsource: {1},\npath: {2}\n".format(self.name,
+                                                              self.source,
+                                                              self.path)
 
     @classmethod
     def from_path(cls, path):
@@ -473,6 +497,39 @@ def get_changed_files(path, branch="origin/dev"):
     return changed_files
 
 
+def get_changed_plugins(path, branch="origin/dev"):
+    """Get a list of modules or plugins in a specific branch.
+
+    Args:
+        branch (str, optional): The branch to compare to. Defaults to "dev".
+
+    Raises:
+        RuntimeError: When git request-pull fails.
+
+    Returns:
+        list[str]: A list of changed file paths.
+    """
+    changed_plugins_modules = []
+    get_diff_pr = subprocess.Popen(
+        ["git", "request-pull", branch, "./"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=path,
+    )
+
+    stdout, stderr = get_diff_pr.communicate()
+    stdout = stdout.decode("utf-8")
+
+    if get_diff_pr.returncode > 0:
+        raise RuntimeError("Could not acquire change list")
+    if stdout:
+        for line in stdout.split("\n"):
+            if "plugins/action/" in line or "plugins/modules/" in line:
+                changed_plugins_modules.append(line.split("|", 1)[0].strip())
+
+    return changed_plugins_modules
+
+
 def parse_arguments():
     """Parse and return command line arguments.
 
@@ -511,6 +568,14 @@ def parse_arguments():
         action="store_true",
         help="Print one test per line to stdout. Default behavior prints all tests on same line.",
     )
+    parser.add_argument(
+        "-m",
+        "--minimum",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Detect only the changes from the branch request-pull.",
+    )
     args = parser.parse_args()
     return args
 
@@ -525,7 +590,10 @@ if __name__ == "__main__":
     artifacts = build_artifacts_from_collection(args.path)
     all_artifact_manager = ArtifactManager(artifacts)
 
-    changed_files = get_changed_files(args.path, args.branch)
+    if args.minimum:
+        changed_files = get_changed_plugins(args.path, args.branch)
+    else:
+        changed_files = get_changed_files(args.path, args.branch)
 
     changed_artifacts = []
     for file in changed_files:

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2032,7 +2032,7 @@ def test_copy_multiple_data_set_members(ansible_zos_module):
             assert v_cp.get("rc") == 0
             stdout = v_cp.get("stdout")
             assert stdout is not None
-            assert(len(stdout.splitlines())) == 2
+            assert len(stdout.splitlines()) == 2
 
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")

--- a/tests/functional/modules/test_zos_encode_func.py
+++ b/tests/functional/modules/test_zos_encode_func.py
@@ -77,7 +77,11 @@ KSDS_REPRO_JCL = """//DOREPRO    JOB (T043JM,JM00,1,0,0,0),'CREATE KSDS',CLASS=R
 def test_uss_encoding_conversion_with_invalid_encoding(ansible_zos_module):
     hosts = ansible_zos_module
     results = hosts.all.zos_encode(
-        src=USS_FILE, from_encoding=INVALID_ENCODING, to_encoding=TO_ENCODING
+        src=USS_FILE,
+        encoding={
+            "from": INVALID_ENCODING,
+            "to": TO_ENCODING,
+        },
     )
     pprint(vars(results))
     for result in results.contacted.values():
@@ -89,7 +93,11 @@ def test_uss_encoding_conversion_with_invalid_encoding(ansible_zos_module):
 def test_uss_encoding_conversion_with_the_same_encoding(ansible_zos_module):
     hosts = ansible_zos_module
     results = hosts.all.zos_encode(
-        src=USS_FILE, from_encoding=FROM_ENCODING, to_encoding=FROM_ENCODING
+        src=USS_FILE,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": FROM_ENCODING,
+        },
     )
     pprint(vars(results))
     for result in results.contacted.values():
@@ -102,7 +110,11 @@ def test_uss_encoding_conversion_without_dest(ansible_zos_module):
     hosts = ansible_zos_module
     hosts.all.copy(content=TEST_DATA, dest=USS_FILE)
     results = hosts.all.zos_encode(
-        src=USS_FILE, from_encoding=FROM_ENCODING, to_encoding=TO_ENCODING
+        src=USS_FILE,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
     )
     hosts.all.file(path=USS_FILE, state="absent")
     pprint(vars(results))
@@ -120,8 +132,10 @@ def test_uss_encoding_conversion_when_dest_not_exists_01(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=USS_FILE,
         dest=USS_NONE_FILE,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
         backup=True,
     )
     hosts.all.file(path=USS_FILE, state="absent")
@@ -141,8 +155,10 @@ def test_uss_encoding_conversion_when_dest_not_exists_02(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=MVS_PS,
         dest=MVS_NONE_PS,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
     )
     pprint(vars(results))
     for result in results.contacted.values():
@@ -159,8 +175,10 @@ def test_uss_encoding_conversion_uss_file_to_uss_file(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=USS_FILE,
         dest=USS_DEST_FILE,
-        from_encoding=TO_ENCODING,
-        to_encoding=FROM_ENCODING,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
     )
     hosts.all.file(path=USS_FILE, state="absent")
     hosts.all.file(path=USS_DEST_FILE, state="absent")
@@ -179,8 +197,10 @@ def test_uss_encoding_conversion_uss_file_to_uss_path(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=USS_FILE,
         dest=USS_DEST_PATH,
-        from_encoding=TO_ENCODING,
-        to_encoding=FROM_ENCODING,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
     )
     hosts.all.file(path=USS_FILE, state="absent")
     hosts.all.file(path=USS_DEST_PATH, state="absent")
@@ -201,8 +221,10 @@ def test_uss_encoding_conversion_uss_path_to_uss_path(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=USS_PATH,
         dest=USS_DEST_PATH,
-        from_encoding=TO_ENCODING,
-        to_encoding=FROM_ENCODING,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
         backup=True,
     )
     hosts.all.file(path=USS_PATH, state="absent")
@@ -220,7 +242,12 @@ def test_uss_encoding_conversion_uss_file_to_mvs_ps(ansible_zos_module):
     hosts.all.copy(content=TEST_DATA, dest=USS_FILE)
     hosts.all.zos_data_set(name=MVS_PS, state="present", type="seq")
     results = hosts.all.zos_encode(
-        src=USS_FILE, dest=MVS_PS, from_encoding=TO_ENCODING, to_encoding=FROM_ENCODING
+        src=USS_FILE,
+        dest=MVS_PS,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
     )
     pprint(vars(results))
     for result in results.contacted.values():
@@ -236,8 +263,10 @@ def test_uss_encoding_conversion_mvs_ps_to_uss_file(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=MVS_PS,
         dest=USS_DEST_FILE,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
         backup=True,
     )
     hosts.all.file(path=USS_DEST_FILE, state="absent")
@@ -254,7 +283,12 @@ def test_uss_encoding_conversion_uss_file_to_mvs_pds(ansible_zos_module):
     hosts.all.copy(content=TEST_DATA, dest=USS_FILE)
     hosts.all.zos_data_set(name=MVS_PDS, state="present", type="pds", record_length=80)
     results = hosts.all.zos_encode(
-        src=USS_FILE, dest=MVS_PDS, from_encoding=TO_ENCODING, to_encoding=FROM_ENCODING
+        src=USS_FILE,
+        dest=MVS_PDS,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
     )
     pprint(vars(results))
     for result in results.contacted.values():
@@ -278,8 +312,10 @@ def test_uss_encoding_conversion_uss_file_to_mvs_pds_member(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=USS_FILE,
         dest=MVS_PDS_MEMBER,
-        from_encoding=TO_ENCODING,
-        to_encoding=FROM_ENCODING,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
     )
     hosts.all.file(path=USS_FILE, state="absent")
     pprint(vars(results))
@@ -296,8 +332,10 @@ def test_uss_encoding_conversion_mvs_pds_member_to_uss_file(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=MVS_PDS_MEMBER,
         dest=USS_DEST_FILE,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
         backup=True,
     )
     hosts.all.file(path=USS_DEST_FILE, state="absent")
@@ -316,7 +354,12 @@ def test_uss_encoding_conversion_uss_path_to_mvs_pds(ansible_zos_module):
     hosts.all.copy(content=TEST_DATA, dest=USS_PATH + "/encode2")
     hosts.all.zos_data_set(name=MVS_PDS, state="present", type="pds", record_length=80)
     results = hosts.all.zos_encode(
-        src=USS_PATH, dest=MVS_PDS, from_encoding=TO_ENCODING, to_encoding=FROM_ENCODING
+        src=USS_PATH,
+        dest=MVS_PDS,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        }
     )
     hosts.all.file(path=USS_PATH, state="absent")
     pprint(vars(results))
@@ -333,8 +376,10 @@ def test_uss_encoding_conversion_mvs_pds_to_uss_path(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=MVS_PDS,
         dest=USS_DEST_PATH,
-        from_encoding=TO_ENCODING,
-        to_encoding=FROM_ENCODING,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
     )
     pprint(vars(results))
     for result in results.contacted.values():
@@ -349,8 +394,10 @@ def test_uss_encoding_conversion_mvs_ps_to_mvs_pds_member(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=MVS_PS,
         dest=MVS_PDS_MEMBER,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
     )
     pprint(vars(results))
     for result in results.contacted.values():
@@ -376,7 +423,12 @@ def test_uss_encoding_conversion_uss_file_to_mvs_vsam(ansible_zos_module):
         assert result.get("jobs")[0].get("ret_code").get("code") == 0
         assert result.get("changed") is True
     results = hosts.all.zos_encode(
-        src=USS_FILE, dest=MVS_VS, from_encoding=TO_ENCODING, to_encoding=FROM_ENCODING
+        src=USS_FILE,
+        dest=MVS_VS,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
     )
     pprint(vars(results))
     for result in results.contacted.values():
@@ -392,8 +444,10 @@ def test_uss_encoding_conversion_mvs_vsam_to_uss_file(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=MVS_VS,
         dest=USS_DEST_FILE,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
         backup=True,
     )
     hosts.all.file(path=USS_DEST_FILE, state="absent")
@@ -410,7 +464,12 @@ def test_uss_encoding_conversion_mvs_vsam_to_mvs_ps(ansible_zos_module):
     hosts.all.zos_data_set(name=MVS_PS, state="absent")
     hosts.all.zos_data_set(name=MVS_PS, state="present", type="seq", record_length=47)
     results = hosts.all.zos_encode(
-        src=MVS_VS, dest=MVS_PS, from_encoding=FROM_ENCODING, to_encoding=TO_ENCODING
+        src=MVS_VS,
+        dest=MVS_PS,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
     )
     pprint(vars(results))
     for result in results.contacted.values():
@@ -425,8 +484,10 @@ def test_uss_encoding_conversion_mvs_vsam_to_mvs_pds_member(ansible_zos_module):
     results = hosts.all.zos_encode(
         src=MVS_VS,
         dest=MVS_PDS_MEMBER,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
     )
     hosts.all.zos_data_set(name=MVS_PDS, state="absent")
     pprint(vars(results))
@@ -455,7 +516,12 @@ def test_uss_encoding_conversion_mvs_ps_to_mvs_vsam(ansible_zos_module):
         assert result.get("jobs")[0].get("ret_code").get("code") == 0
         assert result.get("changed") is True
     results = hosts.all.zos_encode(
-        src=MVS_PS, dest=MVS_VS, from_encoding=TO_ENCODING, to_encoding=FROM_ENCODING
+        src=MVS_PS,
+        dest=MVS_VS,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
     )
     hosts.all.zos_data_set(name=MVS_PS, state="absent")
     pprint(vars(results))
@@ -475,8 +541,10 @@ def test_pds_backup(ansible_zos_module):
     hosts.all.shell(cmd="cp {0} \"//'{1}(SAMPLE)'\"".format(TEMP_JCL_PATH, MVS_PDS))
     hosts.all.zos_encode(
         src=MVS_PDS,
-        from_encoding=TO_ENCODING,
-        to_encoding=FROM_ENCODING,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
         backup=True,
         backup_name=BACKUP_DATA_SET,
     )
@@ -498,8 +566,10 @@ def test_ps_backup(ansible_zos_module):
     hosts.all.shell(cmd="cp {0} \"//'{1}'\"".format(TEMP_JCL_PATH, MVS_PS))
     hosts.all.zos_encode(
         src=MVS_PS,
-        from_encoding=TO_ENCODING,
-        to_encoding=FROM_ENCODING,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
         backup=True,
         backup_name=BACKUP_DATA_SET,
     )
@@ -542,8 +612,10 @@ def test_vsam_backup(ansible_zos_module):
     hosts.all.zos_encode(
         src=MVS_VS,
         dest=MVS_PS,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
     )
     contents = hosts.all.shell(cmd="cat \"//'{0}'\"".format(MVS_PS))
     content1 = ""
@@ -552,8 +624,10 @@ def test_vsam_backup(ansible_zos_module):
         content1 = content.get("stdout")
     hosts.all.zos_encode(
         src=MVS_VS,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
         backup=True,
         backup_name=BACKUP_DATA_SET,
     )
@@ -563,8 +637,10 @@ def test_vsam_backup(ansible_zos_module):
     hosts.all.zos_encode(
         src=BACKUP_DATA_SET,
         dest=MVS_PS,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
     )
 
     contents = hosts.all.shell(cmd="cat \"//'{0}'\"".format(MVS_PS))
@@ -602,8 +678,10 @@ def test_uss_backup_entire_folder_to_default_backup_location(ansible_zos_module)
     results = hosts.all.zos_encode(
         src=MVS_PDS,
         dest=TEMP_JCL_PATH + "2",
-        from_encoding=TO_ENCODING,
-        to_encoding=FROM_ENCODING,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
         backup=True,
     )
     backup_name = None
@@ -661,8 +739,10 @@ def test_uss_backup_entire_folder_to_default_backup_location_compressed(
     results = hosts.all.zos_encode(
         src=MVS_PDS,
         dest=TEMP_JCL_PATH + "2",
-        from_encoding=TO_ENCODING,
-        to_encoding=FROM_ENCODING,
+        encoding={
+            "from": TO_ENCODING,
+            "to": FROM_ENCODING,
+        },
         backup=True,
         backup_compress=True,
     )
@@ -683,8 +763,10 @@ def test_return_backup_name_on_module_success_and_failure(ansible_zos_module):
     hosts.all.zos_copy(src=TEMP_JCL_PATH, dest=MVS_PS, remote_src=True)
     enc_ds = hosts.all.zos_encode(
         src=MVS_PS,
-        from_encoding=FROM_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": FROM_ENCODING,
+            "to": TO_ENCODING,
+        },
         backup=True,
         backup_name=BACKUP_DATA_SET,
     )
@@ -695,8 +777,10 @@ def test_return_backup_name_on_module_success_and_failure(ansible_zos_module):
     hosts.all.zos_data_set(name=BACKUP_DATA_SET, state="absent")
     enc_ds = hosts.all.zos_encode(
         src=MVS_PS,
-        from_encoding=INVALID_ENCODING,
-        to_encoding=TO_ENCODING,
+        encoding={
+            "from": INVALID_ENCODING,
+            "to": TO_ENCODING,
+        },
         backup=True,
         backup_name=BACKUP_DATA_SET,
     )

--- a/tests/helpers/zos_blockinfile_helper.py
+++ b/tests/helpers/zos_blockinfile_helper.py
@@ -72,9 +72,14 @@ def set_ds_test_env(test_name, hosts, test_env):
             cmdStr = "cp {0} \"//'{1}'\" ".format(quote(TEMP_FILE), test_env["DS_NAME"])
 
         if test_env["ENCODING"] != "IBM-1047":
-            hosts.all.zos_encode(src=TEMP_FILE, dest=test_env["DS_NAME"], from_encoding="IBM-1047", to_encoding=test_env["ENCODING"])
-            # cmdStr = "/u/behnam/tools/cp_withencoding/bin/cp2 {0} {1} {2}".format(test_env["ENCODING"], quote(TEMP_FILE), quote(test_env["DS_NAME"]))
-            # hosts.all.shell(cmd=cmdStr)
+            hosts.all.zos_encode(
+                src=TEMP_FILE,
+                dest=test_env["DS_NAME"],
+                encoding={
+                    "from": "IBM-1047",
+                    "to": test_env["ENCODING"],
+                },
+            )
         else:
             hosts.all.shell(cmd=cmdStr)
         hosts.all.shell(cmd="rm -rf " + test_env["TEST_DIR"])

--- a/tests/helpers/zos_blockinfile_helper.py
+++ b/tests/helpers/zos_blockinfile_helper.py
@@ -57,7 +57,7 @@ def set_ds_test_env(test_name, hosts, test_env):
     results = hosts.all.shell(cmd='hlq')
     for result in results.contacted.values():
         hlq = result.get("stdout")
-    if(len(hlq) > 8):
+    if len(hlq) > 8:
         hlq = hlq[:8]
     test_env["DS_NAME"] = hlq + "." + test_name.upper() + "." + test_env["DS_TYPE"]
 

--- a/tests/helpers/zos_lineinfile_helper.py
+++ b/tests/helpers/zos_lineinfile_helper.py
@@ -78,7 +78,14 @@ def set_ds_test_env(test_name, hosts, test_env):
             cmdStr = "cp {0} \"//'{1}'\" ".format(quote(TEMP_FILE), test_env["DS_NAME"])
 
         if test_env["ENCODING"] != "IBM-1047":
-            hosts.all.zos_encode(src=TEMP_FILE, dest=test_env["DS_NAME"], from_encoding="IBM-1047", to_encoding=test_env["ENCODING"])
+            hosts.all.zos_encode(
+                src=TEMP_FILE,
+                dest=test_env["DS_NAME"],
+                encoding={
+                    "from": "IBM-1047",
+                    "to": test_env["ENCODING"],
+                },
+            )
         else:
             hosts.all.shell(cmd=cmdStr)
         hosts.all.shell(cmd="rm -rf " + TEMP_FILE)


### PR DESCRIPTION
##### SUMMARY

Addresses JIRA-1978, an enhancement for the `zos_encode` module. Instead of using `from_encoding` and `to_encoding` to define the encoding conversion, the module now uses the interface found in all the other modules of the collection, i.e., an `encoding` parameter with suboptions `from` and `to`.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

zos_encode

##### ADDITIONAL INFORMATION

Before this change, all other modules of the collection that can handle encoding conversion between files and datasets used the same interface for defining the way the conversion happened, except for `zos_encode`. The purpose of this PR is to bring consistency across the interfaces of all modules in the collection.

@fernandofloresg brought up a really important point about supporting the old interface for users that already have working playbooks. Should we keep the old options `from_encoding` and `to_encoding` or just keep the new suboptions? Do note that the current state of `zos_encode` in this branch deleted all references to the old options, but they can be brought in again without too much problem.
