### PR TITLE
Bugfix/393/tmp hlq ddstatements: Adds tmphlq to create_temp datasets in DDStatements.

### DIFF
--- a/changelogs/fragments/393-tmphlq-dd-statements.yml
+++ b/changelogs/fragments/393-tmphlq-dd-statements.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - >
+    zos_mvs_raw - Ensures that temporary datasets created by DD Statements use the tmp_hlq specified.
+    This allows for a user to specify the data set high level qualifier (HLQ)
+    used in any temporary data set created by the module. Often, the
+    defaults are not permitted on systems, this provies a way to override
+    the defaults. (https://github.com/ansible-collections/ibm_zos_core/pull/414).

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -512,6 +512,7 @@ class StdinDefinition(DataDefinition):
     def __init__(
         self,
         content,
+        tmphlq="",
         record_format="FB",
         space_primary=5,
         space_secondary=5,
@@ -539,6 +540,7 @@ class StdinDefinition(DataDefinition):
         """
         self.name = None
         name = DataSet.create_temp(
+            hlq=tmphlq,
             record_format=record_format,
             space_primary=space_primary,
             space_secondary=space_secondary,
@@ -588,11 +590,12 @@ class InputDefinition(StdinDefinition):
 class OutputDefinition(DataDefinition):
     def __init__(
         self,
+        tmphlq="",
         record_format="FBA",
         space_primary=100,
         space_secondary=50,
         space_type="trk",
-        record_length=121,
+        record_length=121
     ):
         """Output DD Data type to be used in a DDStatement.
         This should be used in cases where user wants to receive
@@ -614,6 +617,7 @@ class OutputDefinition(DataDefinition):
         """
         self.name = None
         name = DataSet.create_temp(
+            hlq=tmphlq,
             record_format=record_format,
             space_primary=space_primary,
             space_secondary=space_secondary,

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -595,7 +595,7 @@ class OutputDefinition(DataDefinition):
         space_primary=100,
         space_secondary=50,
         space_type="trk",
-        record_length=121
+        record_length=121,
     ):
         """Output DD Data type to be used in a DDStatement.
         This should be used in cases where user wants to receive

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2368,8 +2368,10 @@ def build_data_definition(dd):
     elif dd.get("dd_unix"):
         data_definition = RawFileDefinition(**(dd.get("dd_unix")))
     elif dd.get("dd_input"):
+        dd.get("dd_input")["tmphlq"] = g_tmphlq
         data_definition = RawInputDefinition(**(dd.get("dd_input")))
     elif dd.get("dd_output"):
+        dd.get("dd_output")["tmphlq"] = g_tmphlq
         data_definition = RawOutputDefinition(**(dd.get("dd_output")))
     elif dd.get("dd_vio"):
         data_definition = VIODefinition(tmphlq=g_tmphlq)

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2366,7 +2366,7 @@ def set_extra_attributes_in_dd(dd):
     elif dd.get("dd_output"):
         dd.get("dd_output")["tmphlq"] = g_tmphlq
     elif dd.get("dd_vio"):
-        dd.get("dd_output")["tmphlq"] = g_tmphlq
+        dd.get("dd_vio")["tmphlq"] = g_tmphlq
     elif dd.get("dd_concat"):
         for single_dd in dd.get("dd_concat").get("dds", []):
             set_extra_attributes_in_dd(single_dd)

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2313,6 +2313,7 @@ def build_dd_statements(parms):
     dd_statements = []
     for dd in parms.get("dds"):
         dd_name = get_dd_name(dd)
+        dd = set_extra_attributes_in_dd(dd)
         data_definition = build_data_definition(dd)
         if data_definition is None:
             raise ValueError("No valid data definition found.")
@@ -2348,6 +2349,30 @@ def get_dd_name(dd):
     return dd_name
 
 
+def set_extra_attributes_in_dd(dd):
+    """
+    Set any extra attributes in dds like global tmphlq.
+    Args:
+        dd (dict): A single DD parm as specified in module parms.
+
+    Returns:
+        dd (dict): A single DD parm as specified in module parms.
+    """
+    global g_tmphlq
+    if dd.get("dd_data_set"):
+        dd.get("dd_data_set")["tmphlq"] = g_tmphlq
+    elif dd.get("dd_input"):
+        dd.get("dd_input")["tmphlq"] = g_tmphlq
+    elif dd.get("dd_output"):
+        dd.get("dd_output")["tmphlq"] = g_tmphlq
+    elif dd.get("dd_vio"):
+        dd.get("dd_output")["tmphlq"] = g_tmphlq
+    elif dd.get("dd_concat"):
+        for single_dd in dd.get("dd_concat").get("dds", []):
+            set_extra_attributes_in_dd(single_dd)
+    return dd
+
+
 def build_data_definition(dd):
     """Build a DataDefinition object for a particular DD parameter.
 
@@ -2361,20 +2386,16 @@ def build_data_definition(dd):
               RawInputDefinition, DummyDefinition]: The DataDefinition object or a list of DataDefinition objects.
     """
     data_definition = None
-    global g_tmphlq
     if dd.get("dd_data_set"):
-        dd.get("dd_data_set")["tmphlq"] = g_tmphlq
         data_definition = RawDatasetDefinition(**(dd.get("dd_data_set")))
     elif dd.get("dd_unix"):
         data_definition = RawFileDefinition(**(dd.get("dd_unix")))
     elif dd.get("dd_input"):
-        dd.get("dd_input")["tmphlq"] = g_tmphlq
         data_definition = RawInputDefinition(**(dd.get("dd_input")))
     elif dd.get("dd_output"):
-        dd.get("dd_output")["tmphlq"] = g_tmphlq
         data_definition = RawOutputDefinition(**(dd.get("dd_output")))
     elif dd.get("dd_vio"):
-        data_definition = VIODefinition(tmphlq=g_tmphlq)
+        data_definition = VIODefinition(**(dd.get("dd_vio")))
     elif dd.get("dd_dummy"):
         data_definition = DummyDefinition()
     elif dd.get("dd_concat"):

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2395,7 +2395,7 @@ def build_data_definition(dd):
     elif dd.get("dd_output"):
         data_definition = RawOutputDefinition(**(dd.get("dd_output")))
     elif dd.get("dd_vio"):
-        data_definition = VIODefinition(**(dd.get("dd_vio")))
+        data_definition = VIODefinition(dd.get("dd_vio").get("tmphlq"))
     elif dd.get("dd_dummy"):
         data_definition = DummyDefinition()
     elif dd.get("dd_concat"):

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -30,10 +30,8 @@ class ArtifactManager(object):
     is used in test cases. In the even a module is used in another test suite
     unrelated to the modules test suite, it will also be returned. This ensures
     that a module changes don't break test suites dependent on a module.
-
     Usage (minimal) example:
         python dependencyfinder.py -p .. -b origin/dev -m
-
     Note: It is possible that only test cases are modified only, without a module
     or modules, in that case without a module pairing no test cases will be
     returned. Its best to run full regression in that case until this can be
@@ -47,7 +45,6 @@ class ArtifactManager(object):
 
     def add(self, artifact):
         """Add an artifact.
-
         Args:
             artifact (Artifact): The artifact to add.
         """
@@ -56,11 +53,9 @@ class ArtifactManager(object):
 
     def find(self, name, source):
         """Find the index of an artifact based on its name and source.
-
         Args:
             name (str): The name of the artifact.
             source (str): The source type of the artifact.
-
         Returns:
             int: The index of the artifact, or None if not found.
         """
@@ -71,10 +66,8 @@ class ArtifactManager(object):
 
     def get_from_path(self, path):
         """Get an artifact based on a path.
-
         Args:
             path (str): The path to use for search.
-
         Returns:
             Artifact: the artifact corresponding to the provided path, or None if not found.
         """
@@ -86,10 +79,8 @@ class ArtifactManager(object):
 
     def get_artifacts_with_matching_source(self, source):
         """Get all artifacts with a particular source type.
-
         Args:
             source (str): The source type of the artifacts to retrieve.
-
         Returns:
             list[Artifact]: A list of all artifacts with a matching source type.
         """
@@ -101,10 +92,8 @@ class ArtifactManager(object):
 
     def get_dependencies_from_paths(self, paths):
         """Get a combined list of dependencies for Artifacts matching provided paths.
-
         Args:
             paths (list[str]): A list of paths to retrieve dependencies from.
-
         Returns:
             list[Dependency]: A list of dependencies for Artifacts matching provided paths.
         """
@@ -113,11 +102,9 @@ class ArtifactManager(object):
 
     def _get_dependencies(self, paths, index=0):
         """Recursive helper method for get_dependencies_from_paths.
-
         Args:
             paths (list[str]): A list of paths to retrieve dependencies from.
             index (int, optional): The index of the current path in the list of paths. Defaults to 0.
-
         Returns:
             tuple(list[Dependency], defaultdict): The current list of identified dependencies.
         """
@@ -138,11 +125,9 @@ class ArtifactManager(object):
 
     def get_artifacts_with_dependency(self, artifacts_depended_on, source=None):
         """Get a list of artifacts that are dependent on one or more of the specified artifacts.
-
         Args:
             artifacts_depended_on (list[Artifact]): A list of artifacts that are depended on.
             source (str, optional): Limit artifacts to search for dependency to those with corresponding source. Defaults to None.
-
         Returns:
             list[Artifact]: A list of artifacts that have a dependency on one or more of the specified artifacts.
         """
@@ -160,12 +145,10 @@ class ArtifactManager(object):
         self, artifacts_depended_on, artifacts_with_potential_dependency, index=0
     ):
         """Recursive helper method for get_artifacts_with_dependency.
-
         Args:
             artifacts_depended_on (list[Artifact]): A list of artifacts that are depended on.
             artifacts_with_potential_dependency (list[Artifact]): A list of artifacts to search for dependencies.
             index (int, optional): The index of the current artifact in the list of artifacts. Defaults to 0.
-
         Returns:
             tuple(list[Artifact], defaultdict): A list of artifacts that have a dependency on one or more of the specified artifacts.
         """
@@ -201,7 +184,6 @@ class Artifact(object):
 
     def __init__(self, name, source, path, dependencies=None):
         """Instantiate an Artifact
-
         Args:
             name (str): The name of the artifact.
             source (str): The source type of the artifact.
@@ -225,10 +207,8 @@ class Artifact(object):
     @classmethod
     def from_path(cls, path):
         """Instantiate an Artifact based on provided path.
-
         Args:
             path (str): The path to an artifact in an Ansible collection.
-
         Returns:
             Artifact: an artifact object.
         """
@@ -259,10 +239,8 @@ class Artifact(object):
 
     def has_dependency(self, potential_dependency):
         """Determines if artifact has a dependency on another artifact.
-
         Args:
             potential_dependency (union[Artifact, Dependency]): The potential dependency to search for in artifact's dependencies.
-
         Returns:
             bool: If the artifact is dependent or not.
         """
@@ -280,7 +258,6 @@ class Dependency(object):
 
     def __init__(self, name, source):
         """Instantiate a Dependency.
-
         Args:
             name (str): The name of the artifact.
             source (str): The source type of the artifact.
@@ -299,10 +276,8 @@ class Dependency(object):
 
 def get_name_and_source_from_path(path):
     """Determine the artifact name and source type based on its path.
-
     Args:
         path (str): The path to an artifact in an Ansible collection.
-
     Returns:
         tuple(str, str): The name and source of an artifact based on its path.
     """
@@ -322,10 +297,8 @@ def get_name_and_source_from_path(path):
 
 def get_module_util_dependencies_in_file(path):
     """Scrape file for module_utils imports.
-
     Args:
         path (str): The path to scrape.
-
     Returns:
         list[str]: A list of module_utils imports found in the file.
     """
@@ -371,10 +344,8 @@ def get_module_util_dependencies_in_file(path):
 
 def get_module_dependencies_in_test_file(path):
     """Scrape test file for module dependencies.
-
     Args:
         path (str): The path to scrape.
-
     Returns:
         list[str]: A list of module dependencies found in the file.
     """
@@ -393,10 +364,8 @@ def get_module_dependencies_in_test_file(path):
 
 def get_helper_dependencies_in_test_file(path):
     """Scrape test file for helper dependencies.
-
     Args:
         path (str): The path to scrape.
-
     Returns:
         list[str]: A list of helper dependencies found in the file.
     """
@@ -430,10 +399,8 @@ def get_helper_dependencies_in_test_file(path):
 
 def build_artifacts_from_collection(collection_root):
     """Build a list of Artifact objects based on python scripts found in collection.
-
     Args:
         collection_root (str): The path to the root of the collection
-
     Returns:
         list[Artifact]: A list of artifacts.
     """
@@ -452,10 +419,8 @@ def build_artifacts_from_collection(collection_root):
 
 def get_all_files_in_dir_tree(base_path):
     """Recursively search subdirectories for files.
-
     Args:
         base_path (str): The directory to recursively search.
-
     Returns:
         list[str]: A list of file paths.
     """
@@ -469,13 +434,10 @@ def get_all_files_in_dir_tree(base_path):
 def get_changed_files(path, branch="origin/dev"):
     """Get a list of files changed compared to specified branch.
     Deleted files are not included.
-
     Args:
         branch (str, optional): The branch to compare to. Defaults to "dev".
-
     Raises:
         RuntimeError: When git diff fails.
-
     Returns:
         list[str]: A list of changed file paths.
     """
@@ -499,13 +461,10 @@ def get_changed_files(path, branch="origin/dev"):
 
 def get_changed_plugins(path, branch="origin/dev"):
     """Get a list of modules or plugins in a specific branch.
-
     Args:
         branch (str, optional): The branch to compare to. Defaults to "dev".
-
     Raises:
         RuntimeError: When git request-pull fails.
-
     Returns:
         list[str]: A list of changed file paths.
     """
@@ -524,6 +483,7 @@ def get_changed_plugins(path, branch="origin/dev"):
         raise RuntimeError("Could not acquire change list, error = [{0}]".format(stderr))
     if stdout:
         for line in stdout.split("\n"):
+<<<<<<< HEAD
             path_corrected_line = None
             if "plugins/action/" in line:
                 path_corrected_line = line.split("|", 1)[0].strip()
@@ -548,13 +508,26 @@ def get_changed_plugins(path, branch="origin/dev"):
         #     for line in stdout.split("\n"):
         #         if "tests/functional/modules/" in line:
         #             changed_plugins_modules.append(line.split("|", 1)[0].strip())
+=======
+            if "plugins/action/" in line or "plugins/modules/" in line\
+                    or "tests/functional/modules/" in line\
+                    or "plugins/module_utils/" in line\
+                    or "tests/unit/" in line:
+                changed_plugins_modules.append(line.split("|", 1)[0].strip())
+>>>>>>> 57089db (Updated dependency finder)
+
+        # # There can be the case where only test cases are updated, question is
+        # # should this be default behavior only when no modules are edited
+        # if not changed_plugins_modules:
+        #     for line in stdout.split("\n"):
+        #         if "tests/functional/modules/" in line:
+        #             changed_plugins_modules.append(line.split("|", 1)[0].strip())
 
     return changed_plugins_modules
 
 
 def parse_arguments():
     """Parse and return command line arguments.
-
     Returns:
         Args: The populated namespace.
     """

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -30,8 +30,10 @@ class ArtifactManager(object):
     is used in test cases. In the even a module is used in another test suite
     unrelated to the modules test suite, it will also be returned. This ensures
     that a module changes don't break test suites dependent on a module.
+
     Usage (minimal) example:
         python dependencyfinder.py -p .. -b origin/dev -m
+
     Note: It is possible that only test cases are modified only, without a module
     or modules, in that case without a module pairing no test cases will be
     returned. Its best to run full regression in that case until this can be
@@ -45,6 +47,7 @@ class ArtifactManager(object):
 
     def add(self, artifact):
         """Add an artifact.
+
         Args:
             artifact (Artifact): The artifact to add.
         """
@@ -53,9 +56,11 @@ class ArtifactManager(object):
 
     def find(self, name, source):
         """Find the index of an artifact based on its name and source.
+
         Args:
             name (str): The name of the artifact.
             source (str): The source type of the artifact.
+
         Returns:
             int: The index of the artifact, or None if not found.
         """
@@ -66,8 +71,10 @@ class ArtifactManager(object):
 
     def get_from_path(self, path):
         """Get an artifact based on a path.
+
         Args:
             path (str): The path to use for search.
+
         Returns:
             Artifact: the artifact corresponding to the provided path, or None if not found.
         """
@@ -79,8 +86,10 @@ class ArtifactManager(object):
 
     def get_artifacts_with_matching_source(self, source):
         """Get all artifacts with a particular source type.
+
         Args:
             source (str): The source type of the artifacts to retrieve.
+
         Returns:
             list[Artifact]: A list of all artifacts with a matching source type.
         """
@@ -92,8 +101,10 @@ class ArtifactManager(object):
 
     def get_dependencies_from_paths(self, paths):
         """Get a combined list of dependencies for Artifacts matching provided paths.
+
         Args:
             paths (list[str]): A list of paths to retrieve dependencies from.
+
         Returns:
             list[Dependency]: A list of dependencies for Artifacts matching provided paths.
         """
@@ -102,9 +113,11 @@ class ArtifactManager(object):
 
     def _get_dependencies(self, paths, index=0):
         """Recursive helper method for get_dependencies_from_paths.
+
         Args:
             paths (list[str]): A list of paths to retrieve dependencies from.
             index (int, optional): The index of the current path in the list of paths. Defaults to 0.
+
         Returns:
             tuple(list[Dependency], defaultdict): The current list of identified dependencies.
         """
@@ -125,9 +138,11 @@ class ArtifactManager(object):
 
     def get_artifacts_with_dependency(self, artifacts_depended_on, source=None):
         """Get a list of artifacts that are dependent on one or more of the specified artifacts.
+
         Args:
             artifacts_depended_on (list[Artifact]): A list of artifacts that are depended on.
             source (str, optional): Limit artifacts to search for dependency to those with corresponding source. Defaults to None.
+
         Returns:
             list[Artifact]: A list of artifacts that have a dependency on one or more of the specified artifacts.
         """
@@ -145,10 +160,12 @@ class ArtifactManager(object):
         self, artifacts_depended_on, artifacts_with_potential_dependency, index=0
     ):
         """Recursive helper method for get_artifacts_with_dependency.
+
         Args:
             artifacts_depended_on (list[Artifact]): A list of artifacts that are depended on.
             artifacts_with_potential_dependency (list[Artifact]): A list of artifacts to search for dependencies.
             index (int, optional): The index of the current artifact in the list of artifacts. Defaults to 0.
+
         Returns:
             tuple(list[Artifact], defaultdict): A list of artifacts that have a dependency on one or more of the specified artifacts.
         """
