### PR TITLE
Bugfix/372/member backup name

### DIFF
--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -98,7 +98,8 @@ def mvs_file_backup(dsn, bk_dsn=None, tmphlq=None):
         # This should not delete a PDS just to create a backup member.
         # Otherwise, we allocate the appropiate space for the backup ds based on src.
         if is_member(bk_dsn):
-            cp_rc = datasets._copy(dsn, bk_dsn)
+            cp_response = datasets._copy(dsn, bk_dsn)
+            cp_rc = cp_response.rc
         else:
             cp_rc = _copy_ds(dsn, bk_dsn)
 

--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -93,7 +93,10 @@ def mvs_file_backup(dsn, bk_dsn=None, tmphlq=None):
                 hlq = datasets.hlq()
             bk_dsn = datasets.tmp_name(hlq)
         bk_dsn = _validate_data_set_name(bk_dsn).upper()
-        cp_rc = _copy_ds(dsn, bk_dsn)
+        if is_member(bk_dsn):
+            cp_rc = datasets._copy(dsn, bk_dsn)
+        else:
+            cp_rc = _copy_ds(dsn, bk_dsn)
         if cp_rc == 12:  # The data set is probably a PDS or PDSE
             # Delete allocated backup that was created when attempting to use _copy_ds()
             # Safe to delete because _copy_ds() would have raised an exception if it did

--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -93,10 +93,15 @@ def mvs_file_backup(dsn, bk_dsn=None, tmphlq=None):
                 hlq = datasets.hlq()
             bk_dsn = datasets.tmp_name(hlq)
         bk_dsn = _validate_data_set_name(bk_dsn).upper()
+
+        # In case the backup ds is a member we trust that the PDS attributes are ok to fit the src content.
+        # This should not delete a PDS just to create a backup member.
+        # Otherwise, we allocate the appropiate space for the backup ds based on src.
         if is_member(bk_dsn):
             cp_rc = datasets._copy(dsn, bk_dsn)
         else:
             cp_rc = _copy_ds(dsn, bk_dsn)
+
         if cp_rc == 12:  # The data set is probably a PDS or PDSE
             # Delete allocated backup that was created when attempting to use _copy_ds()
             # Safe to delete because _copy_ds() would have raised an exception if it did

--- a/tests/functional/modules/test_zos_blockinfile_func.py
+++ b/tests/functional/modules/test_zos_blockinfile_func.py
@@ -147,7 +147,8 @@ Until the issue be addressed I disable related tests.
 ENCODING = ['IBM-1047']
 USS_BACKUP_FILE = "/tmp/backup.tmp"
 MVS_BACKUP_DS = "BLOCKIF.TEST.BACKUP"
-BACKUP_OPTIONS = [None, MVS_BACKUP_DS]
+MVS_BACKUP_PDS = "BLOCKIF.TEST.BACKUP(BACKUP)"
+BACKUP_OPTIONS = [None, MVS_BACKUP_DS, MVS_BACKUP_PDS]
 TEST_ENV = dict(
     TEST_CONT=TEST_CONTENT,
     TEST_DIR="/tmp/zos_blockinfile/",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Change is to add a check to identify if the backup name is a member type, if so, we will not try to allocate it (step in which it currently fails) rather we will use cp to copy into the PDS/PDSE member.


Fixes #372 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/backup.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TEST PLAYBOOK:
- hosts : zvm
  collections : 
    - ibm.ibm_zos_core
  vars:
    #ZOAU: "/zoau/v1.2.0f"
    ZOAU: "/zoau/v1.1.1-ptf1"
    PYZ: "/python3/usr/lpp/IBM/cyp/v3r8/pyz"
  environment: "{{ environment_vars }}"
  tasks : 
    - name : "Delete test dataset"
      zos_data_set :
        name: OMVSADM.TESTIN.BLOCKPDS
        state: absent 
        type: SEQ
      register : result
        
    - name: "Response for deleting the PDS"
      debug:
        msg: "{{ result }}"

    - name : "Create test dataset"
      zos_data_set :
        name: OMVSADM.TESTIN.BLOCK
        state: present 
        type: SEQ
      register : result
    
    - name : "Removed OMVSADM.TESTIN.BLOCKPDS"
      zos_data_set :
        name: OMVSADM.TESTIN.BLOCKPDS
        state: absent 
      register : result
    
    - name: "Response for creating the SEQ DS"
      debug:
        msg: "{{ result }}"
    
    - name : "Create test PDS dataset"
      zos_data_set :
        name: OMVSADM.TESTIN.BLOCKPDS
        state: present 
        type: PDS
        space_primary: 100
        space_type: M
        record_format: VB
        record_length: 90
        replace: yes
      register : result
    
    - name: "Response for creating the PDS DS"
      debug:
        msg: "{{ result }}"
    
    # - name : "Create test PDS member"
    #   zos_data_set :
    #     name: OMVSADM.TESTIN.BLOCKPDS(BACKUP)
    #     state: present 
    #     type: MEMBER
    #     replace: yes
    #   register : result
        
    # - name: "Response for creating the member"
    #   debug:
    #     msg: "{{ result }}"
    
    - name: Ensure we have our own comment added to the partitioned data set member
      zos_blockinfile:
        src: OMVSADM.TESTIN.BLOCK
        block: '# VAR test value'
      register : result
    
    - name: "Response for adding comment  to the DS"
      debug:
        msg: "{{ result }}"
    
    - name: Ensure we have our own comment added to the partitioned data set member with backup name
      zos_blockinfile:
        src: OMVSADM.TESTIN.BLOCK
        block: '# VAR default value'
        backup: true
        backup_name: OMVSADM.TESTIN.BLOCKPDS(BACKUP)
      register : result
    
    - name: "Response for adding block the DS with backup option"
      debug:
        msg: "{{ result }}"
    
    - name : "Delete test dataset"
      zos_data_set :
        name: OMVSADM.TESTIN.BLOCK
        state: absent 
        type: SEQ
      register : result
        
    - name: "Response for deleting the DS"
      debug:
        msg: "{{ result }}"

Output : 


TASK [Ensure we have our own comment added to the partitioned data set member with backup name] *****************************************************************
fatal: [zvm]: FAILED! => {"changed": false, "msg": "creating backup has failed"}


Output after change: 

TASK [Response for adding block the DS with backup option] **************************************************************************************************
ok: [zvm] => {
    "msg": {
        "backup_name": "OMVSADM.TESTIN.BLOCKPDS(BACKUP)",
        "changed": 1,
        "cmd": "dmodhelper -b -d -c IBM-1047 -m BEGIN\nEND\n# {mark} ANSIBLE MANAGED BLOCK $ a\\# VAR default value OMVSADM.TESTIN.BLOCK ",
        "failed": false,
        "found": 0
    }
}


```
