### PR TITLE
Bugfix/412/Fixed module documentation issues

### DIFF
--- a/docs/source/modules/zos_backup_restore.rst
+++ b/docs/source/modules/zos_backup_restore.rst
@@ -42,7 +42,7 @@ operation
 data_sets
   Determines which data sets to include in the backup.
 
-  | **required**: True
+  | **required**: False
   | **type**: dict
 
 
@@ -59,7 +59,7 @@ data_sets
 
     A question mark ``?`` or percent sign ``%`` matches a single character.
 
-    | **required**: True
+    | **required**: False
     | **type**: raw
 
 

--- a/docs/source/modules/zos_copy.rst
+++ b/docs/source/modules/zos_copy.rst
@@ -258,7 +258,7 @@ dest_data_set
     The unit of space used is set using *space_type*.
 
     | **required**: False
-    | **type**: str
+    | **type**: int
 
 
   space_secondary
@@ -267,7 +267,7 @@ dest_data_set
     The unit of space used is set using *space_type*.
 
     | **required**: False
-    | **type**: str
+    | **type**: int
 
 
   space_type

--- a/docs/source/modules/zos_fetch.rst
+++ b/docs/source/modules/zos_fetch.rst
@@ -53,7 +53,7 @@ fail_on_missing
 
   | **required**: False
   | **type**: bool
-  | **default**: true
+  | **default**: True
 
 
 validate_checksum
@@ -61,7 +61,7 @@ validate_checksum
 
   | **required**: False
   | **type**: bool
-  | **default**: true
+  | **default**: True
 
 
 flat
@@ -69,7 +69,7 @@ flat
 
   | **required**: False
   | **type**: bool
-  | **default**: true
+  | **default**: True
 
 
 is_binary
@@ -77,7 +77,6 @@ is_binary
 
   | **required**: False
   | **type**: bool
-  | **default**: false
 
 
 use_qualifier
@@ -85,7 +84,6 @@ use_qualifier
 
   | **required**: False
   | **type**: bool
-  | **default**: false
 
 
 sftp_port

--- a/docs/source/modules/zos_find.rst
+++ b/docs/source/modules/zos_find.rst
@@ -70,6 +70,7 @@ excludes
 
   | **required**: False
   | **type**: list
+  | **elements**: str
 
 
 patterns
@@ -85,6 +86,7 @@ patterns
 
   | **required**: True
   | **type**: list
+  | **elements**: str
 
 
 size
@@ -109,6 +111,7 @@ pds_patterns
 
   | **required**: False
   | **type**: list
+  | **elements**: str
 
 
 resource_type
@@ -129,6 +132,7 @@ volume
 
   | **required**: False
   | **type**: list
+  | **elements**: str
 
 
 

--- a/docs/source/modules/zos_job_output.rst
+++ b/docs/source/modules/zos_job_output.rst
@@ -310,7 +310,8 @@ jobs
     content
       The ddname content.
 
-      | **type**: list[str]
+      | **type**: list
+      | **elements**: str
       | **sample**:
 
         .. code-block:: json

--- a/docs/source/modules/zos_job_submit.rst
+++ b/docs/source/modules/zos_job_submit.rst
@@ -51,7 +51,7 @@ location
 
   LOCAL means locally to the ansible control node.
 
-  | **required**: True
+  | **required**: False
   | **type**: str
   | **default**: DATA_SET
   | **choices**: DATA_SET, USS, LOCAL
@@ -489,7 +489,8 @@ jobs
     content
       The ddname content.
 
-      | **type**: list[str]
+      | **type**: list
+      | **elements**: str
       | **sample**:
 
         .. code-block:: json

--- a/docs/source/modules/zos_mount.rst
+++ b/docs/source/modules/zos_mount.rst
@@ -137,6 +137,7 @@ persistent
 
     | **required**: False
     | **type**: list
+    | **elements**: str
 
 
 