@@ -184,6 +201,7 @@ class Artifact(object):
 
     def __init__(self, name, source, path, dependencies=None):
         """Instantiate an Artifact
+
         Args:
             name (str): The name of the artifact.
             source (str): The source type of the artifact.
@@ -207,8 +225,10 @@ class Artifact(object):
     @classmethod
     def from_path(cls, path):
         """Instantiate an Artifact based on provided path.
+
         Args:
             path (str): The path to an artifact in an Ansible collection.
+
         Returns:
             Artifact: an artifact object.
         """
@@ -239,8 +259,10 @@ class Artifact(object):
 
     def has_dependency(self, potential_dependency):
         """Determines if artifact has a dependency on another artifact.
+
         Args:
             potential_dependency (union[Artifact, Dependency]): The potential dependency to search for in artifact's dependencies.
+
         Returns:
             bool: If the artifact is dependent or not.
         """
@@ -258,6 +280,7 @@ class Dependency(object):
 
     def __init__(self, name, source):
         """Instantiate a Dependency.
+
         Args:
             name (str): The name of the artifact.
             source (str): The source type of the artifact.
@@ -276,8 +299,10 @@ class Dependency(object):
 
 def get_name_and_source_from_path(path):
     """Determine the artifact name and source type based on its path.
+
     Args:
         path (str): The path to an artifact in an Ansible collection.
+
     Returns:
         tuple(str, str): The name and source of an artifact based on its path.
     """
