### PR TITLE
Release v1.3.6

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,5 +1,5 @@
 .. ...........................................................................
-.. © Copyright IBM Corporation 2020                                          .
+.. © Copyright IBM Corporation 2020, 2022                                      .
 .. ...........................................................................
 
 ========
@@ -74,7 +74,7 @@ What's New
       ``ansible-core`` v2.9 which continues to use ``retries`` and users of
       ``ansible-core`` v2.11 or later which uses ``reconnection_retries``. This
       also resolves a bug in the connection that referenced a deprecated
-      constant.  
+      constant.
     * ``zos_job_output`` fixes a bug that returned all ddname's when a specific
       ddname was provided. Now a specific ddname can be returned and all others
       ignored.

--- a/docs/source/requirements_managed.rst
+++ b/docs/source/requirements_managed.rst
@@ -13,8 +13,8 @@ proceed to install the IBM z/OS core collection.
 
 * z/OS `V2R3`_ or `later`_
 * `z/OS OpenSSH`_
-* Supported by `IBM Open Enterprise SDK for Python`_
-  (previously `IBM Open Enterprise Python for z/OS`_) 3.8.2 or later
+* Supported by `IBM Open Enterprise SDK for Python`_ v3.8.2 -
+  Supported by `IBM Open Enterprise SDK for Python`_ v3.9.5
 * `IBM Z Open Automation Utilities`_ (ZOAU)
 
    .. note::

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -39,7 +39,6 @@ def _update_result(result, src, dest, ds_type="USS", is_binary=False):
         "VSAM": "VSAM",
         "USS": "USS",
     }
-    file_or_ds = "file" if ds_type == "USS" else "data set"
     updated_result = dict((k, v) for k, v in result.items())
     updated_result.update(
         {

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -62,9 +62,6 @@ class ActionModule(ActionBase):
                 result["failed"] = True
                 result["msg"] = to_text(u"NOT SUPPORTING THE DIRECTORY.")
                 return result
-
-            changed = False
-            module_return = dict(changed=False)
 
             if tmp is None or "-tmp-" not in tmp:
                 tmp = self._make_tmp_path()

--- a/plugins/connection/zos_ssh.py
+++ b/plugins/connection/zos_ssh.py
@@ -278,7 +278,6 @@ import fcntl
 import hashlib
 import os
 import pty
-import re
 import subprocess
 import time
 from functools import wraps
@@ -289,13 +288,11 @@ from ansible.errors import (
     AnsibleError,
     AnsibleFileNotFound,
 )
-from ansible.errors import AnsibleOptionsError
 from ansible.compat import selectors
 from ansible.module_utils.six import PY3, text_type, binary_type
 from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.module_utils.parsing.convert_bool import BOOLEANS, boolean
-from ansible.plugins.connection import ConnectionBase, BUFSIZE
+from ansible.plugins.connection import ConnectionBase
 from ansible.plugins.shell.powershell import _parse_clixml
 from ansible.utils.display import Display
 from ansible.utils.path import unfrackpath, makedirs_safe

--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -22,7 +22,6 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module im
 
 import time
 from shutil import copy2, copytree, rmtree
-from stat import S_IREAD, S_IWRITE, ST_MODE
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
     MissingZOAUImport,
 )

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -12,14 +12,6 @@
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.dd_statement import (
-    DDStatement,
-    DatasetDefinition,
-    FileDefinition,
-    StdinDefinition,
-    DummyDefinition,
-)
 
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -282,29 +282,19 @@ backup_name:
 
 import re
 import json
-from ansible.module_utils.six import b
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes
 from ansible.module_utils.six import PY3
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     better_arg_parser, data_set, backup as Backup)
-from os import path
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
     MissingZOAUImport,
 )
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
-    BetterArgParser,
-)
+
 
 try:
     from zoautil_py import zsystem
 except Exception:
     Datasets = MissingZOAUImport()
-
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
 
 # supported data set types
 DS_TYPE = ['PS', 'PO']
@@ -420,8 +410,6 @@ def main():
             ['batch', 'operation'],
         ],
     )