--- a/docs/source/modules/zos_mvs_raw.rst
+++ b/docs/source/modules/zos_mvs_raw.rst
@@ -103,7 +103,7 @@ dds
     data_set_name
       The data set name.
 
-      | **required**: True
+      | **required**: False
       | **type**: str
 
 
@@ -657,7 +657,7 @@ dds
 
       If a list of strings is provided, newlines will be added to each of the lines when used as input.
 
-      | **required**: False
+      | **required**: True
       | **type**: raw
 
 
@@ -831,7 +831,7 @@ dds
         data_set_name
           The data set name.
 
-          | **required**: True
+          | **required**: False
           | **type**: str
 
 
@@ -1371,7 +1371,7 @@ dds
 
           If a list of strings is provided, newlines will be added to each of the lines when used as input.
 
-          | **required**: False
+          | **required**: True
           | **type**: raw
 
 

--- a/plugins/modules/zos_backup_restore.py
+++ b/plugins/modules/zos_backup_restore.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_backup_restore.py
+++ b/plugins/modules/zos_backup_restore.py
@@ -43,7 +43,7 @@ options:
   data_sets:
     description:
       - Determines which data sets to include in the backup.
-    required: True
+    required: False
     type: dict
     suboptions:
       include:
@@ -62,7 +62,7 @@ options:
             If there are two asterisks in a qualifier, they must be the first and last characters.
           - A question mark C(?) or percent sign C(%) matches a single character.
         type: raw
-        required: True
+        required: False
       exclude:
         description:
           - When I(operation=backup), specifies a list of data sets or data set patterns

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -275,14 +275,14 @@ options:
           - If the destination I(dest) data set does not exist , this sets the
             primary space allocated for the data set.
           - The unit of space used is set using I(space_type).
-        type: str
+        type: int
         required: false
       space_secondary:
         description:
           - If the destination I(dest) data set does not exist , this sets the
             secondary space allocated for the data set.
           - The unit of space used is set using I(space_type).
-        type: str
+        type: int
         required: false
       space_type:
         description:
@@ -2309,7 +2309,20 @@ def main():
             src=dict(type='path'),
             dest=dict(required=True, type='str'),
             is_binary=dict(type='bool', default=False),
-            encoding=dict(type='dict'),
+            encoding=dict(
+                type='dict',
+                required=False,
+                options={
+                    'from': dict(
+                        type='str',
+                        required=True,
+                    ),
+                    "to": dict(
+                        type='str',
+                        required=True,
+                    )
+                }
+            ),
             content=dict(type='str', no_log=True),
             backup=dict(type='bool', default=False),
             backup_name=dict(type='str'),
@@ -2346,8 +2359,8 @@ def main():
                     record_length=dict(type='int', required=False),
                     block_size=dict(type='int', required=False),
                     directory_blocks=dict(type="int", required=False),
-                    key_offset=dict(type="int", required=False),
-                    key_length=dict(type="int", required=False),
+                    key_offset=dict(type="int", required=False, no_log=False),
+                    key_length=dict(type="int", required=False, no_log=False),
                     sms_storage_class=dict(type="str", required=False),
                     sms_data_class=dict(type="str", required=False),
                     sms_management_class=dict(type="str", required=False),
@@ -2362,7 +2375,8 @@ def main():
             copy_member=dict(type='bool'),
             src_member=dict(type='bool'),
             local_charset=dict(type='str'),
-            force=dict(type='bool', default=False)
+            force=dict(type='bool', default=False),
+            mode=dict(type='str', required=False),
         ),
         add_file_common_args=True,
     )
@@ -2434,17 +2448,6 @@ def main():
                 to_encoding=dict(arg_type="encoding"),
             )
         )