@@ -297,8 +322,10 @@ def get_name_and_source_from_path(path):
 
 def get_module_util_dependencies_in_file(path):
     """Scrape file for module_utils imports.
+
     Args:
         path (str): The path to scrape.
+
     Returns:
         list[str]: A list of module_utils imports found in the file.
     """
@@ -344,8 +371,10 @@ def get_module_util_dependencies_in_file(path):
 
 def get_module_dependencies_in_test_file(path):
     """Scrape test file for module dependencies.
+
     Args:
         path (str): The path to scrape.
+
     Returns:
         list[str]: A list of module dependencies found in the file.
     """
@@ -364,8 +393,10 @@ def get_module_dependencies_in_test_file(path):
 
 def get_helper_dependencies_in_test_file(path):
     """Scrape test file for helper dependencies.
+
     Args:
         path (str): The path to scrape.
+
     Returns:
         list[str]: A list of helper dependencies found in the file.
     """
@@ -399,8 +430,10 @@ def get_helper_dependencies_in_test_file(path):
 
 def build_artifacts_from_collection(collection_root):
     """Build a list of Artifact objects based on python scripts found in collection.
+
     Args:
         collection_root (str): The path to the root of the collection
+
     Returns:
         list[Artifact]: A list of artifacts.
     """
@@ -419,8 +452,10 @@ def build_artifacts_from_collection(collection_root):
 
 def get_all_files_in_dir_tree(base_path):
     """Recursively search subdirectories for files.
+
     Args:
         base_path (str): The directory to recursively search.
+
     Returns:
         list[str]: A list of file paths.
     """
