### PR TITLE
Bugfix - corrects the dd_name used in jobs.py

### DIFF
--- a/changelogs/fragments/507-display-specific-ddname.yml
+++ b/changelogs/fragments/507-display-specific-ddname.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >
+    zos_job_output - fixes a bug that returned all ddname's when a specific
+      ddname was provided. Now a specific ddname can be returned and all others
+      ignored. (https://github.com/ansible-collections/ibm_zos_core/pull/507)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -52,6 +52,11 @@ Version 1.4.0-beta.2
 
       * fixed option `tag_ccsid` to correctly allow for type int.
 
+    * ``module_utils``
+
+      * jobs.py - fixes a utility used by module zos_job_output that would
+        truncate the DD content.
+
   * Documentation
 
     * Review :ref:`version 1.4.0-beta.1<my-reference-label>` release notes for additional content.

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -53,7 +53,7 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None):
     job_id = parsed_args.get("job_id") or "*"
     job_name = parsed_args.get("job_name") or "*"
     owner = parsed_args.get("owner") or "*"
-    dd_name = parsed_args.get("ddname") or ""
+    dd_name = parsed_args.get("dd_name") or ""
 
     job_detail = _get_job_output(job_id, owner, job_name, dd_name)
     if len(job_detail) == 0:

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -104,7 +104,7 @@ def test_zos_job_output_job_exists_with_filtered_ddname(ansible_zos_module):
     )
     hosts.all.file(path=TEMP_PATH, state="absent")
     dd_name = "JESMSGLG"
-    results = hosts.all.zos_job_output(job_name="SAMPLE", ddname=dd_name)
+    results = hosts.all.zos_job_output(job_name="HELLO", ddname=dd_name)
     for result in results.contacted.values():
         assert result.get("changed") is False
         assert result.get("jobs") is not None

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -103,7 +103,7 @@ def test_zos_job_output_job_exists_with_filtered_ddname(ansible_zos_module):
         src="{0}/SAMPLE".format(TEMP_PATH), location="USS", wait=True, volume=None
     )
     hosts.all.file(path=TEMP_PATH, state="absent")
-    dd_name="JESMSGLG"
+    dd_name = "JESMSGLG"
     results = hosts.all.zos_job_output(job_name="SAMPLE", ddname=dd_name)
     for result in results.contacted.values():
         assert result.get("changed") is False

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -91,3 +91,23 @@ def test_zos_job_output_job_exists(ansible_zos_module):
             result.get("jobs")[0].get("ret_code").get("steps")[0].get("step_name")
             == "STEP0001"
         )
+
+
+def test_zos_job_output_job_exists_with_filtered_ddname(ansible_zos_module):
+    hosts = ansible_zos_module
+    hosts.all.file(path=TEMP_PATH, state="directory")
+    hosts.all.shell(
+        cmd="echo {0} > {1}/SAMPLE".format(quote(JCL_FILE_CONTENTS), TEMP_PATH)
+    )
+    hosts.all.zos_job_submit(
+        src="{0}/SAMPLE".format(TEMP_PATH), location="USS", wait=True, volume=None
+    )
+    hosts.all.file(path=TEMP_PATH, state="absent")
+    dd_name="JESMSGLG"
+    results = hosts.all.zos_job_output(job_name="SAMPLE", ddname=dd_name)
+    for result in results.contacted.values():
+        assert result.get("changed") is False
+        assert result.get("jobs") is not None
+        for job in result.get("jobs"):
+            assert len(job.get("ddnames")) == 1
+            assert job.get("ddnames")[0].get("ddname") == dd_name


### PR DESCRIPTION
##### SUMMARY

Fixed a typo in module_utils/job.py:
module_utils/job.py line 59 in 1.3.4 code reads:
dd_name = parsed_args.get("ddname") or ""

To
dd_name = parsed_args.get("dd_name") or ""
Fixes https://github.com/ansible-collections/ibm_zos_core/issues/329 on support 1.3.x branch

This was cherry-picked from a prior release to forward fix the 1.4.0-beta.2 release. 
These are the commits cherry-picked:
https://github.com/ansible-collections/ibm_zos_core/pull/334/commits/31f8eb3b48c99c12f6c74ab0db34e59c04010c00
https://github.com/ansible-collections/ibm_zos_core/pull/334/commits/dd7b3f51115b275610ee47fb26d4f94e58adb6a7


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
