### PR TITLE
Enhancement/tmp hlq zos data set

### DIFF
--- a/changelogs/fragments/tmp-hlq-zos_data_set.yml
+++ b/changelogs/fragments/tmp-hlq-zos_data_set.yml
@@ -1,0 +1,7 @@
+minor_changes:
+   - >
+     zos_mvs_raw - Ensures that temporary datasets created by zos_data_set use the tmp_hlq specified.
+     This allows for a user to specify the data set high level qualifier (HLQ)
+     used in any temporary data set created by the module. Often, the
+     defaults are not permitted on systems, this provies a way to override
+     the defaults. (https://github.com/ansible-collections/ibm_zos_core/pull/491).

--- a/changelogs/fragments/tmp-hlq-zos_data_set.yml
+++ b/changelogs/fragments/tmp-hlq-zos_data_set.yml
@@ -1,6 +1,6 @@
 minor_changes:
    - >
-     zos_mvs_raw - Ensures that temporary datasets created by zos_data_set use the tmp_hlq specified.
+     zos_data_set - Ensures that temporary datasets created by zos_data_set use the tmp_hlq specified.
      This allows for a user to specify the data set high level qualifier (HLQ)
      used in any temporary data set created by the module. Often, the
      defaults are not permitted on systems, this provides a way to override

--- a/changelogs/fragments/tmp-hlq-zos_data_set.yml
+++ b/changelogs/fragments/tmp-hlq-zos_data_set.yml
@@ -3,5 +3,5 @@ minor_changes:
      zos_mvs_raw - Ensures that temporary datasets created by zos_data_set use the tmp_hlq specified.
      This allows for a user to specify the data set high level qualifier (HLQ)
      used in any temporary data set created by the module. Often, the
-     defaults are not permitted on systems, this provies a way to override
+     defaults are not permitted on systems, this provides a way to override
      the defaults. (https://github.com/ansible-collections/ibm_zos_core/pull/491).

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -110,6 +110,7 @@ class DataSet(object):
         sms_data_class=None,
         sms_management_class=None,
         volumes=None,
+        tmp_hlq=None,
     ):
         """Creates data set if it does not already exist.
 
@@ -164,6 +165,7 @@ class DataSet(object):
                     When using SMS, volumes can be provided when the storage class being used
                     has GUARANTEED_SPACE=YES specified. Otherwise, the allocation will fail.
                     Defaults to None.
+            tmp_hlq (str, optional): High level qualifier for temporary datasets.
 
         Returns:
             bool -- Indicates if changes were made.
@@ -595,6 +597,7 @@ class DataSet(object):
         sms_data_class=None,
         sms_management_class=None,
         volumes=None,
+        tmp_hlq=None,
     ):
         """A wrapper around zoautil_py
         Dataset.create() to raise exceptions on failure.
@@ -650,6 +653,7 @@ class DataSet(object):
                     When using SMS, volumes can be provided when the storage class being used
                     has GUARANTEED_SPACE=YES specified. Otherwise, the allocation will fail.
                     Defaults to None.
+            tmp_hlq (str, optional): High level qualifier for temporary datasets.
 
         Raises:
             DatasetCreateError: When data set creation fails.

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -487,6 +487,7 @@ class DataSet(object):
         sms_data_class=None,
         sms_management_class=None,
         volumes=None,
+        tmp_hlq=None,
     ):
         """Attempts to replace an existing data set.
 
@@ -540,6 +541,7 @@ class DataSet(object):
                     When using SMS, volumes can be provided when the storage class being used
                     has GUARANTEED_SPACE=YES specified. Otherwise, the allocation will fail.
                     Defaults to None.
+            tmp_hlq (str, optional): High level qualifier for temporary datasets.
         """
         arguments = locals()
         DataSet.delete(name)

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -678,7 +678,10 @@ def data_set_name(contents, dependencies):
         if dependencies.get("state") != "present":
             raise ValueError('Data set name must be provided when "state!=present"')
         if dependencies.get("type") != "MEMBER":