-
-    if not module.params.get("destination_dataset"):
-        module.params["destination_dataset"] = {
-            "dd_type": "BASIC",
-            "space_primary": 5,
-            "space_secondary": 3,
-            "space_type": 'TRK',
-            "record_format": 'FB',
-            "record_length": 80,
-            "block_size": 6147,
-        }
 
     res_args = temp_path = conv_path = None
     try:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020, 2021
+# Copyright (c) IBM Corporation 2019, 2020, 2021, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -23,7 +23,7 @@ short_description: Manage data sets
 description:
   - Create, delete and set attributes of data sets.
   - When forcing data set replacement, contents will not be preserved.
-version_added: "2.9"
+version_added: "1.0.0"
 author: "Blake Becker (@blakeinate)"
 options:
   name:
@@ -34,7 +34,6 @@ options:
       - Required if I(type=MEMBER) or I(state!=present) and not using I(batch).
     type: str
     required: false
-    version_added: "2.9"
   state:
     description:
       - The final state desired for specified data set.
@@ -89,7 +88,6 @@ options:
       - absent
       - cataloged
       - uncataloged
-    version_added: "2.9"
   type:
     description:
       - The data set type to be used when creating a data set. (e.g C(pdse))
@@ -112,7 +110,6 @@ options:
       - HFS
       - ZFS
     default: PDS
-    version_added: "2.9"
   space_primary:
     description:
       - The amount of primary space to allocate for the dataset.
@@ -120,7 +117,6 @@ options:
     type: int
     required: false
     default: 5
-    version_added: "2.9"
   space_secondary:
     description:
       - The amount of secondary space to allocate for the dataset.
@@ -128,7 +124,6 @@ options:
     type: int
     required: false
     default: 3
-    version_added: "2.9"
   space_type:
     description:
       - The unit of measurement to use when defining primary and secondary space.
@@ -142,7 +137,6 @@ options:
       - TRK
     required: false
     default: M
-    version_added: "2.9"
   record_format:
     description:
       - The format of the data set. (e.g C(FB))
@@ -156,7 +150,6 @@ options:
       - U
     default: FB
     type: str
-    version_added: "2.9"
   sms_storage_class:
     description:
       - The storage class for an SMS-managed dataset.
@@ -165,7 +158,6 @@ options:
       - Note that all non-linear VSAM datasets are SMS-managed.
     type: str
     required: false
-    version_added: "2.9"
   sms_data_class:
     description:
       - The data class for an SMS-managed dataset.
@@ -174,7 +166,6 @@ options:
       - Note that all non-linear VSAM datasets are SMS-managed.
     type: str
     required: false
-    version_added: "2.9"
   sms_management_class:
     description:
       - The management class for an SMS-managed dataset.
@@ -183,7 +174,6 @@ options:
       - Note that all non-linear VSAM datasets are SMS-managed.
     type: str
     required: false
-    version_added: "2.9"
   record_length:
     description:
       - The length, in bytes, of each record in the data set.
@@ -191,19 +181,16 @@ options:
       - "Defaults vary depending on format: If FB/FBA 80, if VB/VBA 137, if U 0."
     type: int
     required: false
-    version_added: "2.9"
   block_size:
     description:
       - The block size to use for the data set.
     type: int
     required: false
-    version_added: "2.9"
   directory_blocks:
     description:
       - The number of directory blocks to allocate to the data set.
     type: int
     required: false
-    version_added: "2.9"
   key_offset:
     description:
       - The key offset to use when creating a KSDS data set.
@@ -211,7 +198,6 @@ options:
       - I(key_offset) should only be provided when I(type=KSDS)
     type: int
     required: false
-    version_added: "2.9"
   key_length:
     description:
       - The key length to use when creating a KSDS data set.
@@ -219,7 +205,6 @@ options:
       - I(key_length) should only be provided when I(type=KSDS)
     type: int
     required: false
-    version_added: "2.9"
   volumes:
     description:
       - >
@@ -238,7 +223,6 @@ options:
       - Accepts a string when using a single volume and a list of strings when using multiple.
     type: raw
     required: false