-
-    params = module.params
 
     arg_defs = dict(
         library=dict(arg_type='str', required=False, aliases=['lib', 'name']),

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -283,7 +283,6 @@ backup_name:
 import re
 import json
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import PY3
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     better_arg_parser, data_set, backup as Backup)
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -253,7 +253,6 @@ backup_name:
 
 import json
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import PY3
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     better_arg_parser, data_set, backup as Backup)
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -252,29 +252,18 @@ backup_name:
 """
 
 import json
-from ansible.module_utils.six import b
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_bytes
 from ansible.module_utils.six import PY3
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     better_arg_parser, data_set, backup as Backup)
-from os import path
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
     MissingZOAUImport,
-)
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
-    BetterArgParser,
 )
 
 try:
     from zoautil_py import datasets
 except Exception:
     Datasets = MissingZOAUImport()
-
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
 
 # supported data set types
 DS_TYPE = ['PS', 'PO']
@@ -384,8 +373,6 @@ def main():
         ),
         mutually_exclusive=[['insertbefore', 'insertafter']],
     )
-
-    params = module.params
 
     arg_defs = dict(
         src=dict(arg_type='data_set_or_path', aliases=['path', 'destfile', 'name'], required=True),

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1572,7 +1572,7 @@ def get_file_checksum(src):
             while block:
                 hash_digest.update(block)
                 block = infile.read(blksize)
-    except Exception as err:
+    except Exception:
         raise
     return hash_digest.hexdigest()
 

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -263,7 +263,6 @@ import os
 
 from math import ceil
 from shutil import rmtree
-from ansible.module_utils.six import PY3
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.parsing.convert_bool import boolean

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -257,14 +257,12 @@ rc:
 """
 
 
-import base64
-import hashlib
 import tempfile
 import re
 import os
 
 from math import ceil
-from shutil import rmtree, move
+from shutil import rmtree
 from ansible.module_utils.six import PY3
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
@@ -278,11 +276,6 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler im
     MissingZOAUImport,
 )
 
-
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
 
 try:
     from zoautil_py import datasets, mvscmd, types

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -333,7 +333,6 @@ changed:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import job_output
-from tempfile import NamedTemporaryFile
 
 
 def run_module():

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -491,7 +491,7 @@ EXAMPLES = r"""
 
 from ansible.module_utils.basic import AnsibleModule
 from time import sleep
-from os import chmod, path, remove, stat
+from os import chmod, path, remove
 from tempfile import NamedTemporaryFile
 import re
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import job_output

--- a/plugins/modules/zos_lineinfile.py
+++ b/plugins/modules/zos_lineinfile.py
@@ -244,17 +244,12 @@ backup_name:
     type: str
     sample: /path/to/file.txt.2015-02-03@04:15~
 """
-import re
 import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     better_arg_parser, data_set, backup as Backup)
-from os import path
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
     MissingZOAUImport,
-)
-from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
-    BetterArgParser,
 )
 
 

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -147,11 +147,6 @@ from os import chmod
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
     BetterArgParser,
 )
-
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
 
 
 def run_module():

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -139,7 +139,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
     AnsibleModuleHelper,
 )
-from ansible.module_utils.six import PY3
 from tempfile import NamedTemporaryFile
 from stat import S_IEXEC, S_IREAD, S_IWRITE
 from os import chmod

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -94,7 +94,6 @@ EXAMPLES = r"""
 from ansible.module_utils.basic import AnsibleModule
 from os import chmod
 from tempfile import NamedTemporaryFile
-import json
 from stat import S_IEXEC, S_IREAD, S_IWRITE
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
     BetterArgParser,

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -606,7 +606,6 @@ if __name__ == "__main__":
     # TODO: add logic to only grab necessary tests that are impacted by changes
     args = parse_arguments()
 
-    global collection_to_use
     collection_to_use = args.collection
 
     artifacts = build_artifacts_from_collection(args.path)


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

Version 1.3.6
=============

What's New
----------

* Bug Fixes

  * Modules

    * ``zos_copy`` fixes a bug that when a directory is copied from the
      controller to the managed node and a mode is set, the mode is now applied
      to the directory on the controller. If the directory being copied contains
      files and mode is set, mode will only be applied to the files being copied
      not the pre-existing files.
    * ``zos_copy`` - fixes a bug where options were not defined in the module
      argument spec that will result in error when running `ansible-core` v2.11
      and using options `force` or `mode`.
    * ``zos_copy`` - was enhanced for when `src` is a directory and ends with "/",
      the contents of it will be copied into the root of `dest`. It it doesn't
      end with "/", the directory itself will be copied.
    * ``zos_fetch`` - fixes a bug where an option was not defined in the module
      argument spec that will result in error when running `ansible-core` v2.11
      and using option `encoding`.
    * ``zos_job_submit`` - fixes a bug where an option was not defined in the
      module argument spec that will result in error when running
      `ansible-core` v2.11 and using option `encoding`.
    * ``jobs.py`` - fixes a utility used by module `zos_job_output` that would
      truncate the DD content.
    * ``zos_ssh`` connection plugin was updated to correct a bug that causes
      an `ANSIBLE_SSH_CONTROL_PATH_DIR` attribute error only when using
      ansible-core v2.11.

Availability
------------

* `Automation Hub`
* `Galaxy`
* `GitHub`

Reference
---------

* Supported by `z/OS V2R3`_ or later
* Supported by the `z/OS® shell`
* Supported by `IBM Open Enterprise SDK for Python` v3.8.2 -
  `IBM Open Enterprise SDK for Python` v3.9.5
* Supported by IBM `Z Open Automation Utilities 1.1.0` and
  `Z Open Automation Utilities 1.1.1`