@@ -434,10 +469,13 @@ def get_all_files_in_dir_tree(base_path):
 def get_changed_files(path, branch="origin/dev"):
     """Get a list of files changed compared to specified branch.
     Deleted files are not included.
+
     Args:
         branch (str, optional): The branch to compare to. Defaults to "dev".
+
     Raises:
         RuntimeError: When git diff fails.
+
     Returns:
         list[str]: A list of changed file paths.
     """
@@ -461,10 +499,13 @@ def get_changed_files(path, branch="origin/dev"):
 
 def get_changed_plugins(path, branch="origin/dev"):
     """Get a list of modules or plugins in a specific branch.
+
     Args:
         branch (str, optional): The branch to compare to. Defaults to "dev".
+
     Raises:
         RuntimeError: When git request-pull fails.
+
     Returns:
         list[str]: A list of changed file paths.
     """
@@ -483,7 +524,6 @@ def get_changed_plugins(path, branch="origin/dev"):
         raise RuntimeError("Could not acquire change list, error = [{0}]".format(stderr))
     if stdout:
         for line in stdout.split("\n"):
-<<<<<<< HEAD
             path_corrected_line = None
             if "plugins/action/" in line:
                 path_corrected_line = line.split("|", 1)[0].strip()
@@ -508,26 +548,13 @@ def get_changed_plugins(path, branch="origin/dev"):
         #     for line in stdout.split("\n"):
         #         if "tests/functional/modules/" in line:
         #             changed_plugins_modules.append(line.split("|", 1)[0].strip())