-            contents = DataSet.temp_name()
+            tmphlq = dependencies.get("tmp_hlq")
+            if tmphlq is None:
+                tmphlq = ""
+            contents = DataSet.temp_name(tmphlq)
         else:
             raise ValueError(
                 'Data set and member name must be provided when "type=MEMBER"'
@@ -1007,7 +1010,7 @@ def parse_and_validate_args(params):
             type=data_set_name,
             default=data_set_name,
             required=False,
-            dependencies=["type", "state", "batch"],
+            dependencies=["type", "state", "batch", "tmp_hlq"],
         ),
         state=dict(
             type="str",

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -236,6 +236,14 @@ options:
     type: bool
     required: false
     default: false
+  tmp_hlq:
+    description:
+      - Override the default high level qualifier (HLQ) for temporary and backup
+        datasets.
+      - The default HLQ is the Ansible user used to execute the module and if
+        that is not available, then the value C(TMPHLQ) is used.
+    required: false
+    type: str
   batch:
     description:
       - Batch can be used to perform operations on multiple data sets in a single module call.

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1064,6 +1064,11 @@ def parse_and_validate_args(params):
             aliases=["volume"],
             dependencies=["state"],
         ),
+        tmp_hlq=dict(
+            type='qualifier_or_empty',
+            required=False,
+            default=None
+        ),
         mutually_exclusive=[
             ["batch", "name"],
             # ["batch", "state"],

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1192,6 +1192,11 @@ def run_module():
             required=False,
             aliases=["volume"],
         ),
+        tmp_hlq=dict(
+            type="str",
+            required=False,
+            default=None
+        ),
     )
     result = dict(changed=False, message="", names=[])
 

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -219,7 +219,7 @@ def test_data_set_present_when_uncataloged(ansible_zos_module, jcl):
             assert result.get("changed") is True
     finally:
         hosts.all.file(path=TEMP_PATH, state="absent")
-        hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
+        hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent", volumes=DEFAULT_VOLUME)
 
 
 @pytest.mark.parametrize(
@@ -718,3 +718,19 @@ def test_data_set_creation_zero_values(ansible_zos_module):
             assert result.get("module_stderr") is None
     finally:
         hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
+
+
+def test_data_set_creation_with_tmp_hlq(ansible_zos_module, dstype):
+    try:
+        tmphlq = "TMPHLQ"
+        hosts = ansible_zos_module
+        results = hosts.all.zos_data_set(state="present", tmp_hlq=tmphlq)
+        dsname = None
+        for result in results.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("module_stderr") is None
+            dsname = result.get("names")
+            assert result.get("names")[:6] == tmphlq
+    finally:
+        if dsname :
+            hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -720,7 +720,7 @@ def test_data_set_creation_zero_values(ansible_zos_module):
         hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
 
 
-def test_data_set_creation_with_tmp_hlq(ansible_zos_module, dstype):
+def test_data_set_creation_with_tmp_hlq(ansible_zos_module):
     try:
         tmphlq = "TMPHLQ"
         hosts = ansible_zos_module
@@ -729,8 +729,8 @@ def test_data_set_creation_with_tmp_hlq(ansible_zos_module, dstype):
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
-            dsname = result.get("names")
-            assert result.get("names")[:6] == tmphlq
+            for dsname in result.get("names"):
+                assert dsname[:6] == tmphlq
     finally:
         if dsname:
             hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -732,5 +732,5 @@ def test_data_set_creation_with_tmp_hlq(ansible_zos_module, dstype):
             dsname = result.get("names")
             assert result.get("names")[:6] == tmphlq
     finally:
-        if dsname :
+        if dsname:
             hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added tmp_hlq option in zos_data_set, when a temp dataset is created using state:present and no name. This allows the user to still create a tmp dataset but specifying the TMPHLQ.

In the process I had to modify the interfaces ensure_present, replace, and create for plugins/module_utils/data_set.py

Also added a new test case for it. 

Corrected an existing test case which was relying in a subsequent test to catalog and delete a test dataset.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_data_set

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
