### PR TITLE
Bugfix [zos_mount] ccsid type is string when it should be int, update dependency finder

### DIFF
--- a/changelogs/fragments/511-update-ccsid-type-int.yml
+++ b/changelogs/fragments/511-update-ccsid-type-int.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >
+    zos_mount - fixed option `tag_ccsid` to correctly allow for type int.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/511)

--- a/plugins/modules/zos_mount.py
+++ b/plugins/modules/zos_mount.py
@@ -1169,7 +1169,7 @@ def main():
         tag_untagged=dict(
             arg_type="str", default="", choices=["", "TEXT", "NOTEXT"], required=False
         ),
-        tag_ccsid=dict(arg_type="str", required=False),
+        tag_ccsid=dict(arg_type="int", required=False),
         allow_uid=dict(arg_type="bool", default=True, required=False),
         sysname=dict(arg_type="str", default="", required=False),
         automove=dict(

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -510,8 +510,21 @@ def get_changed_plugins(path, branch="origin/dev"):
         list[str]: A list of changed file paths.
     """
     changed_plugins_modules = []
+
+    # Added the remote repository URL to avoid the warning "warn: Are you sure you pushed 'HEAD' there?"
+    # which results in a non-zero RC and fails the script. Follows the man page usage:
+    # git request-pull [-p] <start> <URL> [<end>], also for the end it can no longer be './' else you will
+    # see a error `refs/..... found at ./ but points to a different object' so its best to use the branch name
+    #
+    # --show-current not supported on the git version in the container?
+    # stream = os.popen('git branch --show-current')
+    stream = os.popen("git branch |grep '*' |cut -d' ' -f2")
+    current_branch_name = stream.read()
+    current_branch_name = current_branch_name.rstrip()
+
+    branch = branch.rstrip()
     get_diff_pr = subprocess.Popen(
-        ["git", "request-pull", branch, "./"],
+        ["git", "request-pull", branch, "git@github.com:ansible-collections/ibm_zos_core.git", current_branch_name],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         cwd=path,
@@ -519,9 +532,17 @@ def get_changed_plugins(path, branch="origin/dev"):
 
     stdout, stderr = get_diff_pr.communicate()
     stdout = stdout.decode("utf-8")
+    stderr = stderr.decode('utf-8')
 
-    if get_diff_pr.returncode > 0:
+    if get_diff_pr.returncode == 1:
+        if "Could not read from remote repository" in stderr:
+            pass
+        else:
+            raise RuntimeError("Could not acquire change list, error = [{0}]".format(stderr))
+
+    if get_diff_pr.returncode > 1:
         raise RuntimeError("Could not acquire change list, error = [{0}]".format(stderr))
+
     if stdout:
         for line in stdout.split("\n"):
             path_corrected_line = None
@@ -606,7 +627,6 @@ if __name__ == "__main__":
     # TODO: add logic to only grab necessary tests that are impacted by changes
     args = parse_arguments()
 
-    global collection_to_use
     collection_to_use = args.collection
 
     artifacts = build_artifacts_from_collection(args.path)

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -33,5 +33,4 @@ plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-
 plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 docs/source/modules/zos_apf.rst rstcheck!skip #Inline emphasis start-string without end-string
-tests/dependencyfinder.py pylint:global-at-module-level # Ignore for test helper
 tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -30,5 +30,4 @@ plugins/modules/zos_backup_restore.py validate-modules:missing-gplv3-license # L
 plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-spec # We use our own argument parser for advanced conditional and dependent arguments.
 plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-tests/dependencyfinder.py pylint:global-at-module-level # Ignore for test helper
 tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -31,5 +31,4 @@ plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-
 plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 docs/source/modules/zos_apf.rst rstcheck!skip #Inline emphasis start-string without end-string
-tests/dependencyfinder.py pylint:global-at-module-level # Ignore for test helper
 tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -30,5 +30,4 @@ plugins/modules/zos_backup_restore.py validate-modules:missing-gplv3-license # L
 plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-spec # We use our own argument parser for advanced conditional and dependent arguments.
 plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-tests/dependencyfinder.py pylint:global-at-module-level # Ignore for test helper
 tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -31,5 +31,4 @@ plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-
 plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 docs/source/modules/zos_apf.rst rstcheck!skip #Inline emphasis start-string without end-string
-tests/dependencyfinder.py pylint:global-at-module-level # Ignore for test helper
 tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -32,5 +32,4 @@ plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-
 plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 docs/source/modules/zos_apf.rst rstcheck!skip #Inline emphasis start-string without end-string
-tests/dependencyfinder.py pylint:global-at-module-level # Ignore for test helper
 tests/dependencyfinder.py shebang # This is not an ansible module but a test helper so this shebang limitation is not required.


### PR DESCRIPTION
##### SUMMARY
This bugffix addresses zos_mount. It fixed option `tag_ccsid` to correctly allow for type int.
It addresses issue #506 

It also updates the dependency finder such that it can support pull request base branches that are not only `origin/dev`.
It addresses also issue #508 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

