### PR TITLE
Added documentation for local_charset parameter

### DIFF
--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -134,6 +134,13 @@ options:
     type: bool
     required: false
     default: false
+  local_charset:
+    description:
+      - Used to explictly define the local charset for the controller, in case encoding
+        is not defined zos_fetch will default the encoding values as from = remote node
+        default charset and to = local_charset.
+    type: str
+    required: false
 notes:
     - When fetching PDSE and VSAM data sets, temporary storage will be used
       on the remote z/OS system. After the PDSE or VSAM data set is


### PR DESCRIPTION
##### SUMMARY
Added documentation for local_charset parameter to remove below messages when running `ansible-test sanity --test validate-modules`: 

ERROR: plugins/modules/zos_fetch.py:0:0: parameter-type-not-in-doc: Argument 'local_charset' in argument_spec defines type as 'str' but documentation doesn't define type
ERROR: plugins/modules/zos_fetch.py:0:0: undocumented-parameter: Argument 'local_charset' is listed in the argument_spec, but not documented in the module documentation

defined in #343 . Does not fixes all the issues this rather is an atomic PR, let me know if a PR with bigger impact is preferred.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zos_fetch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
