### PR TITLE
enhancement/9108/zos_job_submit_test Modify zos_job_submit functional test suite to not leave tmp files

### DIFF
--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -62,75 +62,81 @@ HELLO, WORLD
 """
 
 
-TEMP_PATH = "/tmp/ansible/jcl"
+TEMP_PATH = "/tmp/jcl"
 DATA_SET_NAME = "imstestl.ims1.test05"
 DATA_SET_NAME_SPECIAL_CHARS = "imstestl.im@1.xxx05"
 
 
 def test_job_submit_PDS(ansible_zos_module):
-    hosts = ansible_zos_module
-    hosts.all.file(path=TEMP_PATH, state="directory")
-    hosts.all.shell(
-        cmd="echo {0} > {1}/SAMPLE".format(quote(JCL_FILE_CONTENTS), TEMP_PATH)
-    )
-    hosts.all.zos_data_set(
-        name=DATA_SET_NAME, state="present", type="pds", replace=True
-    )
-    hosts.all.shell(
-        cmd="cp {0}/SAMPLE \"//'{1}(SAMPLE)'\"".format(TEMP_PATH, DATA_SET_NAME)
-    )
-    results = hosts.all.zos_job_submit(
-        src="{0}(SAMPLE)".format(DATA_SET_NAME), location="DATA_SET", wait=True
-    )
-    hosts.all.file(path=TEMP_PATH, state="absent")
-    for result in results.contacted.values():
-        print("\nTJSP.................\n")
-        print(result)
-        assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
-        assert result.get("jobs")[0].get("ret_code").get("code") == 0
-        assert result.get("changed") is True
+    try:
+        hosts = ansible_zos_module
+        hosts.all.file(path=TEMP_PATH, state="directory")
+        hosts.all.shell(
+            cmd="echo {0} > {1}/SAMPLE".format(quote(JCL_FILE_CONTENTS), TEMP_PATH)
+        )
+        hosts.all.zos_data_set(
+            name=DATA_SET_NAME, state="present", type="pds", replace=True
+        )
+        hosts.all.shell(
+            cmd="cp {0}/SAMPLE \"//'{1}(SAMPLE)'\"".format(TEMP_PATH, DATA_SET_NAME)
+        )
+        results = hosts.all.zos_job_submit(
+            src="{0}(SAMPLE)".format(DATA_SET_NAME), location="DATA_SET", wait=True
+        )
+        for result in results.contacted.values():
+            print("\nTJSP.................\n")
+            print(result)
+            assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
+            assert result.get("jobs")[0].get("ret_code").get("code") == 0
+            assert result.get("changed") is True
+    finally:
+        hosts.all.file(path=TEMP_PATH, state="absent")
 
 
 def test_job_submit_PDS_special_characters(ansible_zos_module):
-    hosts = ansible_zos_module
-    hosts.all.file(path=TEMP_PATH, state="directory")
-    hosts.all.shell(
-        cmd="echo {0} > {1}/SAMPLE".format(quote(JCL_FILE_CONTENTS), TEMP_PATH)
-    )
-    hosts.all.zos_data_set(
-        name=DATA_SET_NAME_SPECIAL_CHARS, state="present", type="pds", replace=True
-    )
-    hosts.all.shell(
-        cmd="cp {0}/SAMPLE \"//'{1}(SAMPLE)'\"".format(
-            TEMP_PATH, DATA_SET_NAME_SPECIAL_CHARS
+    try:
+        hosts = ansible_zos_module
+        hosts.all.file(path=TEMP_PATH, state="directory")
+        hosts.all.shell(
+            cmd="echo {0} > {1}/SAMPLE".format(quote(JCL_FILE_CONTENTS), TEMP_PATH)
         )
-    )
-    results = hosts.all.zos_job_submit(
-        src="{0}(SAMPLE)".format(DATA_SET_NAME_SPECIAL_CHARS),
-        location="DATA_SET",
-        wait=True,
-    )
-    hosts.all.file(path=TEMP_PATH, state="absent")
-    for result in results.contacted.values():
-        assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
-        assert result.get("jobs")[0].get("ret_code").get("code") == 0
-        assert result.get("changed") is True
+        hosts.all.zos_data_set(
+            name=DATA_SET_NAME_SPECIAL_CHARS, state="present", type="pds", replace=True
+        )
+        hosts.all.shell(
+            cmd="cp {0}/SAMPLE \"//'{1}(SAMPLE)'\"".format(
+                TEMP_PATH, DATA_SET_NAME_SPECIAL_CHARS
+            )
+        )
+        results = hosts.all.zos_job_submit(
+            src="{0}(SAMPLE)".format(DATA_SET_NAME_SPECIAL_CHARS),
+            location="DATA_SET",
+            wait=True,
+        )
+        for result in results.contacted.values():
+            assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
+            assert result.get("jobs")[0].get("ret_code").get("code") == 0
+            assert result.get("changed") is True
+    finally:
+        hosts.all.file(path=TEMP_PATH, state="absent")
 
 
 def test_job_submit_USS(ansible_zos_module):
-    hosts = ansible_zos_module
-    hosts.all.file(path=TEMP_PATH, state="directory")
-    hosts.all.shell(
-        cmd="echo {0} > {1}/SAMPLE".format(quote(JCL_FILE_CONTENTS), TEMP_PATH)
-    )
-    results = hosts.all.zos_job_submit(
-        src="{0}/SAMPLE".format(TEMP_PATH), location="USS", wait=True, volume=None
-    )
-    hosts.all.file(path=TEMP_PATH, state="absent")
-    for result in results.contacted.values():
-        assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
-        assert result.get("jobs")[0].get("ret_code").get("code") == 0
-        assert result.get("changed") is True
+    try:
+        hosts = ansible_zos_module
+        hosts.all.file(path=TEMP_PATH, state="directory")
+        hosts.all.shell(
+            cmd="echo {0} > {1}/SAMPLE".format(quote(JCL_FILE_CONTENTS), TEMP_PATH)
+        )
+        results = hosts.all.zos_job_submit(
+            src="{0}/SAMPLE".format(TEMP_PATH), location="USS", wait=True, volume=None
+        )
+        for result in results.contacted.values():
+            assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
+            assert result.get("jobs")[0].get("ret_code").get("code") == 0
+            assert result.get("changed") is True
+    finally:
+        hosts.all.file(path=TEMP_PATH, state="absent")
 
 
 def test_job_submit_LOCAL(ansible_zos_module):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Modified path for temp JCL and added try- finally blocks to ensure cleanup in tests even in failures.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/functional/modules/test_zos_job_submit_func.py

Before this change executing python3 -m pytest --ignore=functional/modules/test_module_security.py --durations=0 --host-pattern=all -Z=/var/lib/jenkins/workspace/zos-multipath-4/ibm_zos_core/configuration.yml ../tests/functional/modules/test_zos_job_submit_func.py would leave a folder called Ansible in /tmp.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
