### PR TITLE
[Bug] zos_operator throws TypeError when wait_time_s is specified 

### DIFF
--- a/changelogs/fragments/389-fixes-zos-operator-timeout-option.yml
+++ b/changelogs/fragments/389-fixes-zos-operator-timeout-option.yml
@@ -4,6 +4,6 @@ bugfixes:
   - ibm_zos_operator - fixed the wait_time_s to default to 1 second (https://github.com/ansible-collections/ibm_zos_core/issues/389).
 minor_changes:
   - ibm_zos_operator - deprecated the wait option, not needed with wait_time_s minor_changes (https://github.com/ansible-collections/ibm_zos_core/issues/389).
-  - ibm_zos_operator - added in the reponse the cmd result (https://github.com/ansible-collections/ibm_zos_core/issues/389).
-  - ibm_zos_operator - added in the reponse the wait_time_s set (https://github.com/ansible-collections/ibm_zos_core/issues/389).
-  - ibm_zos_operator - added in the reponse the elapsed time (https://github.com/ansible-collections/ibm_zos_core/issues/389).
+  - ibm_zos_operator - added in the response the cmd result (https://github.com/ansible-collections/ibm_zos_core/issues/389).
+  - ibm_zos_operator - added in the response the wait_time_s set (https://github.com/ansible-collections/ibm_zos_core/issues/389).
+  - ibm_zos_operator - added in the response the elapsed time (https://github.com/ansible-collections/ibm_zos_core/issues/389).

--- a/changelogs/fragments/389-fixes-zos-operator-timeout-option.yml
+++ b/changelogs/fragments/389-fixes-zos-operator-timeout-option.yml
@@ -1,6 +1,9 @@
 bugfixes:
-  - >
-    ibm_zos_operator - Fixes a bug such that when specifying 
-    wait_time_s and wait=True in zos_operator it throws an error
-    and does not execute the command.
-    (https://github.com/ansible-collections/ibm_zos_core/issues/389).
+  - ibm_zos_operator - fixed such that specifying wait_time_s would throw an error (https://github.com/ansible-collections/ibm_zos_core/issues/389).
+  - ibm_zos_operator - fixed case sensitive error checks, invalid, error & unidentifiable (https://github.com/ansible-collections/ibm_zos_core/issues/389).
+  - ibm_zos_operator - fixed the wait_time_s to default to 1 second (https://github.com/ansible-collections/ibm_zos_core/issues/389).
+minor_changes:
+  - ibm_zos_operator - deprecated the wait option, not needed with wait_time_s minor_changes (https://github.com/ansible-collections/ibm_zos_core/issues/389).
+  - ibm_zos_operator - added in the reponse the cmd result (https://github.com/ansible-collections/ibm_zos_core/issues/389).
+  - ibm_zos_operator - added in the reponse the wait_time_s set (https://github.com/ansible-collections/ibm_zos_core/issues/389).
+  - ibm_zos_operator - added in the reponse the elapsed time (https://github.com/ansible-collections/ibm_zos_core/issues/389).

--- a/changelogs/fragments/389-fixes-zos-operator-timeout-option.yml
+++ b/changelogs/fragments/389-fixes-zos-operator-timeout-option.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >
+    ibm_zos_operator - Fixes a bug such that when specifying 
+    wait_time_s and wait=True in zos_operator it throws an error
+    and does not execute the command.
+    (https://github.com/ansible-collections/ibm_zos_core/issues/389).

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -297,6 +297,9 @@ def run_operator_command(params):
     wait_s = 1
     if params.get("wait"):
         wait_s = params.get("wait_time_s")
+        # To comply with docs "When set to 0, the system default is used."
+        if wait_s == 0:
+            wait_s = 1
         if wait_s:
             # kwargs.update({"timeout": "{0}".format(wait_s)})
             kwargs.update({"parameters": "ISFDELAY={0}".format(wait_s)})

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -28,6 +28,7 @@ author:
   - "Ping Xiao (@xiaopingBJ)"
   - "Demetrios Dimatos (@ddimatos)"
   - "Rich Parker (@richp405)"
+  - "Oscar Fernando Flores (@fernandofloresg)"
 options:
   cmd:
     description:

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -218,7 +218,7 @@ def run_module():
         module.deprecate(
             msg='Support for configuring wait has been deprecated.'
             'Configuring wait is now managed by setting \'wait_time_s\'',
-            date='2022-09-01', collection_name='ibm.ibm_zos_core')
+            date='2022-09-01', collection_name='ibm.ibm_zos_core', version='1.5.0')
 
     try:
         new_params = parse_params(module.params)

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -51,22 +51,18 @@ options:
   wait_time_s:
     description:
       - Set maximum time in seconds to wait for the commands to execute.
-      - When set to 0, the system default is used.
       - This option is helpful on a busy system requiring more time to execute
         commands.
-      - Setting I(wait) can instruct if execution should wait the
-        full I(wait_time_s).
     type: int
     required: false
-    default: 0
+    default: 1
   wait:
     description:
+      - Configuring wait used by the M(ibm.ibm_zos_core.zos_operator) module has been
+        deprecated and will be removed in ibm.ibm_zos_core collection version
+        1.6.0.
       - Specify to wait the full I(wait_time_s) interval before retrieving
         responses.
-      - This option is recommended to ensure that the responses are accessible and
-        captured by logging facilities and the I(verbose) option.
-      - I(delay=True) waits the full I(wait_time_s) interval.
-      - I(delay=False) returns as soon as the first command executes.
     type: bool
     required: false
     default: true
@@ -90,44 +86,58 @@ EXAMPLES = r"""
   zos_operator:
     cmd: 'd u,all'
     wait_time_s: 5
-    wait: false
 
 - name: Execute operator command to show jobs, always waiting 7 seconds for response
   zos_operator:
     cmd: 'd u,all'
     wait_time_s: 7
-    wait: true
 """
 
 RETURN = r"""
 rc:
     description:
-      Return code of the operator command
+      Return code for the submitted operator command.
     returned: always
     type: int
     sample: 0
+cmd:
+    description:
+      Operator command submitted.
+    returned: always
+    type: str
+    sample: d u,all
+wait_time_s:
+    description:
+      The maximum time in seconds to wait for the commands to execute.
+    returned: always
+    type: int
+    sample: 5
 content:
     description:
-       The text from the command issued, plus verbose messages if I(verbose=True)
+       The resulting text from the command submitted.
     returned: on success
     type: list
     sample:
-        [ "MV2C      2020039  04:29:57.58             ISF031I CONSOLE XIAOPIN ACTIVATED ",
-          "MV2C      2020039  04:29:57.58            -D U,ALL                           ",
-          "MV2C      2020039  04:29:57.59             IEE457I 04.29.57 UNIT STATUS 948  ",
-          "         UNIT TYPE STATUS        VOLSER     VOLSTATE      SS                 ",
-          "          0100 3277 OFFLINE                                 0                ",
-          "          0101 3277 OFFLINE                                 0                ",
-          "ISF050I USER=OMVSADM GROUP= PROC=REXX TERMINAL=09A3233B",
-          "ISF051I SAF Access allowed SAFRC=0 ACCESS=READ CLASS=SDSF RESOURCE=GROUP.ISFSPROG.SDSF",
-          "ISF051I SAF Access allowed SAFRC=0 ACCESS=READ CLASS=SDSF RESOURCE=ISFCMD.FILTER.PREFIX",
-          "ISF055I ACTION=D Access allowed USERLEVEL=7 REQLEVEL=1",
-          "ISF051I SAF Access allowed SAFRC=0 ACCESS=READ CLASS=SDSF RESOURCE=ISFCMD.ODSP.ULOG.JES2",
-          "ISF147I REXX variable ISFTIMEOUT fetched, return code 00000001 value is ''.",
-          "ISF754I Command 'SET DELAY 5' generated from associated variable ISFDELAY.",
-          "ISF769I System command issued, command text: D U,ALL -S.",
-          "ISF146I REXX variable ISFDIAG set, return code 00000001 value is '00000000 00000000 00000000 00000000 00000000'.",
-          "ISF766I Request completed, status: COMMAND ISSUED."
+        [ "EC33017A   2022244  16:00:49.00             ISF031I CONSOLE OMVS0000 ACTIVATED",
+          "EC33017A   2022244  16:00:49.00            -D U,ALL ",
+          "EC33017A   2022244  16:00:49.00             IEE457I 16.00.49 UNIT STATUS 645",
+          "                                           UNIT TYPE STATUS        VOLSER     VOLSTATE      SS",
+          "                                           0000 3390 F-NRD                        /RSDNT     0",
+          "                                           0001 3211 OFFLINE                                 0",
+          "                                           0002 3211 OFFLINE                                 0",
+          "                                           0003 3211 OFFLINE                                 0",
+          "                                           0004 3211 OFFLINE                                 0",
+          "                                           0005 3211 OFFLINE                                 0",
+          "                                           0006 3211 OFFLINE                                 0",
+          "                                           0007 3211 OFFLINE                                 0",
+          "                                           0008 3211 OFFLINE                                 0",
+          "                                           0009 3277 OFFLINE                                 0",
+          "                                           000C 2540 A                                       0",
+          "                                           000D 2540 A                                       0",
+          "                                           000E 1403 A                                       0",
+          "                                           000F 1403 A                                       0",
+          "                                           0010 3211 A                                       0",
+          "                                           0011 3211 A                                       0"
         ]
 changed:
     description:
@@ -190,13 +200,18 @@ def run_module():
     module_args = dict(
         cmd=dict(type="str", required=True),
         verbose=dict(type="bool", required=False, default=False),
-        wait_time_s=dict(type="int", required=False, default=0),
+        wait_time_s=dict(type="int", required=False, default=1),
         wait=dict(type="bool", required=False, default=True),
     )
 
     result = dict(changed=False)
-
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+
+    if module.params.get('wait'):
+        module.deprecate(
+            msg='Support for configuring wait has been deprecated.'
+            'Configuring wait is now managed by setting \'wait_time_s\'',
+            date='2022-09-01', collection_name='ibm.ibm_zos_core')
 
     try:
         new_params = parse_params(module.params)
@@ -233,8 +248,9 @@ def run_module():
                     ssctr += 1
 
         # call is returned from run_operator_command, specifying what was run.
-        # Adding this to user return can help in tracing compound call errors.
-        result["content"].append("Ran" + rc_message.get("call"))
+        #result["cmd"] = new_params.get("cmd")
+        result["cmd"] = rc_message.get("call")
+        result["wait_time_s"] = new_params.get("wait_time_s")
         result["changed"] = False
 
         # rc=0, something succeeded (the calling script ran),
@@ -290,37 +306,22 @@ def run_operator_command(params):
     kwargs = {}
 
     if params.get("verbose"):
-        kwargs.update({"verbose": "verbose"})
+        kwargs.update({"verbose": True})
+        kwargs.update({"debug": True})
 
-    if params.get("debug"):
-        kwargs.update({"debug": "debug"})
-
-    wait_s = 1
-    if params.get("wait"):
-        wait_s = params.get("wait_time_s")
-        # To comply with docs "When set to 0, the system default is used."
-        if wait_s == 0:
-            wait_s = 1
-        if wait_s:
-            # kwargs.update({"timeout": "{0}".format(wait_s)})
-            kwargs.update({"parameters": "ISFDELAY={0}".format(wait_s)})
-            # it *appears* IFSdelay is passing through correctly... did 1x-4x tests 0 to 20 seconds
+    wait_s = params.get("wait_time_s")
     cmdtxt = params.get("cmd")
 
     args = []
     rc, stdout, stderr = execute_command(cmdtxt, wait_s, *args, **kwargs)
 
-    extrastdout = ""
-    if params.get("verbose"):
-        extrastdout = "\n====================\nresult code: {0}\n====================".format(rc)
-
     if rc > 0:
-        message = "\nOut: {0}\nErr: {1}\nRan: {2}".format(stdout + extrastdout, stderr, cmdtxt)
+        message = "\nOut: {0}\nErr: {1}\nRan: {2}".format(stdout, stderr, cmdtxt)
         raise OperatorCmdError(cmdtxt, rc, message.split("\n"))
 
     return {
         "rc": rc,
-        "stdout": stdout + extrastdout,
+        "stdout": stdout,
         "stderr": stderr,
         "call": cmdtxt,
     }

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -165,8 +165,6 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module im
 )
 from ansible.module_utils.six import PY3
 
-
-
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
     MissingZOAUImport,
 )
@@ -257,7 +255,7 @@ def run_module():
                     ssctr += 1
 
         # call is returned from run_operator_command, specifying what was run.
-        #result["cmd"] = new_params.get("cmd")
+        # result["cmd"] = new_params.get("cmd")
         result["cmd"] = rc_message.get("call")
         result["wait_time_s"] = new_params.get("wait_time_s")
         result["changed"] = False

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -177,8 +177,8 @@ except Exception:
     ZOAUResponse = MissingZOAUImport()
 
 
-def execute_command(operator_cmd, *args, **kwargs):
-    response = opercmd.execute(operator_cmd, args, kwargs)
+def execute_command(operator_cmd, timeout=1, *args, **kwargs):
+    response = opercmd.execute(operator_cmd, timeout, args, kwargs)
     rc = response.rc
     stdout = response.stdout_response
     stderr = response.stderr_response
@@ -294,16 +294,17 @@ def run_operator_command(params):
     if params.get("debug"):
         kwargs.update({"debug": "debug"})
 
+    wait_s = 1
     if params.get("wait"):
-        wait = params.get("wait_time_s")
-        if wait:
-            kwargs.update({"timeout": "{0}".format(wait)})
-            kwargs.update({"parameters": "ISFDELAY={0}".format(wait)})
+        wait_s = params.get("wait_time_s")
+        if wait_s:
+            # kwargs.update({"timeout": "{0}".format(wait_s)})
+            kwargs.update({"parameters": "ISFDELAY={0}".format(wait_s)})
             # it *appears* IFSdelay is passing through correctly... did 1x-4x tests 0 to 20 seconds
     cmdtxt = params.get("cmd")
 
     args = []
-    rc, stdout, stderr = execute_command(cmdtxt, *args, **kwargs)
+    rc, stdout, stderr = execute_command(cmdtxt, wait_s, *args, **kwargs)
 
     extrastdout = ""
     if params.get("verbose"):

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -98,20 +98,19 @@ def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
         assert result.get("content") is not None
 
 
-# Disable this test case until ZOAU releases the timeout support we had in REXX
-# def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
-#     hosts = ansible_zos_module
-#     startmod = time.time()
-#     results = hosts.all.zos_operator(
-#         cmd="d u,all", verbose=True, wait_time_s=5, wait=True
-#     )
-#     endmod = time.time()
-#     timediff = endmod - startmod
-#     assert timediff > 4
-#     for result in results.contacted.values():
-#         assert result["rc"] == 0
-#         assert result.get("changed") is True
-#         assert result.get("content") is not None
+def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
+    hosts = ansible_zos_module
+    startmod = time.time()
+    results = hosts.all.zos_operator(
+        cmd="d u,all", verbose=True, wait_time_s=5, wait=True
+    )
+    endmod = time.time()
+    timediff = endmod - startmod
+    assert timediff > 4
+    for result in results.contacted.values():
+        assert result["rc"] == 0
+        assert result.get("changed") is True
+        assert result.get("content") is not None
 
 
 def test_zos_operator_positive_verbose_with_quick_delay(ansible_zos_module):

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -91,11 +91,11 @@ def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
 
         print("\n\n\n")
 
-    # assert timediff > 4
-    # for result in results.contacted.values():
-    #    assert result["rc"] == 0
-    #    assert result.get("changed") is True
-    #    assert result.get("content") is not None
+    assert timediff < 10
+    for result in results.contacted.values():
+       assert result["rc"] == 0
+       assert result.get("changed") is True
+       assert result.get("content") is not None
 
 
 # Disable this test case until ZOAU releases the timeout support we had in REXX
@@ -118,7 +118,7 @@ def test_zos_operator_positive_verbose_with_quick_delay(ansible_zos_module):
     hosts = ansible_zos_module
     startmod = time.time()
     results = hosts.all.zos_operator(
-        cmd="d u,all", verbose=True, wait_time_s=10, wait=False
+        cmd="d u,all", verbose=True, wait_time_s=10, wait=True
     )
     endmod = time.time()
     timediff = endmod - startmod

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -15,9 +15,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import os
-import sys
-import warnings
 import time
 
 import ansible.constants
@@ -73,51 +70,25 @@ def test_zos_operator_positive_path_verbose(ansible_zos_module):
         assert result.get("content") is not None
 
 
-def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
-    hosts = ansible_zos_module
-    startmod = time.time()
-    results = hosts.all.zos_operator(
-        cmd="d u,all", verbose=True, wait_time_s=5, wait=True
-    )
-    endmod = time.time()
-    timediff = endmod - startmod
-    if timediff < 4:
-        print("\n........testable delay failed (short): assertion commented for testing....\n")
-        print(results)
+# def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
+#     hosts = ansible_zos_module
+#     wait_time = 1
+#     results = hosts.all.zos_operator(
+#         cmd="ENTER A LONG RUNNING CMD", verbose=True, wait_time_s=wait_time
+#     )
 
-        for result in results.contacted.values():
-            print("\n......result.....\n")
-            print("\n.......rc={0}\nchg={1}\ncon={2}\n".format(result["rc"], result.get("changed"), result.get("content")))
-
-        print("\n\n\n")
-
-    assert timediff < 10
-    for result in results.contacted.values():
-        assert result["rc"] == 0
-        assert result.get("changed") is True
-        assert result.get("content") is not None
-
-
-def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
-    hosts = ansible_zos_module
-    startmod = time.time()
-    results = hosts.all.zos_operator(
-        cmd="d u,all", verbose=True, wait_time_s=5, wait=True
-    )
-    endmod = time.time()
-    timediff = endmod - startmod
-    assert timediff > 4
-    for result in results.contacted.values():
-        assert result["rc"] == 0
-        assert result.get("changed") is True
-        assert result.get("content") is not None
+#     for result in results.contacted.values():
+#         assert result["rc"] == 0
+#         assert result.get("changed") is False
+#         assert result.get("content") is not None
+#         assert result.get("elapsed") > wait_time
 
 
 def test_zos_operator_positive_verbose_with_quick_delay(ansible_zos_module):
     hosts = ansible_zos_module
     startmod = time.time()
     results = hosts.all.zos_operator(
-        cmd="d u,all", verbose=True, wait_time_s=10, wait=True
+        cmd="d u,all", verbose=True, wait_time_s=10
     )
     endmod = time.time()
     timediff = endmod - startmod

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -93,9 +93,9 @@ def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
 
     assert timediff < 10
     for result in results.contacted.values():
-       assert result["rc"] == 0
-       assert result.get("changed") is True
-       assert result.get("content") is not None
+        assert result["rc"] == 0
+        assert result.get("changed") is True
+        assert result.get("content") is not None
 
 
 # Disable this test case until ZOAU releases the timeout support we had in REXX


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
After ZOAU implemented timeout option in opercmd support was missing from zos_operator. Changed the opercmd.execute_command call to use the latest interface and explicitly provide the timeout value, had to be done this way since zoau python utils does a validation in this value over kwargs. 
Added the case when wait_time_s is 0 to default to 1 and be true to the docs "When set to 0, the system default is used".

Also changed the test to now validate for timeouts and enabled the quick delay test.

**Update, in addition to the original issue these updates are have included in this PR:**
- bugfixes:
  - ibm_zos_operator - fixed such that specifying wait_time_s would throw an error (original issue in this PR)
  - ibm_zos_operator - fixed case sensitive error checks, invalid, error & unidentifiable 
  - ibm_zos_operator - fixed the wait_time_s to default to 1 second 
- minor_changes:
  - ibm_zos_operator - deprecated the wait option, not needed with wait_time_s minor_changes
  - ibm_zos_operator - added in the response the cmd result 
  - ibm_zos_operator - added in the response the wait_time_s set 
  - ibm_zos_operator - added in the response the elapsed time 
  
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
fixes #389 
fixes #377 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_operator

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
