### PR TITLE
Fixes zos_operator verbosity and excessive lines in content returned

### DIFF
--- a/changelogs/fragments/400-fixes-verbose-trailing-lines.yml
+++ b/changelogs/fragments/400-fixes-verbose-trailing-lines.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - >
+    zos_operator - was updated to correct missing verbosity content
+    when the option verbose was set to True.
+    zos_operator - was updated to correct the trailing lines that would appear
+    in the result content.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/400).

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -39,12 +39,8 @@ options:
     required: true
   verbose:
     description:
-      - Return diagnostic messages that lists and describes the execution of the
-        operator commands.
-      - Return security trace messages that help you understand and diagnose the
-        execution of the operator commands
-      - Return trace instructions displaying how the the command's operation is
-        read, evaluated and executed.
+      - Return diagnostic messages that describes the commands execution,
+        options, buffer and response size.
     type: bool
     required: false
     default: false

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -194,7 +194,7 @@ except Exception:
 
 def execute_command(operator_cmd, timeout=1, *args, **kwargs):
     start = timer()
-    response = opercmd.execute(operator_cmd, timeout, args, kwargs)
+    response = opercmd.execute(operator_cmd, timeout, *args, **kwargs)
     end = timer()
     rc = response.rc
     stdout = response.stdout_response
@@ -241,7 +241,8 @@ def run_module():
         tstr = rc_message.get("stdout")
         if tstr is not None:
             for s in tstr.split("\n"):
-                result["content"].append(s)
+                if s:
+                    result["content"].append(s)
                 if ssctr < 5:
                     short_str.append(s)
                     ssctr += 1
@@ -249,7 +250,8 @@ def run_module():
         tstr = rc_message.get("stderr")
         if tstr is not None:
             for s in tstr.split("\n"):
-                result["content"].append(s)
+                if s:
+                    result["content"].append(s)
                 if ssctr < 5:
                     short_str.append(s)
                     ssctr += 1

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -68,6 +68,10 @@ def test_zos_operator_positive_path_verbose(ansible_zos_module):
         assert result["rc"] == 0
         assert result.get("changed") is True
         assert result.get("content") is not None
+        # Traverse the content list for a known verbose keyword and track state
+        if any('BGYSC0804I' in str for str in result.get("content")):
+            is_verbose =True
+        assert is_verbose
 
 
 def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -70,7 +70,7 @@ def test_zos_operator_positive_path_verbose(ansible_zos_module):
         assert result.get("content") is not None
         # Traverse the content list for a known verbose keyword and track state
         if any('BGYSC0804I' in str for str in result.get("content")):
-            is_verbose =True
+            is_verbose = True
         assert is_verbose
 
 

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -70,18 +70,19 @@ def test_zos_operator_positive_path_verbose(ansible_zos_module):
         assert result.get("content") is not None
 
 
-# def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
-#     hosts = ansible_zos_module
-#     wait_time = 1
-#     results = hosts.all.zos_operator(
-#         cmd="ENTER A LONG RUNNING CMD", verbose=True, wait_time_s=wait_time
-#     )
+def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
+    "Long running command should take over 30 seconds"
+    hosts = ansible_zos_module
+    wait_time = 10
+    results = hosts.all.zos_operator(
+        cmd="RO *ALL,LOG 'dummy syslog message'", verbose=True, wait_time_s=wait_time
+    )
 
-#     for result in results.contacted.values():
-#         assert result["rc"] == 0
-#         assert result.get("changed") is False
-#         assert result.get("content") is not None
-#         assert result.get("elapsed") > wait_time
+    for result in results.contacted.values():
+        assert result["rc"] == 0
+        assert result.get("changed") is True
+        assert result.get("content") is not None
+        assert result.get("elapsed") > wait_time
 
 
 def test_zos_operator_positive_verbose_with_quick_delay(ansible_zos_module):


### PR DESCRIPTION
##### SUMMARY
This fixes the issue where the verbosity was not returned when a user set it to True. It also fixes the extra empty lines returned in the response in the content field. 

It also updates the documentation to remove the security references under verbosity as that no longer supported content. 

Fixes #397 
Fixes #399 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`zos_operator`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
ok: [zvm] => {
    "result": {
        "changed": true,
        "cmd": "d t",
        "content": [
            "EC33017A   2022245  13:14:52.00             ISF031I CONSOLE OMVS0000 ACTIVATED",
            "EC33017A   2022245  13:14:52.00            -D T ",
            "EC33017A   2022245  13:14:52.00             IEE136I LOCAL: TIME=13.14.50 DATE=2022.245  UTC: TIME=20.14.50 DATE=2022.245",
            "",
            ""
        ],
        "elapsed": 9.16,
        "failed": false,
        "rc": 0,
        "wait_time_s": 10
    }
}
```
After:
```
ok: [zvm] => {
    "result": {
        "changed": true,
        "cmd": "d t",
        "content": [
            "EC33017A   2022245  13:25:09.00             ISF031I CONSOLE OMVS0000 ACTIVATED",
            "EC33017A   2022245  13:25:09.00            -D T ",
            "EC33017A   2022245  13:25:09.00             IEE136I LOCAL: TIME=13.25.07 DATE=2022.245  UTC: TIME=20.25.07 DATE=2022.245",
            "BGYSC0804I Using timeout of 10 seconds.",
            "BGYSC0801I CONSBUFPGNUM=128 - Console command output buffer memory size to be allocated: 131072 bytes",
            "BGYSC0802I Console command returned output string size of 77 bytes."
        ],
        "elapsed": 8.43,
        "failed": false,
        "rc": 0,
        "wait_time_s": 10
    }
}
```