-    version_added: "2.9"
     aliases:
       - volume
   replace:
@@ -252,14 +236,12 @@ options:
     type: bool
     required: false
     default: false
-    version_added: "2.9"
   batch:
     description:
       - Batch can be used to perform operations on multiple data sets in a single module call.
     type: list
     elements: dict
     required: false
-    version_added: "2.9"
     suboptions:
       name:
         description:
@@ -269,7 +251,6 @@ options:
           - Required if I(type=MEMBER) or I(state!=present)
         type: str
         required: false
-        version_added: "2.9"
       state:
         description:
           - The final state desired for specified data set.
@@ -324,7 +305,6 @@ options:
           - absent
           - cataloged
           - uncataloged
-        version_added: "2.9"
       type:
         description:
           - The data set type to be used when creating a data set. (e.g C(pdse))
@@ -347,7 +327,6 @@ options:
           - HFS
           - ZFS
         default: PDS
-        version_added: "2.9"
       space_primary:
         description:
           - The amount of primary space to allocate for the dataset.
@@ -355,7 +334,6 @@ options:
         type: int
         required: false
         default: 5
-        version_added: "2.9"
       space_secondary:
         description:
           - The amount of secondary space to allocate for the dataset.
@@ -363,7 +341,6 @@ options:
         type: int
         required: false
         default: 3
-        version_added: "2.9"
       space_type:
         description:
           - The unit of measurement to use when defining primary and secondary space.
@@ -377,7 +354,6 @@ options:
           - TRK
         required: false
         default: M
-        version_added: "2.9"
       record_format:
         description:
           - The format of the data set. (e.g C(FB))
@@ -391,7 +367,6 @@ options:
           - U
         default: FB
         type: str
-        version_added: "2.9"
       sms_storage_class:
         description:
           - The storage class for an SMS-managed dataset.
@@ -400,7 +375,6 @@ options:
           - Note that all non-linear VSAM datasets are SMS-managed.
         type: str
         required: false
-        version_added: "2.9"
       sms_data_class:
         description:
           - The data class for an SMS-managed dataset.
@@ -409,7 +383,6 @@ options:
           - Note that all non-linear VSAM datasets are SMS-managed.
         type: str
         required: false
-        version_added: "2.9"
       sms_management_class:
         description:
           - The management class for an SMS-managed dataset.
@@ -418,7 +391,6 @@ options:
           - Note that all non-linear VSAM datasets are SMS-managed.
         type: str
         required: false
-        version_added: "2.9"
       record_length:
         description:
           - The length, in bytes, of each record in the data set.
@@ -426,19 +398,16 @@ options:
           - "Defaults vary depending on format: If FB/FBA 80, if VB/VBA 137, if U 0."
         type: int
         required: false
-        version_added: "2.9"
       block_size:
         description:
           - The block size to use for the data set.
         type: int
         required: false
-        version_added: "2.9"
       directory_blocks:
         description:
           - The number of directory blocks to allocate to the data set.
         type: int
         required: false
-        version_added: "2.9"
       key_offset:
         description:
           - The key offset to use when creating a KSDS data set.
@@ -446,7 +415,6 @@ options:
           - I(key_offset) should only be provided when I(type=KSDS)
         type: int
         required: false
-        version_added: "2.9"
       key_length:
         description:
           - The key length to use when creating a KSDS data set.
@@ -454,7 +422,6 @@ options:
           - I(key_length) should only be provided when I(type=KSDS)
         type: int
         required: false
-        version_added: "2.9"
       volumes:
         description:
           - >
@@ -473,7 +440,6 @@ options:
           - Accepts a string when using a single volume and a list of strings when using multiple.
         type: raw
         required: false
-        version_added: "2.9"
         aliases:
           - volume
       replace:
@@ -487,7 +453,6 @@ options:
         type: bool
         required: false
         default: false
