### PR TITLE
Fix job name in zos_job_output test case

### DIFF
--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -97,7 +97,7 @@ def test_zos_job_output_job_exists_with_filtered_ddname(ansible_zos_module):
     )
     hosts.all.file(path=TEMP_PATH, state="absent")
     dd_name = "JESMSGLG"
-    results = hosts.all.zos_job_output(job_name="SAMPLE", ddname=dd_name)
+    results = hosts.all.zos_job_output(job_name="HELLO", ddname=dd_name)
     for result in results.contacted.values():
         assert result.get("changed") is False
         assert result.get("jobs") is not None


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
This corrects the name of a job in a test case, it was accidently named to match the JCL instead of the Jobname; for now this is a simple fix, it would be better if the JCLs were named to match the JOB names to avoid confusion.

This fixes #509 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


