### PR TITLE
Update the forked ssh code to support both ansible 2.9 an 2.11

### DIFF
--- a/changelogs/fragments/513-zos_ssh-support-ansible-2.11.yml
+++ b/changelogs/fragments/513-zos_ssh-support-ansible-2.11.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >
+    zos_ssh - fixes connection plugin which will error when using `ansible-core`
+    2.11 with an `AttributeError: module 'ansible.constants' has no attribute
+    'ANSIBLE_SSH_CONTROL_PATH_DIR'`.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/513)

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -606,6 +606,7 @@ if __name__ == "__main__":
     # TODO: add logic to only grab necessary tests that are impacted by changes
     args = parse_arguments()
 
+    global collection_to_use
     collection_to_use = args.collection
 
     artifacts = build_artifacts_from_collection(args.path)


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
Fixes the issue in #495 

Where when using ansible-core 2.11 and `zos_ping` which requires the `zos_ssh` connection such that you receive an error

```
AttributeError: module 'ansible.constants' has no attribute 'ANSIBLE_SSH_CONTROL_PATH_DIR'.
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`zos_ssh` affects `zos_ping`

##### ADDITIONAL INFORMATION
Tested it in both ansible 2.9 and ansible-core 2.11.

Result for ansible-core 2.11:
```
(ansible-doc) ddimatos:[ ~/git/github/playbooks ]ansible --version
ansible [core 2.11.12]
  config file = /Users/ddimatos/git/github/playbooks/ansible.cfg
  configured module search path = ['/Users/ddimatos/.ansible/collections/ansible_collections/ibm/ibm_zos_core/plugins/modules']
  ansible python module location = /Users/ddimatos/ansible_versions/3_8_13/ansible-doc/lib/python3.8/site-packages/ansible
  ansible collection location = /Users/ddimatos/.ansible/collections:/usr/share/ansible/collections
  executable location = /Users/ddimatos/ansible_versions/3_8_13/ansible-doc/bin/ansible
  python version = 3.8.13 (default, Jun 14 2022, 23:29:22) [Clang 13.0.0 (clang-1300.0.27.3)]
  jinja version = 3.1.2
  libyaml = True
(ansible-doc) ddimatos:[ ~/git/github/playbooks ]ansible-playbook -i inventory zos_ping.yml

PLAY [zvm] **************************************************************************************************************************************************************************************************

TASK [Ping host - zvm] **************************************************************************************************************************************************************************************
ok: [zvm]

TASK [Response] *********************************************************************************************************************************************************************************************
ok: [zvm] => {
    "msg": "pong"
}

PLAY RECAP **************************************************************************************************************************************************************************************************
zvm                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```

Result for ansible 2.9.x:
```
(ansible-test) ddimatos:[ ~/git/github/playbooks ]ansible --version
ansible 2.9.27
  config file = /Users/ddimatos/git/github/playbooks/ansible.cfg
  configured module search path = ['/Users/ddimatos/.ansible/collections/ansible_collections/ibm/ibm_zos_core/plugins/modules']
  ansible python module location = /Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/site-packages/ansible
  executable location = /Library/Frameworks/Python.framework/Versions/3.8/bin/ansible
  python version = 3.8.2 (v3.8.2:7b3ab5921f, Feb 24 2020, 17:52:18) [Clang 6.0 (clang-600.0.57)]
(ansible-test) ddimatos:[ ~/git/github/playbooks ]ansible-playbook -i inventory zos_ping.yml

PLAY [zvm] **************************************************************************************************************************************************************************************************

TASK [Ping host - zvm] **************************************************************************************************************************************************************************************
ok: [zvm]

TASK [Response] *********************************************************************************************************************************************************************************************
ok: [zvm] => {
    "msg": "pong"
}

PLAY RECAP **************************************************************************************************************************************************************************************************
zvm                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

```