-=======
-            if "plugins/action/" in line or "plugins/modules/" in line\
-                    or "tests/functional/modules/" in line\
-                    or "plugins/module_utils/" in line\
-                    or "tests/unit/" in line:
-                changed_plugins_modules.append(line.split("|", 1)[0].strip())
->>>>>>> 57089db (Updated dependency finder)
-
-        # # There can be the case where only test cases are updated, question is
-        # # should this be default behavior only when no modules are edited
-        # if not changed_plugins_modules:
-        #     for line in stdout.split("\n"):
-        #         if "tests/functional/modules/" in line:
-        #             changed_plugins_modules.append(line.split("|", 1)[0].strip())
 
     return changed_plugins_modules
 
 
 def parse_arguments():
     """Parse and return command line arguments.
+
     Returns:
         Args: The populated namespace.
     """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Discovered that during the implementation of tmphlq there were some missing DDStatements in zos_mvs_raw that were missing the tmphlq when calling Datasets.create_temp()


Added TMPHLQ as a parameter for StdinDefinition and OutputDefinition **defaulting as an empty string**, this is different as how tmphlq is defaulted to None in other sections of the code because the hlq parameter of create_temp is a string and defaults as empty too, so I wanted to keep consistency with that interface.

Also, since tmphlq was now added to more than dd type I abstracted the assignment into a function called set_extra_attributes_in_dd to avoid overpopulating the build_data_definition function with tmphlq assignments, figured that we could add extra attributes there too if needed in the future(maybe pass it as kwargs to add into the dds).

Fixes #393 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_mvs_raw

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