-        version_added: "2.9"
 
 """
 EXAMPLES = r"""
@@ -1160,8 +1125,8 @@ def run_module():
                     type="int",
                     required=False,
                 ),
-                key_offset=dict(type="int", required=False),
-                key_length=dict(type="int", required=False),
+                key_offset=dict(type="int", required=False, no_log=False),
+                key_length=dict(type="int", required=False, no_log=False),
                 replace=dict(
                     type="bool",
                     default=False,
@@ -1203,8 +1168,8 @@ def run_module():
             type="int",
             required=False,
         ),
-        key_offset=dict(type="int", required=False),
-        key_length=dict(type="int", required=False),
+        key_offset=dict(type="int", required=False, no_log=False),
+        key_length=dict(type="int", required=False, no_log=False),
         replace=dict(
             type="bool",
             default=False,

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -55,14 +55,14 @@ options:
     description:
       - When set to true, the task will fail if the source file is missing.
     required: false
-    default: "true"
+    default: true
     type: bool
   validate_checksum:
     description:
       - Verify that the source and destination checksums match after the files
         are fetched.
     required: false
-    default: "true"
+    default: true
     type: bool
   flat:
     description:
@@ -71,20 +71,20 @@ options:
         the destination directory without appending remote hostname to the
         destination.
     required: false
-    default: "true"
+    default: true
     type: bool
   is_binary:
     description:
       - Specifies if the file being fetched is a binary.
     required: false
-    default: "false"
+    default: false
     type: bool
   use_qualifier:
     description:
       - Indicates whether the data set high level qualifier should be used when
         fetching.
     required: false
-    default: "false"
+    default: false
     type: bool
   sftp_port:
     description:
@@ -562,7 +562,14 @@ def run_module():
             is_binary=dict(required=False, default=False, type="bool"),
             use_qualifier=dict(required=False, default=False, type="bool"),
             validate_checksum=dict(required=False, default=True, type="bool"),
-            encoding=dict(required=False, type="dict"),
+            encoding=dict(
+                required=False,
+                type="dict",
+                options={
+                    "from": dict(type="str", required=True),
+                    "to": dict(type="str", required=True)
+                }
+            ),
             sftp_port=dict(type="int", required=False),
             ignore_sftp_stderr=dict(type="bool", default=False, required=False),
             local_charset=dict(type="str"),

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020, 2021, 2021
+# Copyright (c) IBM Corporation 2019, 2020, 2021, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -20,7 +20,7 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: zos_find
-version_added: "2.9"
+version_added: "1.3.0"
 short_description: Find matching data sets
 description:
   - Return a list of data sets based on specific criteria.
@@ -68,6 +68,7 @@ options:
     aliases:
       - exclude
     type: list
+    elements: str
     required: false
   patterns:
     description:
@@ -79,6 +80,7 @@ options:
       - If C(pds_patterns) is provided, C(patterns) must be member patterns.
       - When searching for members within a PDS/PDSE, pattern can be a regular expression.
     type: list
+    elements: str
     required: true
   size:
     description:
@@ -98,6 +100,7 @@ options:
       - pds_paths
       - pds_pattern
     type: list
+    elements: str
     required: false
   resource_type:
     description:
@@ -118,6 +121,7 @@ options:
       - If provided, only the data sets allocated in the specified list of
         volumes will be searched.
     type: list
+    elements: str
     required: false
     aliases:
       - volumes
@@ -821,11 +825,21 @@ def main():
                 default="creation_date"
             ),
             contains=dict(type="str", required=False),
-            excludes=dict(type="list", required=False, aliases=["exclude"]),
-            patterns=dict(type="list", required=True),
+            excludes=dict(
+                type="list",
+                elements="str",
+                required=False,
+                aliases=["exclude"]
+            ),
+            patterns=dict(
+                type="list",
+                elements="str",
+                required=True
+            ),
             size=dict(type="str", required=False),
             pds_patterns=dict(
                 type="list",
+                elements="str",
                 required=False,
                 aliases=["pds_pattern", "pds_paths"]
             ),
