### PR TITLE
Bugfix/496/copy directory when omitting slash

### DIFF
--- a/changelogs/fragments/515-copy-support-directories.yml
+++ b/changelogs/fragments/515-copy-support-directories.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - >
+    zos_copy - was enhanced for when `src` is a directory and ends with "/",
+    the contents of it will be copied into the root of `dest`. It it doesn't
+    end with "/", the directory itself will be copied.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/515)

--- a/docs/source/modules/zos_copy.rst
+++ b/docs/source/modules/zos_copy.rst
@@ -213,6 +213,8 @@ src
 
   If ``src`` is a file and dest ends with "/" or destination is a directory, the file is copied to the directory with the same filename as src.
 
+  If ``src`` is a directory and ends with "/", the contents of it will be copied into the root of ``dest``. It it doesn't end with "/", the directory itself will be copied.
+
   If ``src`` is a VSAM data set, destination must also be a VSAM.
 
   Wildcards can be used to copy multiple PDS/PDSE members to another PDS/PDSE.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -21,20 +21,23 @@ What's New
       to the directory on the controller. If the directory being copied contains
       files and mode is set, mode will only be applied to the files being copied
       not the pre-existing files.
-    * zos_copy - fixes a bug where options were not defined in the module
+    * ``zos_copy`` - fixes a bug where options were not defined in the module
       argument spec that will result in error when running `ansible-core` v2.11
       and using options `force` or `mode`.
-    * zos_fetch - fixes a bug where an option was not defined in the module
+    * ``zos_copy`` - was enhanced for when `src` is a directory and ends with "/",
+      the contents of it will be copied into the root of `dest`. It it doesn't
+      end with "/", the directory itself will be copied.
+    * ``zos_fetch`` - fixes a bug where an option was not defined in the module
       argument spec that will result in error when running `ansible-core` v2.11
       and using option `encoding`.
-    * zos_job_submit - fixes a bug where an option was not defined in the module
-      argument spec that will result in error when running `ansible-core` v2.11
-      and using option `encoding`.
-    * jobs.py - fixes a utility used by module `zos_job_output` that would
+    * ``zos_job_submit`` - fixes a bug where an option was not defined in the
+      module argument spec that will result in error when running
+      `ansible-core` v2.11 and using option `encoding`.
+    * ``jobs.py`` - fixes a utility used by module `zos_job_output` that would
       truncate the DD content.
     * ``zos_ssh`` connection plugin was updated to correct a bug that causes
       an `ANSIBLE_SSH_CONTROL_PATH_DIR` attribute error only when using
-      ansible-core v2.11..
+      ansible-core v2.11.
 
 
 Version 1.3.4

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1000,14 +1000,16 @@ class USSCopyHandler(CopyHandler):
         return dest
 
     def _copy_to_dir(self, src_dir, dest_dir, conv_path, temp_path, force):
-        """Helper function to copy a USS directory to another USS directory
+        """Helper function to copy a USS directory to another USS directory.
+        If the path for dest_dir does not end with a trailing slash ("/"),
+        the src_dir itself will be copied into the destination.
 
         Arguments:
             src_dir {str} -- USS source directory
             dest_dir {str} -- USS dest directory
+            conv_path {str} -- Path to the converted source directory
             temp_path {str} -- Path to the location where the control node
                                transferred data to
-            conv_path {str} -- Path to the converted source directory
             force {bool} -- Whether to copy files to an already existing directory
 
         Returns:
