### PR TITLE
[Bug] [zos_copy] Bugfixes for v1.3.6

### DIFF
--- a/changelogs/fragments/462-copy-fetch-submit-utils.yml
+++ b/changelogs/fragments/462-copy-fetch-submit-utils.yml
@@ -15,5 +15,8 @@ bugfixes:
     argument spec that will result in error when running `ansible-core` 2.11
     and using option `encoding`.
     jobs.py - fixes a utility used by module `zos_job_output` would truncate
-    the DD content, issue #354 
+    the DD content, issue #354
+    zos_ssh - fixes connection plugin which will error when using `ansible-core`
+    2.11 with an `AttributeError: module 'ansible.constants' has no attribute
+    'ANSIBLE_SSH_CONTROL_PATH_DIR'`, issue #495
     (https://github.com/ansible-collections/ibm_zos_core/pull/462)

--- a/changelogs/fragments/462-copy-fetch-submit-utils.yml
+++ b/changelogs/fragments/462-copy-fetch-submit-utils.yml
@@ -14,8 +14,8 @@ bugfixes:
     zos_job_submit - fixes a bug where an option was not defined in the module
     argument spec that will result in error when running `ansible-core` 2.11
     and using option `encoding`.
-    jobs.py - fixes a utility used by module `zos_job_output` would truncate
-    the DD content, issue #354
+    jobs.py - fixes a utility used by module `zos_job_output` that would
+    truncate the DD content, issue #354
     zos_ssh - fixes connection plugin which will error when using `ansible-core`
     2.11 with an `AttributeError: module 'ansible.constants' has no attribute
     'ANSIBLE_SSH_CONTROL_PATH_DIR'`, issue #495

--- a/changelogs/fragments/462-copy-fetch-submit-utils.yml
+++ b/changelogs/fragments/462-copy-fetch-submit-utils.yml
@@ -14,4 +14,6 @@ bugfixes:
     zos_job_submit - fixes a bug where an option was not defined in the module
     argument spec that will result in error when running `ansible-core` 2.11
     and using option `encoding`.
+    jobs.py - fixes a utility used by module `zos_job_output` would truncate
+    the DD content, issue #354 
     (https://github.com/ansible-collections/ibm_zos_core/pull/462)

--- a/changelogs/fragments/462-set-mode-directories-files.yml
+++ b/changelogs/fragments/462-set-mode-directories-files.yml
@@ -1,0 +1,17 @@
+bugfixes:
+  - >
+    zos_copy - fixes a bug that when a directory is copied from the controller
+    to the managed node and a mode is set, the mode is now applied to the
+    directory on the controller. If the directory being copied contains files
+    and mode is set, mode will only be applied to the files being copied not the
+    pre-existing files.
+    zos_copy - fixes a bug where options were not defined in the module
+    argument spec that will result in error when running `ansible-core` 2.11
+    and using options `force` or `mode`.
+    zos_fetch - fixes a bug where an option was not defined in the module
+    argument spec that will result in error when running `ansible-core` 2.11
+    and using option `encoding`.
+    zos_job_submit - fixes a bug where an option was not defined in the module
+    argument spec that will result in error when running `ansible-core` 2.11
+    and using option `encoding`.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/462)

--- a/docs/source/modules/zos_apf.rst
+++ b/docs/source/modules/zos_apf.rst
@@ -121,7 +121,7 @@ persistent
 
     | **required**: False
     | **type**: str
-    | **default**: /* {mark} ANSIBLE MANAGED BLOCK <timestamp> */
+    | **default**: /\* {mark} ANSIBLE MANAGED BLOCK <timestamp> \*/
 
 
   backup

--- a/docs/source/modules/zos_mvs_raw.rst
+++ b/docs/source/modules/zos_mvs_raw.rst
@@ -635,6 +635,8 @@ dds
   dd_input
     *dd_input* is used to specify an in-stream data set.
 
+    *dd_input* supports single or multiple lines of input.
+
     Input will be saved to a temporary data set with a record length of 80.
 
     | **required**: False
@@ -650,8 +652,6 @@ dds
 
     content
       The input contents for the DD.
-
-      *dd_input* supports single or multiple lines of input.
 
       Multi-line input can be provided as a multi-line string or a list of strings with 1 line per list item.
 
@@ -687,7 +687,7 @@ dds
       src_encoding
         The encoding of the data set on the z/OS system.
 
-        for *dd_input*, *src_encoding* should generally not need to be changed.
+        *dd_input* and *src_encoding* generally do not need to be changed.
 
         | **required**: False
         | **type**: str
@@ -744,7 +744,7 @@ dds
       src_encoding
         The encoding of the data set on the z/OS system.
 
-        for *dd_input*, *src_encoding* should generally not need to be changed.
+        *dd_input* and *src_encoding* generally do not need to be changed.
 
         | **required**: False
         | **type**: str
@@ -1356,6 +1356,8 @@ dds
       dd_input
         *dd_input* is used to specify an in-stream data set.
 
+        *dd_input* supports single or multiple lines of input.
+
         Input will be saved to a temporary data set with a record length of 80.
 
         | **required**: False
@@ -1364,8 +1366,6 @@ dds
 
         content
           The input contents for the DD.
-
-          *dd_input* supports single or multiple lines of input.
 
           Multi-line input can be provided as a multi-line string or a list of strings with 1 line per list item.
 
@@ -1401,7 +1401,7 @@ dds
           src_encoding
             The encoding of the data set on the z/OS system.
 
-            for *dd_input*, *src_encoding* should generally not need to be changed.
+            *dd_input* and *src_encoding* generally do not need to be changed.
 
             | **required**: False
             | **type**: str

--- a/docs/source/modules/zos_mvs_raw.rst
+++ b/docs/source/modules/zos_mvs_raw.rst
@@ -116,9 +116,6 @@ dds
       | **type**: str
       | **choices**: library, pds, pdse, large, basic, seq, rrds, esds, lds, ksds
 
-      | **required**: False
-      | **type**: str
-      | **choices**: library, pds, pdse, large, basic, seq, rrds, esds, lds, ksds
 
     disposition
       *disposition* indicates the status of a data set.
@@ -137,9 +134,6 @@ dds
       | **type**: str
       | **choices**: delete, keep, catlg, catalog, uncatlg, uncatalog
 
-      | **required**: False
-      | **type**: str
-      | **choices**: delete, keep, catlg, catalog, uncatlg, uncatalog
 
     disposition_abnormal
       *disposition_abnormal* indicates what to do with the data set after an abnormal termination of the program.
@@ -148,9 +142,6 @@ dds
       | **type**: str
       | **choices**: delete, keep, catlg, catalog, uncatlg, uncatalog
 
-      | **required**: False
-      | **type**: str
-      | **choices**: delete, keep, catlg, catalog, uncatlg, uncatalog
 
     reuse
       Determines if a data set should be reused if *disposition=NEW* and if a data set with a matching name already exists.
@@ -183,8 +174,6 @@ dds
       | **required**: False
       | **type**: bool
 
-      | **required**: False
-      | **type**: bool
 
     backup
       Determines if a backup should be made of an existing data set when *disposition=NEW*, *replace=true*, and a data set with the desired name is found.
@@ -194,8 +183,6 @@ dds
       | **required**: False
       | **type**: bool
 
-      | **required**: False
-      | **type**: bool
 
     space_type
       The unit of measurement to use when allocating space for a new data set using *space_primary* and *space_secondary*.
@@ -226,8 +213,6 @@ dds
       | **required**: False
       | **type**: int
 
-      | **required**: False
-      | **type**: int
 
     volumes
       The volume or volumes on which a data set resides or will reside.
@@ -248,8 +233,6 @@ dds
       | **required**: False
       | **type**: str
 
-      | **required**: False
-      | **type**: str
 
     sms_storage_class
       The desired storage class for a new SMS-managed data set.
@@ -272,8 +255,6 @@ dds
       | **required**: False
       | **type**: str
 
-      | **required**: False
-      | **type**: str
 
     block_size
       The maximum length of a block in bytes.
@@ -290,8 +271,6 @@ dds
       | **required**: False
       | **type**: int
 
-      | **required**: False
-      | **type**: int
 
     key_label
       The label for the encryption key used by the system to encrypt the data set.
@@ -314,8 +293,6 @@ dds
       | **required**: False
       | **type**: dict
 
-      | **required**: False
-      | **type**: dict
 
       label
         The label for the key encrypting key used by the Encryption Key Manager.
@@ -329,8 +306,6 @@ dds
         | **required**: True
         | **type**: str
 
-        | **required**: True
-        | **type**: str
 
       encoding
         How the label for the key encrypting key specified by *label* is encoded by the Encryption Key Manager.
@@ -615,7 +590,6 @@ dds
       | **type**: str
       | **choices**: u, vb, vba, fb, fba
 
-      *dd_input* supports single or multiple lines of input.
 
     return_content
       Determines how content should be returned to the user.
@@ -705,7 +679,7 @@ dds
 
         ``base64`` means return content in binary mode.
 
-        | **required**: False
+        | **required**: True
         | **type**: str
         | **choices**: text, base64
 
@@ -743,8 +717,6 @@ dds
       | **required**: True
       | **type**: str
 
-      | **required**: True
-      | **type**: str
 
     return_content
       Determines how content should be returned to the user.
@@ -754,8 +726,6 @@ dds
       | **required**: True
       | **type**: dict
 
-      | **required**: True
-      | **type**: dict
 
       type
         The type of the content to be returned.
@@ -770,9 +740,6 @@ dds
         | **type**: str
         | **choices**: text, base64
 
-        | **required**: True
-        | **type**: str
-        | **choices**: text, base64
 
       src_encoding
         The encoding of the data set on the z/OS system.
@@ -783,9 +750,6 @@ dds
         | **type**: str
         | **default**: ibm-1047
 
-        | **required**: False
-        | **type**: str
-        | **default**: ibm-1047
 
       response_encoding
         The encoding to use when returning the contents of the data set.
@@ -846,8 +810,6 @@ dds
       | **required**: True
       | **type**: str
 
-      | **required**: True
-      | **type**: str
 
     dds
       A list of DD statements, which can contain any of the following types: *dd_data_set*, *dd_unix*, and *dd_input*.
@@ -892,9 +854,6 @@ dds
           | **type**: str
           | **choices**: new, shr, mod, old
 
-          | **required**: False
-          | **type**: str
-          | **choices**: new, shr, mod, old
 
         disposition_normal
           *disposition_normal* indicates what to do with the data set after normal termination of the program.
@@ -911,9 +870,6 @@ dds
           | **type**: str
           | **choices**: delete, keep, catlg, catalog, uncatlg, uncatalog
 
-          | **required**: False
-          | **type**: str
-          | **choices**: delete, keep, catlg, catalog, uncatlg, uncatalog
 
         reuse
           Determines if data set should be reused if *disposition=NEW* and a data set with matching name already exists.
@@ -1005,8 +961,6 @@ dds
           | **required**: False
           | **type**: str
 
-          | **required**: False
-          | **type**: str
 
         sms_storage_class
           The desired storage class for a new SMS-managed data set.
@@ -1018,8 +972,6 @@ dds
           | **required**: False
           | **type**: str
 
-          | **required**: False
-          | **type**: str
 
         sms_data_class
           The desired data class for a new SMS-managed data set.
@@ -1031,8 +983,6 @@ dds
           | **required**: False
           | **type**: str
 
-          | **required**: False
-          | **type**: str
 
         block_size
           The maximum length of a block in bytes.
@@ -1084,8 +1034,6 @@ dds
             | **required**: True
             | **type**: str
 
-            | **required**: True
-            | **type**: str
 
           encoding
             How the label for the key encrypting key specified by *label* is encoded by the Encryption Key Manager.
@@ -1098,9 +1046,6 @@ dds
             | **type**: str
             | **choices**: l, h
 
-            | **required**: True
-            | **type**: str
-            | **choices**: l, h
 
 
         encryption_key_2
@@ -1124,8 +1069,6 @@ dds
             | **required**: True
             | **type**: str
 
-            | **required**: True
-            | **type**: str
 
           encoding
             How the label for the key encrypting key specified by *label* is encoded by the Encryption Key Manager.
@@ -1138,7 +1081,6 @@ dds
             | **type**: str
             | **choices**: l, h
 
-            Maps to KEYCD2 on z/OS.
 
 
         key_length
@@ -1162,7 +1104,6 @@ dds
           | **required**: False
           | **type**: int
 
-          Provide *key_offset* only for VSAM key-sequenced data sets.
 
         record_length
           The logical record length. (e.g ``80``).
@@ -1178,7 +1119,6 @@ dds
           | **required**: False
           | **type**: int
 
-          Maps to LRECL on z/OS.
 
         record_format
           The format and characteristics of the records for new data set.
@@ -1196,7 +1136,6 @@ dds
           | **required**: False
           | **type**: dict
 
-          If not provided, no content from the DD is returned.
 
           type
             The type of the content to be returned.
@@ -1211,7 +1150,6 @@ dds
             | **type**: str
             | **choices**: text, base64
 
-            ``base64`` means return content in binary mode.
 
           src_encoding
             The encoding of the data set on the z/OS system.
@@ -1229,9 +1167,6 @@ dds
             | **default**: iso8859-1
 
 
-            | **required**: False
-            | **type**: str
-            | **default**: iso8859-1
 
 
       dd_unix
@@ -1240,8 +1175,6 @@ dds
         | **required**: False
         | **type**: dict
 
-      dd_unix
-        The path to a file in UNIX System Services (USS).
 
         path
           The path to an existing UNIX file.
@@ -1261,8 +1194,6 @@ dds
           | **type**: str
           | **choices**: keep, delete
 
-        disposition_normal
-          Indicates what to do with the UNIX file after normal termination of the program.
 
         disposition_abnormal
           Indicates what to do with the UNIX file after abnormal termination of the program.
@@ -1380,7 +1311,6 @@ dds
           | **type**: str
           | **choices**: u, vb, vba, fb, fba
 
-          *record_format* is required in situations where the data will be processed as records and therefore, *record_length*, *block_size* and *record_format* need to be supplied since a UNIX file would normally be treated as a stream of bytes.
 
         return_content
           Determines how content should be returned to the user.
@@ -1431,7 +1361,6 @@ dds
         | **required**: False
         | **type**: dict
 
-        Input will be saved to a temporary data set with a record length of 80.
 
         content
           The input contents for the DD.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,6 +6,37 @@
 Releases
 ========
 
+Version 1.3.6
+=============
+
+What's New
+----------
+
+* Bug Fixes
+
+  * Modules
+
+    * ``zos_copy`` fixes a bug that when a directory is copied from the
+      controller to the managed node and a mode is set, the mode is now applied
+      to the directory on the controller. If the directory being copied contains
+      files and mode is set, mode will only be applied to the files being copied
+      not the pre-existing files.
+    * zos_copy - fixes a bug where options were not defined in the module
+      argument spec that will result in error when running `ansible-core` v2.11
+      and using options `force` or `mode`.
+    * zos_fetch - fixes a bug where an option was not defined in the module
+      argument spec that will result in error when running `ansible-core` v2.11
+      and using option `encoding`.
+    * zos_job_submit - fixes a bug where an option was not defined in the module
+      argument spec that will result in error when running `ansible-core` v2.11
+      and using option `encoding`.
+    * jobs.py - fixes a utility used by module `zos_job_output` that would
+      truncate the DD content.
+    * ``zos_ssh`` connection plugin was updated to correct a bug that causes
+      an `ANSIBLE_SSH_CONTROL_PATH_DIR` attribute error only when using
+      ansible-core v2.11..
+
+
 Version 1.3.4
 =============
 

--- a/docs/source/requirements-single.rst
+++ b/docs/source/requirements-single.rst
@@ -12,7 +12,7 @@ Requirements
 The **IBM z/OS core collection** requires both a **control node** and
 **managed node** be configured with a minimum set of requirements. The
 control node is often referred to as the **controller** and the
-managed node as the **host**.
+managed node as the **host** or **target**.
 
 Control node
 ============
@@ -58,14 +58,14 @@ proceed to install the IBM z/OS core collection.
       files differently. Please review the README.ZOS guide included with the
       ported ``bash`` shell for further configurations.
 
-.. _Installing and Configuring ZOA Utilities:
-   https://www.ibm.com/support/knowledgecenter/en/SSKFYE_1.1.0/install.html
-
 .. _Ansible documentation:
    https://docs.ansible.com/ansible/2.7/user_guide/intro_inventory.html
 
 .. _Python on z/OS:
-   requirements-single.html#id1
+   requirements_managed.html#id1
+
+.. _Installing and Configuring ZOA Utilities:
+   https://www.ibm.com/support/knowledgecenter/en/SSKFYE_1.1.0/install.html
 
 .. _V2R3:
    https://www.ibm.com/support/knowledgecenter/SSLTBW_2.3.0/com.ibm.zos.v2r3/en/homepage.html
@@ -74,7 +74,7 @@ proceed to install the IBM z/OS core collection.
    https://www.ibm.com/support/knowledgecenter/SSLTBW
 
 .. _IBM Z Open Automation Utilities:
-   requirements-single.html#id1
+   requirements_managed.html#zoau
 
 .. _z/OS OpenSSH:
    https://www.ibm.com/support/knowledgecenter/SSLTBW_2.2.0/com.ibm.zos.v2r2.e0za100/ch1openssh.htm
@@ -84,9 +84,6 @@ proceed to install the IBM z/OS core collection.
 
 .. _playbook configuration:
    https://github.com/IBM/z_ansible_collections_samples/blob/master/docs/share/configuration_guide.md
-
-.. _FAQs:
-   https://ibm.github.io/z_ansible_collections_doc/faqs/faqs.html
 
 .. _z/OS® shell:
    https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.4.0/com.ibm.zos.v2r4.bpxa400/part1.htm
@@ -118,7 +115,6 @@ and required by **IBM z/OS core collection**.
 
 .. _IBM Open Enterprise Python for z/OS:
    http://www.ibm.com/products/open-enterprise-python-zos
-
 .. _IBM Open Enterprise SDK for Python:
    https://www.ibm.com/products/open-enterprise-python-zos
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: ibm
 name: ibm_zos_core
 
 # The collection version
-version: 1.3.4
+version: 1.3.6
 
 # Collection README file
 readme: README.md
@@ -79,4 +79,3 @@ build_ignore:
   - tests/*.ini
   - tests/requirements.txt
   - test_config.yml
-  

--- a/meta/ibm_zos_core_meta.yml
+++ b/meta/ibm_zos_core_meta.yml
@@ -1,5 +1,5 @@
 name: ibm_zos_core
-version: "1.3.4"
+version: "1.3.6"
 managed_requirements:
     -
         name: "IBM Open Enterprise SDK for Python"

--- a/plugins/connection/zos_ssh.py
+++ b/plugins/connection/zos_ssh.py
@@ -488,8 +488,8 @@ class Connection(ConnectionBase):
         self.host = self._play_context.remote_addr
         self.port = self._play_context.port
         self.user = self._play_context.remote_user
-        self.control_path = C.ANSIBLE_SSH_CONTROL_PATH
-        self.control_path_dir = C.ANSIBLE_SSH_CONTROL_PATH_DIR
+        self.control_path = None
+        self.control_path_dir = None
 
         # Windows operates differently from a POSIX connection/shell plugin,
         # we need to set various properties to ensure SSH on Windows continues
@@ -755,6 +755,7 @@ class Connection(ConnectionBase):
             self._persistent = True
 
             if not controlpath:
+                self.control_path_dir = self.get_option('control_path_dir')
                 cpdir = unfrackpath(self.control_path_dir)
                 b_cpdir = to_bytes(cpdir, errors="surrogate_or_strict")
 
@@ -765,6 +766,7 @@ class Connection(ConnectionBase):
                         "Cannot write to ControlPath %s" % to_native(cpdir)
                     )
 
+                self.control_path = self.get_option('control_path')
                 if not self.control_path:
                     self.control_path = self._create_control_path(
                         self.host, self.port, self.user

--- a/plugins/connection/zos_ssh.py
+++ b/plugins/connection/zos_ssh.py
@@ -2,7 +2,7 @@
 # Copyright 2015 Abhijit Menon-Sen <ams@2ndQuadrant.com>
 # Copyright 2017 Toshio Kuratomi <tkuratomi@ansible.com>
 # Copyright (c) 2017 Ansible Project
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -260,7 +260,7 @@ do ix=1 to isfrows
         Address SDSF "ISFBROWSE ST TOKEN('"token.ix"')"
         untilline = linecount + JDS_RECCNT.jx
         startingcount = linecount + 1
-        do kx=linecount+1 to  untilline
+        do kx=1 to isfline.0
             linecount = linecount + 1
             Say isfline.kx
         end

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_backup_restore.py
+++ b/plugins/modules/zos_backup_restore.py
@@ -336,8 +336,6 @@ def main():
                 exclude=dict(type="raw", required=False),
             ),
         ),
-        space=dict(type="int", required=False, aliases=["size"]),
-        space_type=dict(type="str", required=False, aliases=["unit"]),
         volume=dict(type="str", required=False),
         full_volume=dict(type="bool", default=False),
         temp_volume=dict(type="str", required=False, aliases=["dest_volume"]),
@@ -346,6 +344,8 @@ def main():
         overwrite=dict(type="bool", default=False),
         sms_storage_class=dict(type="str", required=False),
         sms_management_class=dict(type="str", required=False),
+        space=dict(type="int", required=False, aliases=["size"]),
+        space_type=dict(type="str", required=False, aliases=["unit"]),
         hlq=dict(type="str", required=False),
     )
 

--- a/plugins/modules/zos_backup_restore.py
+++ b/plugins/modules/zos_backup_restore.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1888,20 +1888,30 @@ def run_module(module, arg_def):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            src=dict(type='path'),
-            dest=dict(required=True, type='str'),
-            is_binary=dict(type='bool', default=False),
-            encoding=dict(type='dict'),
-            content=dict(type='str', no_log=True),
             backup=dict(type='bool', default=False),
             backup_name=dict(type='str'),
-            model_ds=dict(type='str', required=False),
+            content=dict(type='str', no_log=True),
+            dest=dict(required=True, type='str'),
+            encoding=dict(
+                type='dict',
+                required=False,
+                options={
+                    'from': dict(type='str', required=True),
+                    'to': dict(type='str', required=True)
+                }
+            ),
+            force=dict(type='bool', default=False),
+            ignore_sftp_stderr=dict(type='bool', default=False),
+            is_binary=dict(type='bool', default=False),
             local_follow=dict(type='bool', default=True),
+            mode=dict(type='str', required=False),
+            model_ds=dict(type='str', required=False),
             remote_src=dict(type='bool', default=False),
             sftp_port=dict(type='int', required=False),
-            ignore_sftp_stderr=dict(type='bool', default=False),
+            src=dict(type='path'),
             validate=dict(type='bool'),
             volume=dict(type='str', required=False),
+            # These arguments come from the action plugin.
             is_uss=dict(type='bool'),
             is_pds=dict(type='bool'),
             is_mvs_dest=dict(type='bool'),
@@ -1910,7 +1920,6 @@ def main():
             copy_member=dict(type='bool'),
             src_member=dict(type='bool'),
             local_charset=dict(type='str'),
-            force=dict(type='bool', default=False)
         ),
         add_file_common_args=True,
     )

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -913,6 +913,68 @@ def parse_and_validate_args(params):
     params = fix_old_size_arg(params)
 
     arg_defs = dict(
+        # For individual data set args
+        name=dict(
+            type=data_set_name,
+            default=data_set_name,
+            required=False,
+            dependencies=["type", "state", "batch"],
+        ),
+        state=dict(
+            type="str",
+            default="present",
+            choices=["present", "absent", "cataloged", "uncataloged"],
+        ),
+        type=dict(type=data_set_type, required=False, dependencies=["state"]),
+        space_type=dict(type=space_type, required=False, dependencies=["state"]),
+        space_primary=dict(type="int", required=False, dependencies=["state"]),
+        space_secondary=dict(type="int", required=False, dependencies=["state"]),
+        record_format=dict(
+            type=record_format,
+            required=False,
+            dependencies=["state"],
+            aliases=["format"],
+        ),
+        sms_management_class=dict(
+            type=sms_class, required=False, dependencies=["state"]
+        ),
+        # I know this alias is odd, ZOAU used to document they supported
+        # SMS data class when they were actually passing as storage class
+        # support for backwards compatability with previous module versions
+        sms_storage_class=dict(
+            type=sms_class,
+            required=False,
+            dependencies=["state"],
+            aliases=["data_class"],
+        ),
+        sms_data_class=dict(type=sms_class, required=False, dependencies=["state"]),
+        block_size=dict(
+            type=valid_when_state_present,
+            required=False,
+            dependencies=["state"],
+        ),
+        directory_blocks=dict(
+            type=valid_when_state_present,
+            required=False,
+            dependencies=["state"],
+        ),
+        record_length=dict(
+            type=record_length,
+            required=False,
+            dependencies=["state", "record_format"],
+        ),
+        key_offset=dict(type=valid_when_state_present, required=False),
+        key_length=dict(type=valid_when_state_present, required=False),
+        replace=dict(
+            type="bool",
+            default=False,
+        ),
+        volumes=dict(
+            type=volumes,
+            required=False,
+            aliases=["volume"],
+            dependencies=["state"],
+        ),
         # Used for batch data set args
         batch=dict(
             type="list",
@@ -993,68 +1055,6 @@ def parse_and_validate_args(params):
                     dependencies=["state"],
                 ),
             ),
-        ),
-        # For individual data set args
-        name=dict(
-            type=data_set_name,
-            default=data_set_name,
-            required=False,
-            dependencies=["type", "state", "batch"],
-        ),
-        state=dict(
-            type="str",
-            default="present",
-            choices=["present", "absent", "cataloged", "uncataloged"],
-        ),
-        type=dict(type=data_set_type, required=False, dependencies=["state"]),
-        space_type=dict(type=space_type, required=False, dependencies=["state"]),
-        space_primary=dict(type="int", required=False, dependencies=["state"]),
-        space_secondary=dict(type="int", required=False, dependencies=["state"]),
-        record_format=dict(
-            type=record_format,
-            required=False,
-            dependencies=["state"],
-            aliases=["format"],
-        ),
-        sms_management_class=dict(
-            type=sms_class, required=False, dependencies=["state"]
-        ),
-        # I know this alias is odd, ZOAU used to document they supported
-        # SMS data class when they were actually passing as storage class
-        # support for backwards compatability with previous module versions
-        sms_storage_class=dict(
-            type=sms_class,
-            required=False,
-            dependencies=["state"],
-            aliases=["data_class"],
-        ),
-        sms_data_class=dict(type=sms_class, required=False, dependencies=["state"]),
-        block_size=dict(
-            type=valid_when_state_present,
-            required=False,
-            dependencies=["state"],
-        ),
-        directory_blocks=dict(
-            type=valid_when_state_present,
-            required=False,
-            dependencies=["state"],
-        ),
-        record_length=dict(
-            type=record_length,
-            required=False,
-            dependencies=["state", "record_format"],
-        ),
-        key_offset=dict(type=valid_when_state_present, required=False),
-        key_length=dict(type=valid_when_state_present, required=False),
-        replace=dict(
-            type="bool",
-            default=False,
-        ),
-        volumes=dict(
-            type=volumes,
-            required=False,
-            aliases=["volume"],
-            dependencies=["state"],
         ),
         mutually_exclusive=[
             ["batch", "name"],
@@ -1146,16 +1146,20 @@ def run_module():
             dependencies=["batch"],
         ),
         type=dict(type="str", required=False, default="PDS"),
-        space_type=dict(type="str", required=False, default="M"),
         space_primary=dict(type="raw", required=False, aliases=["size"]),
         space_secondary=dict(type="int", required=False),
+        space_type=dict(type="str", required=False, default="M"),
         record_format=dict(type="str", required=False, aliases=["format"]),
-        sms_management_class=dict(type="str", required=False),
         # I know this alias is odd, ZOAU used to document they supported
         # SMS data class when they were actually passing as storage class
         # support for backwards compatability with previous module versions
         sms_storage_class=dict(type="str", required=False, aliases=["data_class"]),
         sms_data_class=dict(type="str", required=False),
+        sms_management_class=dict(type="str", required=False),
+        record_length=dict(
+            type="int",
+            required=False,
+        ),
         block_size=dict(
             type="int",
             required=False,
@@ -1164,20 +1168,16 @@ def run_module():
             type="int",
             required=False,
         ),
-        record_length=dict(
-            type="int",
-            required=False,
-        ),
         key_offset=dict(type="int", required=False),
         key_length=dict(type="int", required=False),
-        replace=dict(
-            type="bool",
-            default=False,
-        ),
         volumes=dict(
             type="raw",
             required=False,
             aliases=["volume"],
+        ),
+        replace=dict(
+            type="bool",
+            default=False,
         ),
     )
     result = dict(changed=False, message="", names=[])

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -326,10 +326,10 @@ def verify_uss_path_exists(file):
 
 def run_module():
     module_args = dict(
-        src=dict(type="str", required=True),
-        dest=dict(type="str"),
         from_encoding=dict(type="str", default="IBM-1047"),
         to_encoding=dict(type="str", default="ISO8859-1"),
+        src=dict(type="str", required=True),
+        dest=dict(type="str"),
         backup=dict(type="bool", default=False),
         backup_name=dict(type="str", required=False, default=None),
         backup_compress=dict(type="bool", required=False, default=False),

--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -542,13 +542,21 @@ def run_module():
             src=dict(required=True, type="str"),
             dest=dict(required=True, type="path"),
             fail_on_missing=dict(required=False, default=True, type="bool"),
+            validate_checksum=dict(required=False, default=True, type="bool"),
             flat=dict(required=False, default=True, type="bool"),
             is_binary=dict(required=False, default=False, type="bool"),
             use_qualifier=dict(required=False, default=False, type="bool"),
-            validate_checksum=dict(required=False, default=True, type="bool"),
-            encoding=dict(required=False, type="dict"),
             sftp_port=dict(type="int", required=False),
+            encoding=dict(
+                type='dict',
+                required=False,
+                options={
+                    'from': dict(type='str', required=True),
+                    'to': dict(type='str', required=True)
+                }
+            ),
             ignore_sftp_stderr=dict(type="bool", default=False, required=False),
+            # This argument comes from the action plugin.
             local_charset=dict(type="str"),
         )
     )

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -641,12 +641,12 @@ def run_module():
             options={
                 'from': dict(
                     type='str',
-                    required=True,
+                    required=False,
                     default='ISO8859-1'
                 ),
                 'to': dict(
                     type='str',
-                    required=True,
+                    required=False,
                     default='IBM-1047'
                 )
             }

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -625,17 +625,33 @@ def assert_valid_return_code(max_rc, found_rc):
 def run_module():
     module_args = dict(
         src=dict(type="str", required=True),
-        wait=dict(type="bool", required=False),
         location=dict(
             type="str",
             default="DATA_SET",
             choices=["DATA_SET", "USS", "LOCAL"],
         ),
-        encoding=dict(type="dict", required=False),
-        volume=dict(type="str", required=False),
-        return_output=dict(type="bool", required=False, default=True),
+        wait=dict(type="bool", required=False),
         wait_time_s=dict(type="int", default=60),
         max_rc=dict(type="int", required=False),
+        return_output=dict(type="bool", required=False, default=True),
+        volume=dict(type="str", required=False),
+        encoding=dict(
+            type='dict',
+            required=False,
+            options={
+                'from': dict(
+                    type='str',
+                    required=True,
+                    default='ISO8859-1'
+                ),
+                'to': dict(
+                    type='str',
+                    required=True,
+                    default='IBM-1047'
+                )
+            }
+        ),
+        # This argument comes from the action plugin.
         temp_file=dict(type="path", required=False),
     )
 

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_lineinfile.py
+++ b/plugins/modules/zos_lineinfile.py
@@ -343,20 +343,20 @@ def main():
             aliases=['path', 'destfile', 'name'],
             required=True
         ),
+        regexp=dict(type='str'),
         state=dict(
             type='str',
             default='present',
             choices=['absent', 'present']
         ),
-        regexp=dict(type='str'),
         line=dict(type='str'),
+        backrefs=dict(type='bool', default=False),
         insertafter=dict(
             type='str',
         ),
         insertbefore=dict(
             type='str',
         ),
-        backrefs=dict(type='bool', default=False),
         backup=dict(type='bool', default=False),
         backup_name=dict(type='str', required=False, default=None),
         firstmatch=dict(type='bool', default=False),

--- a/plugins/modules/zos_lineinfile.py
+++ b/plugins/modules/zos_lineinfile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1726,9 +1726,9 @@ def run_module():
 
     module_args = dict(
         program_name=dict(type="str", aliases=["program", "pgm"], required=True),
+        parm=dict(type="str", required=False),
         auth=dict(type="bool", default=False),
         verbose=dict(type="bool", default=False),
-        parm=dict(type="str", required=False),
         dds=dict(
             type="list",
             elements="dict",

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -541,6 +541,7 @@ options:
       dd_input:
         description:
           - I(dd_input) is used to specify an in-stream data set.
+          - I(dd_input) supports single or multiple lines of input.
           - Input will be saved to a temporary data set with a record length of 80.
         required: false
         type: dict
@@ -553,7 +554,6 @@ options:
           content:
             description:
               - The input contents for the DD.
-              - I(dd_input) supports single or multiple lines of input.
               - Multi-line input can be provided as a multi-line string
                 or a list of strings with 1 line per list item.
               - If a list of strings is provided, newlines will be
@@ -1143,6 +1143,7 @@ options:
               dd_input:
                 description:
                   - I(dd_input) is used to specify an in-stream data set.
+                  - I(dd_input) supports single or multiple lines of input.
                   - Input will be saved to a temporary data set with a record length of 80.
                 required: false
                 type: dict
@@ -1150,7 +1151,6 @@ options:
                   content:
                     description:
                       - The input contents for the DD.
-                      - I(dd_input) supports single or multiple lines of input.
                       - Multi-line input can be provided as a multi-line string
                         or a list of strings with 1 line per list item.
                       - If a list of strings is provided, newlines will be

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -581,7 +581,7 @@ options:
               src_encoding:
                 description:
                   - The encoding of the data set on the z/OS system.
-                  - for I(dd_input), I(src_encoding) should generally not need to be changed.
+                  - I(dd_input) and I(src_encoding) generally do not need to be changed.
                 type: str
                 default: ibm-1047
               response_encoding:
@@ -622,7 +622,7 @@ options:
               src_encoding:
                 description:
                   - The encoding of the data set on the z/OS system.
-                  - for I(dd_input), I(src_encoding) should generally not need to be changed.
+                  - I(dd_input) and I(src_encoding) generally do not need to be changed.
                 type: str
                 default: ibm-1047
               response_encoding:
@@ -1178,7 +1178,7 @@ options:
                       src_encoding:
                         description:
                           - The encoding of the data set on the z/OS system.
-                          - for I(dd_input), I(src_encoding) should generally not need to be changed.
+                          - I(dd_input) and I(src_encoding) generally do not need to be changed.
                         type: str
                         default: ibm-1047
                       response_encoding:

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python3
-
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -23,6 +21,22 @@ import argparse
 
 
 class ArtifactManager(object):
+    """
+    Dependency analyzer will review modules and action plugin changes and then
+    discover which tests should be run. It addition to mapping a test suite,
+    whether it is functional or unit, it will also see if the module/plugin
+    is used in test cases. In the even a module is used in another test suite
+    unrelated to the modules test suite, it will also be returned. This ensures
+    that a module changes don't break test suites dependent on a module.
+
+    Usage (minimal) example:
+        python dependencyfinder.py -p .. -b origin/dev -m
+
+    Note: It is possible that only test cases are modified only, without a module
+    or modules, in that case without a module pairing no test cases will be
+    returned. Its best to run full regression in that case until this can be
+    updated to support detecting only test cases.
+    """
     artifacts = []
 
     def __init__(self, artifacts=None):
@@ -197,6 +211,14 @@ class Artifact(object):
         self.path = path
         if dependencies:
             self.dependencies = dependencies
+
+    def __str__(self):
+        """
+        Print the Artifact class instance variables in a pretty manor.
+        """
+        return "name: {0},\nsource: {1},\npath: {2}\n".format(self.name,
+                                                              self.source,
+                                                              self.path)
 
     @classmethod
     def from_path(cls, path):
@@ -465,12 +487,67 @@ def get_changed_files(path, branch="origin/dev"):
     stdout, stderr = get_diff.communicate()
     stdout = stdout.decode("utf-8")
     if get_diff.returncode > 0:
-        raise RuntimeError("Could not acquire change list")
+        raise RuntimeError("Could not acquire change list, error = [{0}]".format(stderr))
     if stdout:
         changed_files = [
             x.split("\t")[-1] for x in stdout.split("\n") if "D" not in x.split("\t")[0]
         ]
     return changed_files
+
+
+def get_changed_plugins(path, branch="origin/dev"):
+    """Get a list of modules or plugins in a specific branch.
+
+    Args:
+        branch (str, optional): The branch to compare to. Defaults to "dev".
+
+    Raises:
+        RuntimeError: When git request-pull fails.
+
+    Returns:
+        list[str]: A list of changed file paths.
+    """
+    changed_plugins_modules = []
+    get_diff_pr = subprocess.Popen(
+        ["git", "request-pull", branch, "./"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=path,
+    )
+
+    stdout, stderr = get_diff_pr.communicate()
+    stdout = stdout.decode("utf-8")
+
+    if get_diff_pr.returncode > 0:
+        raise RuntimeError("Could not acquire change list, error = [{0}]".format(stderr))
+    if stdout:
+        for line in stdout.split("\n"):
+            path_corrected_line = None
+            if "plugins/action/" in line:
+                path_corrected_line = line.split("|", 1)[0].strip()
+            if "plugins/modules/" in line:
+                path_corrected_line = line.split("|", 1)[0].strip()
+            if "functional/modules/" in line:
+                if re.match('...', line):
+                    line = line.replace("...", "tests")
+                path_corrected_line = line.split("|", 1)[0].strip()
+            if "plugins/module_utils/" in line:
+                path_corrected_line = line.split("|", 1)[0].strip()
+            if "unit/" in line:
+                if re.match('...', line):
+                    line = line.replace("...", "tests")
+                path_corrected_line = line.split("|", 1)[0].strip()
+            if path_corrected_line is not None:
+                changed_plugins_modules.append(path_corrected_line)
+
+        # # There can be the case where only test cases are updated, question is
+        # # should this be default behavior only when no modules are edited
+        # if not changed_plugins_modules:
+        #     for line in stdout.split("\n"):
+        #         if "tests/functional/modules/" in line:
+        #             changed_plugins_modules.append(line.split("|", 1)[0].strip())
+
+    return changed_plugins_modules
 
 
 def parse_arguments():
@@ -511,6 +588,14 @@ def parse_arguments():
         action="store_true",
         help="Print one test per line to stdout. Default behavior prints all tests on same line.",
     )
+    parser.add_argument(
+        "-m",
+        "--minimum",
+        required=False,
+        action="store_true",
+        default=False,
+        help="Detect only the changes from the branch request-pull.",
+    )
     args = parser.parse_args()
     return args
 
@@ -525,7 +610,10 @@ if __name__ == "__main__":
     artifacts = build_artifacts_from_collection(args.path)
     all_artifact_manager = ArtifactManager(artifacts)
 
-    changed_files = get_changed_files(args.path, args.branch)
+    if args.minimum:
+        changed_files = get_changed_plugins(args.path, args.branch)
+    else:
+        changed_files = get_changed_files(args.path, args.branch)
 
     changed_artifacts = []
     for file in changed_files:

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -604,7 +604,6 @@ if __name__ == "__main__":
     # TODO: add logic to only grab necessary tests that are impacted by changes
     args = parse_arguments()
 
-    global collection_to_use
     collection_to_use = args.collection
 
     artifacts = build_artifacts_from_collection(args.path)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2322,7 +2322,7 @@ def test_copy_multiple_data_set_members(ansible_zos_module):
             assert v_cp.get("rc") == 0
             stdout = v_cp.get("stdout")
             assert stdout is not None
-            assert(len(stdout.splitlines())) == 2
+            assert (len(stdout.splitlines())) == 2
 
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -412,6 +412,52 @@ def test_copy_uss_file_to_uss_dir(ansible_zos_module):
         hosts.all.file(path=dest_path, state="absent")
 
 
+def test_copy_dir_and_change_mode(ansible_zos_module):
+    hosts = ansible_zos_module
+    dest_path = "/tmp/new_dir"
+
+    source_path = tempfile.mkdtemp()
+    subdir_path = "{0}/subdir".format(source_path)
+    mode = "0755"
+
+    try:
+        os.mkdir(subdir_path)
+        populate_dir(subdir_path)
+
+        hosts.all.file(path=dest_path, state="directory")
+        copy_result = hosts.all.zos_copy(
+            src=source_path,
+            dest=dest_path,
+            force=True,
+            mode=mode
+        )
+
+        stat_dir_res = hosts.all.stat(path=dest_path)
+        stat_subdir_res = hosts.all.stat(path="{0}/subdir".format(dest_path))
+        stat_file_res = hosts.all.stat(path="{0}/subdir/file3".format(dest_path))
+
+        for result in copy_result.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest_path
+        for result in stat_dir_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is True
+            assert result.get("stat").get("mode") == mode
+        for result in stat_subdir_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is True
+            assert result.get("stat").get("mode") == mode
+        for result in stat_file_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is False
+            assert result.get("stat").get("mode") == mode
+
+    finally:
+        hosts.all.file(path=dest_path, state="absent")
+        shutil.rmtree(source_path)
+
+
 def test_copy_uss_file_to_non_existing_sequential_data_set(ansible_zos_module):
     hosts = ansible_zos_module
     dest = "USER.TEST.SEQ.FUNCTEST"
@@ -1549,7 +1595,6 @@ def test_copy_local_nested_dir_to_uss(ansible_zos_module):
     dest_path = "/tmp/new_dir"
 
     source_path = tempfile.mkdtemp()
-    source_parent_dir = source_path.split("/")[-1]
     subdir_a_path = "{0}/subdir_a".format(source_path)
     subdir_b_path = "{0}/subdir_b".format(source_path)
 
@@ -1561,8 +1606,8 @@ def test_copy_local_nested_dir_to_uss(ansible_zos_module):
 
         copy_result = hosts.all.zos_copy(src=source_path, dest=dest_path)
 
-        stat_subdir_a_res = hosts.all.stat(path="{0}/{1}/subdir_a".format(dest_path, source_parent_dir))
-        stat_subdir_b_res = hosts.all.stat(path="{0}/{1}/subdir_b".format(dest_path, source_parent_dir))
+        stat_subdir_a_res = hosts.all.stat(path="{0}/subdir_a".format(dest_path))
+        stat_subdir_b_res = hosts.all.stat(path="{0}/subdir_b".format(dest_path))
 
         for result in copy_result.contacted.values():
             assert result.get("msg") is None
@@ -1583,7 +1628,6 @@ def test_copy_local_nested_dir_to_existing_uss_dir_forced(ansible_zos_module):
     dest_path = "/tmp/new_dir"
 
     source_path = tempfile.mkdtemp()
-    source_parent_dir = source_path.split("/")[-1]
     subdir_a_path = "{0}/subdir_a".format(source_path)
     subdir_b_path = "{0}/subdir_b".format(source_path)
 
@@ -1600,8 +1644,8 @@ def test_copy_local_nested_dir_to_existing_uss_dir_forced(ansible_zos_module):
             force=True
         )
 
-        stat_subdir_a_res = hosts.all.stat(path="{0}/{1}/subdir_a".format(dest_path, source_parent_dir))
-        stat_subdir_b_res = hosts.all.stat(path="{0}/{1}/subdir_b".format(dest_path, source_parent_dir))
+        stat_subdir_a_res = hosts.all.stat(path="{0}/subdir_a".format(dest_path))
+        stat_subdir_b_res = hosts.all.stat(path="{0}/subdir_b".format(dest_path))
 
         for result in copy_result.contacted.values():
             assert result.get("msg") is None

--- a/tests/helpers/zos_blockinfile_helper.py
+++ b/tests/helpers/zos_blockinfile_helper.py
@@ -57,7 +57,7 @@ def set_ds_test_env(test_name, hosts, test_env):
     results = hosts.all.shell(cmd='hlq')
     for result in results.contacted.values():
         hlq = result.get("stdout")
-    if(len(hlq) > 8):
+    if (len(hlq) > 8):
         hlq = hlq[:8]
     test_env["DS_NAME"] = hlq + "." + test_name.upper() + "." + test_env["DS_TYPE"]
 

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -61,3 +61,4 @@ plugins/modules/zos_ping.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_tso_command.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_tso_command.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_tso_command.py import-2.6!skip # Python 2.6 is unsupported
+tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -61,3 +61,4 @@ plugins/modules/zos_ping.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_tso_command.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_tso_command.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_tso_command.py import-2.6!skip # Python 2.6 is unsupported
+tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -61,3 +61,4 @@ plugins/modules/zos_ping.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_tso_command.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_tso_command.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_tso_command.py import-2.6!skip # Python 2.6 is unsupported
+tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -61,3 +61,4 @@ plugins/modules/zos_ping.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_tso_command.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_tso_command.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_tso_command.py import-2.6!skip # Python 2.6 is unsupported
+tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.


### PR DESCRIPTION
##### SUMMARY

Fixes for 
- #411 (mode gets ignored when copying between directories)
- #412 (unsupported parameters in zos_copy in Ansible 2.11)
- #354 `zos_job_output` had DD's truncated, fix was in module_utils `job.py`
- #495 `zos_ssh` used by with `zos_ping` fails with an attribute error when used with `ansible-core` v2.11

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

zos_copy

##### ADDITIONAL INFORMATION

For #411: When using `mode` in zos_copy and copying between directories, the given permissions are applied to the destination directory and any files that were not already present in it. Preexisting files and subdirectories are left with the same permissions they had before running the module.

For #412: `force` was added to the `arg_spec` of the module.