@@ -833,7 +847,12 @@ def main():
                 type="str", required=False, default="nonvsam",
                 choices=["cluster", "data", "index", "nonvsam"]
             ),
-            volume=dict(type="list", required=False, aliases=["volumes"])
+            volume=dict(
+                type="list",
+                elements="str",
+                required=False,
+                aliases=["volumes"]
+            )
         )
     )
 

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -33,7 +33,7 @@ description:
     like "*".
   - If there is no ddname, or if ddname="?", output of all the ddnames under
     the given job will be displayed.
-version_added: "2.9"
+version_added: "1.0.0"
 author:
   - "Jack Ho (@jacklotusho)"
   - "Demetrios Dimatos (@ddimatos)"
@@ -154,7 +154,8 @@ jobs:
         content:
           description:
              The ddname content.
-          type: list[str]
+          type: list
+          elements: str
           sample:
              [ "         1 //HELLO    JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,       JOB00134",
                "           //             MSGCLASS=X,MSGLEVEL=1,NOTIFY=S0JM                                ",

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -26,7 +26,7 @@ description:
     - Submit a job and optionally monitor for its execution.
     - Optionally wait for the job output until the job finishes.
     - For the uncataloged dataset, specify the volume serial number.
-version_added: "2.9"
+version_added: "1.0.0"
 options:
   src:
     required: true
@@ -39,7 +39,7 @@ options:
       - Or an LOCAL file in ansible control node.
         (e.g "/User/tester/ansible-playbook/sample.jcl")
   location:
-    required: true
+    required: false
     default: DATA_SET
     type: str
     choices:
@@ -186,7 +186,8 @@ jobs:
         content:
           description:
              The ddname content.
-          type: list[str]
+          type: list
+          elements: str
           sample:
              [ "         1 //HELLO    JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,       JOB00134",
                "           //             MSGCLASS=X,MSGLEVEL=1,NOTIFY=S0JM                                ",
@@ -658,13 +659,28 @@ def assert_valid_return_code(max_rc, found_rc):
 def run_module():
     module_args = dict(
         src=dict(type="str", required=True),
-        wait=dict(type="bool", required=False),
+        wait=dict(type="bool", required=False, default=False),
         location=dict(
             type="str",
             default="DATA_SET",
             choices=["DATA_SET", "USS", "LOCAL"],
         ),
-        encoding=dict(type="dict", required=False),
+        encoding=dict(
+            type="dict",
+            required=False,
+            options={
+                "from": dict(
+                    type="str",
+                    required=False,
+                    default="ISO8859-1"
+                ),
+                "to": dict(
+                    type="str",
+                    required=False,
+                    default="IBM-1047"
+                )
+            }
+        ),
         volume=dict(type="str", required=False),
         return_output=dict(type="bool", required=False, default=True),
         wait_time_s=dict(type="int", default=60),

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_mount.py
+++ b/plugins/modules/zos_mount.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020, 2021
+# Copyright (c) IBM Corporation 2020, 2021, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_mount.py
+++ b/plugins/modules/zos_mount.py
@@ -157,6 +157,7 @@ options:
                     - Comments are used to encapsulate the I(persistent/data_store) entry
                       such that they can easily be understood and located.
                 type: list
+                elements: str
                 required: False
     unmount_opts:
         description:
@@ -215,6 +216,7 @@ options:
             - TEXT
             - NOTEXT
         required: False
+        default: ''
     tag_ccsid:
         description:
             - Identifies the coded character set identifier (ccsid) to be
@@ -1079,7 +1081,7 @@ def main():
                     ),
                     backup=dict(type="bool", default=False),
                     backup_name=dict(type="str", required=False, default=None),
-                    comment=dict(type="list", required=False),
+                    comment=dict(type="list", elements="str", required=False),
                 ),
             ),
             unmount_opts=dict(

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -27,7 +27,7 @@ description:
   - Run a z/OS program.
   - This is analogous to a job step in JCL.
   - Defaults will be determined by underlying API if value not provided.
-version_added: "2.9"
+version_added: "1.2.0"
 options:
   program_name:
     description:
@@ -89,7 +89,7 @@ options:
             description:
               - The data set name.
             type: str
-            required: true
+            required: false
           type:
             description:
               - The data set type. Only required when I(disposition=new).
@@ -558,7 +558,7 @@ options:
                 or a list of strings with 1 line per list item.
               - If a list of strings is provided, newlines will be
                 added to each of the lines when used as input.
-            required: false
+            required: true
             type: raw
           return_content:
             description:
@@ -693,7 +693,7 @@ options:
                     description:
                       - The data set name.
                     type: str
-                    required: true
+                    required: false
                   type:
                     description:
                       - The data set type. Only required when I(disposition=new).
@@ -1155,7 +1155,7 @@ options:
                         or a list of strings with 1 line per list item.
                       - If a list of strings is provided, newlines will be
                         added to each of the lines when used as input.
-                    required: false
+                    required: true
                     type: raw
                   return_content:
                     description:
@@ -1560,7 +1560,7 @@ def run_module():
         sms_data_class=dict(type="str"),
         block_size=dict(type="int"),
         directory_blocks=dict(type="int"),
-        key_label=dict(type="str"),
+        key_label=dict(type="str", no_log=True),
         type=dict(
             type="str",
             choices=[
@@ -1578,6 +1578,7 @@ def run_module():
         ),
         encryption_key_1=dict(
             type="dict",
+            no_log=True,
             options=dict(
                 label=dict(type="str", required=True),
                 encoding=dict(type="str", required=True, choices=["l", "h"]),
@@ -1585,13 +1586,14 @@ def run_module():
         ),
         encryption_key_2=dict(
             type="dict",
+            no_log=True,
             options=dict(
                 label=dict(type="str", required=True),
                 encoding=dict(type="str", required=True, choices=["l", "h"]),
             ),
         ),
-        key_length=dict(type="int"),
-        key_offset=dict(type="int"),
+        key_length=dict(type="int", no_log=False),
+        key_offset=dict(type="int", no_log=False),
         record_length=dict(type="int"),
         record_format=dict(type="str", choices=["u", "vb", "vba", "fb", "fba"]),
         return_content=dict(

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_ping.py
+++ b/plugins/modules/zos_ping.py
@@ -15,7 +15,7 @@
 DOCUMENTATION = r"""
 ---
 module: zos_ping
-version_added: 2.9
+version_added: 1.1.0
 short_description: Ping z/OS and check dependencies.
 description:
   - M(zos_ping) verifies the presence of z/OS Web Client Enablement Toolkit,

--- a/plugins/modules/zos_ping.py
+++ b/plugins/modules/zos_ping.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2022
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
##### SUMMARY

Fixes #412. Besides adding the `mode` parameter to the `arg_spec` of zos_copy (`force` was already present in this version), it fixes some documentation issues found on other modules.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- zos_backup_restore
- zos_copy
- zos_data_set
- zos_find
- zos_job_output
- zos_job_submit
- zos_mount
- zos_mvs_raw
- zos_ping

##### ADDITIONAL INFORMATION

Most documentation issues were raised by the `validate-modules` test in Ansible:

- Fixed inconsistencies between `required` values found in the module documentation and `arg_spec`
- Fixed inconsistencies between `default` values found in the module documentation and `arg_spec`
- Added `encoding` suboptions in `arg_spec` in modules that have it
- Fixed inconsistencies in `type` values
- Added `no_log=False` to options that get flagged by sanity tests but don't include sensitive information