@@ -1015,6 +1017,8 @@ class USSCopyHandler(CopyHandler):
                        a list of paths for all subdirectories and files
                        that got copied.
         """
+        copy_directory = True if not src_dir.endswith("/") else False
+
         if temp_path:
             temp_path = "{0}/{1}".format(
                 temp_path,
@@ -1023,15 +1027,20 @@ class USSCopyHandler(CopyHandler):
 
         new_src_dir = temp_path or conv_path or src_dir
         new_src_dir = os.path.normpath(new_src_dir)
-        changed_files, original_permissions = self._get_changed_files(new_src_dir, dest_dir)
+        dest = dest_dir
+        changed_files, original_permissions = self._get_changed_files(new_src_dir, dest_dir, copy_directory)
 
         try:
-            dest = shutil.copytree(new_src_dir, dest_dir, dirs_exist_ok=force)
+            if copy_directory:
+                dest = os.path.join(dest_dir, os.path.basename(os.path.normpath(src_dir)))
+            dest = shutil.copytree(new_src_dir, dest, dirs_exist_ok=force)
+
+            # self.fail_json(msg=f'{dest_dir}, {changed_files}, {original_permissions}')
 
             # Restoring permissions for preexisting files and subdirectories.
             for filepath, permissions in original_permissions:
                 mode = "0{0:o}".format(stat.S_IMODE(permissions))
-                self.module.set_mode_if_different(os.path.join(dest, filepath), mode, False)
+                self.module.set_mode_if_different(os.path.join(dest_dir, filepath), mode, False)
         except Exception as err:
             self.fail_json(
                 msg="Error while copying data to destination directory {0}".format(
@@ -1041,12 +1050,15 @@ class USSCopyHandler(CopyHandler):
             )
         return dest, changed_files
 
-    def _get_changed_files(self, src, dest):
+    def _get_changed_files(self, src, dest, copy_directory):
         """Traverses a source directory and gets all the paths to files and
         subdirectories that got copied into a destination.
         Arguments:
             src (str) -- Path to the directory where files are copied from.
             dest (str) -- Path to the directory where files are copied into.
+            copy_directory (bool) -- Whether the src directory itself will be copied
+                                     into dest. The src basename will get appended
+                                     to filepaths when comparing.
 
         Returns:
             tuple -- A list of paths for all new subdirectories and files that
@@ -1057,9 +1069,13 @@ class USSCopyHandler(CopyHandler):
         original_files = self._walk_uss_tree(dest) if os.path.exists(dest) else []
         copied_files = self._walk_uss_tree(src)
 
+        # It's not needed to normalize the path because it was already normalized
+        # on _copy_to_dir.
+        parent_dir = os.path.basename(src) if copy_directory else ''
+
         changed_files = [
             relative_path for relative_path in copied_files
-            if relative_path not in original_files
+            if os.path.join(parent_dir, relative_path) not in original_files
         ]
 
         # Creating tuples with (filename, permissions).
@@ -1663,7 +1679,13 @@ def run_module(module, arg_def):
     #    to 'preserve'
     # ********************************************************************
     if remote_src and "/" in src:
-        src = os.path.realpath(src)
+        # Keeping the trailing slash because the CopyHandler will do
+        # different things depending on its existence.
+        if src.endswith("/"):
+            src = "{0}/".format(os.path.realpath(src))
+        else:
+            src = os.path.realpath(src)
+
         if not os.path.exists(src):
             module.fail_json(msg="Source {0} does not exist".format(src))
         if not os.access(src, os.R_OK):

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -212,6 +212,9 @@ options:
       - If C(src) is a file and dest ends with "/" or destination is a
         directory, the file is copied to the directory with the same filename as
         src.
+      - If C(src) is a directory and ends with "/", the contents of it will be copied
+        into the root of C(dest). It it doesn't end with "/", the directory itself
+        will be copied.
       - If C(src) is a VSAM data set, destination must also be a VSAM.
       - Wildcards can be used to copy multiple PDS/PDSE members to another
         PDS/PDSE.


### PR DESCRIPTION
##### SUMMARY

Fixes #496. zos_copy can now copy the source directory itself when writing its path without a trailing "/", or just the contents when using a "/" at the end, aligning its behavior to the built-in Ansible module. 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`zos_copy`

##### ADDITIONAL INFORMATION

Updated most test cases dealing with USS directories.
