### PR TITLE
Release v1.4.0 beta.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,39 @@ bm.ibm_zos_core Release Notes
 .. contents:: Topics
 
 
+v1.4.0-beta.2
+=============
+
+Release Summary
+---------------
+
+Release Date: '2022-10-17'
+This changelog describes all changes made to the modules and plugins included
+in this collection. The release date is the date the changelog is created.
+For additional details such as required dependencies and availability review
+the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__
+
+
+Minor Changes
+-------------
+
+- zos_copy - enhanced the force option when `force=true` and the remote file or data set `dest` is NOT empty, the `dest` will be deleted and recreated with the `src` data set attributes, otherwise it will be recreated with the `dest` data set attributes. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+- zos_copy - fixes a bug that when a directory is copied from the controller to the managed node and a mode is set, the mode is applied to the directory on the managed node. If the directory being copied contains files and mode is set, mode will only be applied to the files being copied not the pre-existing files. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+- zos_copy - fixes a bug where options were not defined in the module argument spec that will result in error when running `ansible-core` v2.11 and using options `force` or `mode`. (https://github.com/ansible-collections/ibm_zos_core/pull/496)
+- zos_copy - introduced an updated creation policy referred to as precedence rules such that if `dest_data_set` is set, this will take precedence. If `dest` is an empty data set, the empty data set will be written with the expectation its attributes satisfy the copy. If no precedent rule has been exercised, `dest` will be created with the same attributes of `src`. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+- zos_copy - introduced new computation capabilities such that if `dest` is a nonexistent data set, the attributes assigned will depend on the type of `src`. If `src` is a USS file, `dest` will have a Fixed Block (FB) record format and the remaining attributes will be computed. If `src` is binary, `dest` will have a Fixed Block (FB) record format with a record length of 80, block size of 32760, and the remaining attributes will be computed. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+- zos_copy - option `dest_dataset` has been deprecated and removed in favor of the new option `dest_data_set`. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+- zos_copy - was enhanced for when `src` is a directory and ends with "/", the contents of it will be copied into the root of `dest`. It it doesn't end with "/", the directory itself will be copied. (https://github.com/ansible-collections/ibm_zos_core/pull/496)
+
+Bugfixes
+--------
+
+- zos_copy - fixes a bug that did not create a data set on the specified volume. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+- zos_copy - fixes a bug where a number of attributes were not an option when using `dest_data_set`. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+- zos_job_output - fixes a bug that returned all ddname's when a specific ddname was provided. Now a specific ddname can be returned and all others ignored. (https://github.com/ansible-collections/ibm_zos_core/pull/507)
+- zos_mount - fixed option `tag_ccsid` to correctly allow for type int. (https://github.com/ansible-collections/ibm_zos_core/pull/502)
+- zos_operator - enhanced to allow for MVS operator `SET` command, `SET` is equivalent to the abbreviated `T` command. (https://github.com/ansible-collections/ibm_zos_core/pull/501)
+
 v1.4.0-beta.1
 =============
 
@@ -12,7 +45,7 @@ Release Summary
 ---------------
 
 Release Date: '2021-06-23'
-This changelog describes all changes made to the modules and plugins included
+This changlelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
@@ -87,14 +120,14 @@ Bugfixes
 - zos_ssh - fixes connection plugin which will error when using `ansible-core` 2.11 with an `AttributeError module 'ansible.constants' has no attribute 'ANSIBLE_SSH_CONTROL_PATH_DIR'`. (https://github.com/ansible-collections/ibm_zos_core/pull/462)
 - zos_ssh - fixes connection plugin which will error when using `ansible-core` 2.11 with an `AttributeError module 'ansible.constants' has no attribute 'ANSIBLE_SSH_CONTROL_PATH_DIR'`. (https://github.com/ansible-collections/ibm_zos_core/pull/513)
 
-v1.3.4
+v1.3.5
 ======
 
 Release Summary
 ---------------
 
 Release Date: '2022-03-06'
-This changelog describes all changes made to the modules and plugins included
+This changlelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
@@ -119,7 +152,7 @@ Release Summary
 ---------------
 
 Release Date: '2022-26-04'
-This changelog describes all changes made to the modules and plugins included
+This changlelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
@@ -138,7 +171,7 @@ Release Summary
 ---------------
 
 Release Date: '2022-27-04'
-This changelog describes all changes made to the modules and plugins included
+This changlelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
@@ -162,7 +195,7 @@ Release Summary
 ---------------
 
 Release Date: '2021-19-04'
-This changelog describes all changes made to the modules and plugins included
+This changlelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
@@ -219,7 +252,7 @@ Release Summary
 ---------------
 
 Release Date: '2020-10-09'
-This changelog describes all changes made to the modules and plugins included
+This changlelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__.
@@ -252,7 +285,7 @@ Release Summary
 ---------------
 
 Release Date: '2020-26-01'
-This changelog describes all changes made to the modules and plugins included
+This changlelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__
@@ -283,7 +316,7 @@ Release Summary
 ---------------
 
 Release Date: '2020-18-03'
-This changelog describes all changes made to the modules and plugins included
+This changlelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,7 @@ Minor Changes
 - zos_copy - introduced an updated creation policy referred to as precedence rules such that if `dest_data_set` is set, this will take precedence. If `dest` is an empty data set, the empty data set will be written with the expectation its attributes satisfy the copy. If no precedent rule has been exercised, `dest` will be created with the same attributes of `src`. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
 - zos_copy - introduced new computation capabilities such that if `dest` is a nonexistent data set, the attributes assigned will depend on the type of `src`. If `src` is a USS file, `dest` will have a Fixed Block (FB) record format and the remaining attributes will be computed. If `src` is binary, `dest` will have a Fixed Block (FB) record format with a record length of 80, block size of 32760, and the remaining attributes will be computed. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
 - zos_copy - option `dest_dataset` has been deprecated and removed in favor of the new option `dest_data_set`. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
-- zos_copy - was enhanced for when `src` is a directory and ends with "/", the contents of it will be copied into the root of `dest`. It it doesn't end with "/", the directory itself will be copied. (https://github.com/ansible-collections/ibm_zos_core/pull/496)
+- zos_copy - was enhanced for when `src` is a directory and ends with "/", the contents of it will be copied into the root of `dest`. If it doesn't end with "/", the directory itself will be copied. (https://github.com/ansible-collections/ibm_zos_core/pull/496)
 
 Bugfixes
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Release Summary
 ---------------
 
 Release Date: '2021-06-23'
-This changlelog describes all changes made to the modules and plugins included
+This changelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
@@ -94,7 +94,7 @@ Release Summary
 ---------------
 
 Release Date: '2022-03-06'
-This changlelog describes all changes made to the modules and plugins included
+This changelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
@@ -119,7 +119,7 @@ Release Summary
 ---------------
 
 Release Date: '2022-26-04'
-This changlelog describes all changes made to the modules and plugins included
+This changelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
@@ -138,7 +138,7 @@ Release Summary
 ---------------
 
 Release Date: '2022-27-04'
-This changlelog describes all changes made to the modules and plugins included
+This changelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
@@ -162,7 +162,7 @@ Release Summary
 ---------------
 
 Release Date: '2021-19-04'
-This changlelog describes all changes made to the modules and plugins included
+This changelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
@@ -219,7 +219,7 @@ Release Summary
 ---------------
 
 Release Date: '2020-10-09'
-This changlelog describes all changes made to the modules and plugins included
+This changelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__.
@@ -252,7 +252,7 @@ Release Summary
 ---------------
 
 Release Date: '2020-26-01'
-This changlelog describes all changes made to the modules and plugins included
+This changelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__
@@ -283,7 +283,7 @@ Release Summary
 ---------------
 
 Release Date: '2020-18-03'
-This changlelog describes all changes made to the modules and plugins included
+This changelog describes all changes made to the modules and plugins included
 in this collection.
 For additional details such as required dependencies and availablity review
 the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -1,5 +1,4 @@
-objects:
-  role: {}
+objects: {}
 plugins:
   become: {}
   cache: {}
@@ -29,12 +28,12 @@ plugins:
       description: Copy data to z/OS
       name: zos_copy
       namespace: ''
-      version_added: 1.0.0
+      version_added: 1.2.0
     zos_data_set:
       description: Manage data sets
       name: zos_data_set
       namespace: ''
-      version_added: 1.3.0
+      version_added: 1.0.0
     zos_encode:
       description: Perform encoding operations.
       name: zos_encode
@@ -69,7 +68,7 @@ plugins:
       description: Manage textual data on z/OS
       name: zos_lineinfile
       namespace: ''
-      version_added: 1.2.1
+      version_added: 1.2.0
     zos_mount:
       description: Mount a z/OS file system.
       name: zos_mount
@@ -79,7 +78,7 @@ plugins:
       description: Run a z/OS program.
       name: zos_mvs_raw
       namespace: ''
-      version_added: 1.1.0
+      version_added: 1.2.0
     zos_operator:
       description: Execute operator command
       name: zos_operator
@@ -104,4 +103,4 @@ plugins:
   shell: {}
   strategy: {}
   vars: {}
-version: 1.4.0-beta.1
+version: 1.4.0-beta.2

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -359,4 +359,64 @@ releases:
       name: zos_mount
       namespace: ''
     release_date: '2022-06-10'
-  
+  1.4.0-beta.2:
+    changes:
+      bugfixes:
+      - zos_copy - fixes a bug that did not create a data set on the specified volume.
+        (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+      - zos_copy - fixes a bug where a number of attributes were not an option when
+        using `dest_data_set`. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+      - zos_job_output - fixes a bug that returned all ddname's when a specific ddname
+        was provided. Now a specific ddname can be returned and all others ignored.
+        (https://github.com/ansible-collections/ibm_zos_core/pull/507)
+      - zos_mount - fixed option `tag_ccsid` to correctly allow for type int. (https://github.com/ansible-collections/ibm_zos_core/pull/502)
+      - zos_operator - enhanced to allow for MVS operator `SET` command, `SET` is
+        equivalent to the abbreviated `T` command. (https://github.com/ansible-collections/ibm_zos_core/pull/501)
+      minor_changes:
+      - zos_copy - enhanced the force option when `force=true` and the remote file
+        or data set `dest` is NOT empty, the `dest` will be deleted and recreated
+        with the `src` data set attributes, otherwise it will be recreated with the
+        `dest` data set attributes. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+      - zos_copy - fixes a bug that when a directory is copied from the controller
+        to the managed node and a mode is set, the mode is applied to the directory
+        on the managed node. If the directory being copied contains files and mode
+        is set, mode will only be applied to the files being copied not the pre-existing
+        files. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+      - zos_copy - fixes a bug where options were not defined in the module argument
+        spec that will result in error when running `ansible-core` v2.11 and using
+        options `force` or `mode`. (https://github.com/ansible-collections/ibm_zos_core/pull/496)
+      - zos_copy - introduced an updated creation policy referred to as precedence
+        rules such that if `dest_data_set` is set, this will take precedence. If `dest`
+        is an empty data set, the empty data set will be written with the expectation
+        its attributes satisfy the copy. If no precedent rule has been exercised,
+        `dest` will be created with the same attributes of `src`. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+      - zos_copy - introduced new computation capabilities such that if `dest` is
+        a nonexistent data set, the attributes assigned will depend on the type of
+        `src`. If `src` is a USS file, `dest` will have a Fixed Block (FB) record
+        format and the remaining attributes will be computed. If `src` is binary,
+        `dest` will have a Fixed Block (FB) record format with a record length of
+        80, block size of 32760, and the remaining attributes will be computed. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+      - zos_copy - option `dest_dataset` has been deprecated and removed in favor
+        of the new option `dest_data_set`. (https://github.com/ansible-collections/ibm_zos_core/pull/306)
+      - zos_copy - was enhanced for when `src` is a directory and ends with "/", the
+        contents of it will be copied into the root of `dest`. It it doesn't end with
+        "/", the directory itself will be copied. (https://github.com/ansible-collections/ibm_zos_core/pull/496)
+      release_summary: 'Release Date: ''2022-10-17''
+
+        This changelog describes all changes made to the modules and plugins included
+
+        in this collection. The release date is the date the changelog is created.
+
+        For additional details such as required dependencies and availability review
+
+        the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__
+
+        '
+    fragments:
+    - 306-updates-zos-copy-architecture.yml
+    - 496-copy-support-directories.yml
+    - 501-allow-operator-set-command.yml
+    - 502-update-ccsid-type-int.yml
+    - 507-display-specific-ddname.yml
+    - v1.4.0-beta.2_summary.yml
+    release_date: '2022-10-13'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -232,7 +232,7 @@ releases:
     - v1.3.3_summary.yml
     - v1.3.3_summary_bugs.yml
     release_date: '2022-06-07'
-  1.3.4:
+  1.3.5:
     changes:
       bugfixes:
       - "zos_ssh - connection plugin was updated to correct a bug in Ansible that\n
@@ -359,3 +359,4 @@ releases:
       name: zos_mount
       namespace: ''
     release_date: '2022-06-10'
+  

--- a/changelogs/fragments/496-copy-support-directories.yml
+++ b/changelogs/fragments/496-copy-support-directories.yml
@@ -1,0 +1,9 @@
+minor_changes:
+- zos_copy - was enhanced for when `src` is a directory and ends with "/", the
+  contents of it will be copied into the root of `dest`. It it doesn't end with
+  "/", the directory itself will be copied.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/496)
+- zos_copy - fixes a bug where options were not defined in the module
+  argument spec that will result in error when running `ansible-core`
+  v2.11 and using options `force` or `mode`.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/496)

--- a/changelogs/fragments/v1.0.0_summary.yml
+++ b/changelogs/fragments/v1.0.0_summary.yml
@@ -1,6 +1,6 @@
 release_summary: |
   Release Date: '2020-18-03'
-  This changlelog describes all changes made to the modules and plugins included
+  This changelog describes all changes made to the modules and plugins included
   in this collection.
   For additional details such as required dependencies and availablity review
   the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 

--- a/changelogs/fragments/v1.1.0_summary.yml
+++ b/changelogs/fragments/v1.1.0_summary.yml
@@ -1,6 +1,6 @@
 release_summary: |
   Release Date: '2020-26-01'
-  This changlelog describes all changes made to the modules and plugins included
+  This changelog describes all changes made to the modules and plugins included
   in this collection.
   For additional details such as required dependencies and availablity review
   the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__

--- a/changelogs/fragments/v1.2.1_summary.yml
+++ b/changelogs/fragments/v1.2.1_summary.yml
@@ -1,6 +1,6 @@
 release_summary: |
   Release Date: '2020-10-09'
-  This changlelog describes all changes made to the modules and plugins included
+  This changelog describes all changes made to the modules and plugins included
   in this collection.
   For additional details such as required dependencies and availablity review
   the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__.

--- a/changelogs/fragments/v1.3.0_summary.yml
+++ b/changelogs/fragments/v1.3.0_summary.yml
@@ -1,6 +1,6 @@
 release_summary: |
   Release Date: '2021-19-04'
-  This changlelog describes all changes made to the modules and plugins included
+  This changelog describes all changes made to the modules and plugins included
   in this collection.
   For additional details such as required dependencies and availablity review
   the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 

--- a/changelogs/fragments/v1.3.1_summary.yml
+++ b/changelogs/fragments/v1.3.1_summary.yml
@@ -1,6 +1,6 @@
 release_summary: |
   Release Date: '2022-27-04'
-  This changlelog describes all changes made to the modules and plugins included
+  This changelog describes all changes made to the modules and plugins included
   in this collection.
   For additional details such as required dependencies and availablity review
   the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 

--- a/changelogs/fragments/v1.3.3_summary.yml
+++ b/changelogs/fragments/v1.3.3_summary.yml
@@ -1,6 +1,6 @@
 release_summary: |
   Release Date: '2022-26-04'
-  This changlelog describes all changes made to the modules and plugins included
+  This changelog describes all changes made to the modules and plugins included
   in this collection.
   For additional details such as required dependencies and availablity review
   the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 

--- a/changelogs/fragments/v1.3.4_summary.yml
+++ b/changelogs/fragments/v1.3.4_summary.yml
@@ -1,6 +1,6 @@
 release_summary: |
   Release Date: '2022-03-06'
-  This changlelog describes all changes made to the modules and plugins included
+  This changelog describes all changes made to the modules and plugins included
   in this collection.
   For additional details such as required dependencies and availablity review
   the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 

--- a/changelogs/fragments/v1.4.0-beta.1_summary.yml
+++ b/changelogs/fragments/v1.4.0-beta.1_summary.yml
@@ -1,6 +1,6 @@
 release_summary: |
   Release Date: '2021-06-23'
-  This changlelog describes all changes made to the modules and plugins included
+  This changelog describes all changes made to the modules and plugins included
   in this collection.
   For additional details such as required dependencies and availablity review
   the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 

--- a/changelogs/fragments/v1.4.0-beta.2_summary.yml
+++ b/changelogs/fragments/v1.4.0-beta.2_summary.yml
@@ -3,4 +3,4 @@ release_summary: |
   This changelog describes all changes made to the modules and plugins included
   in this collection. The release date is the date the changelog is created.
   For additional details such as required dependencies and availability review
-  the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__ 
+  the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -309,7 +309,7 @@ Reference
 * Supported by IBM `Z Open Automation Utilities 1.1.0`_ and
   `Z Open Automation Utilities 1.1.1`_
 
-Version 1.3.4
+Version 1.3.5
 =============
 
 What's New

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -36,7 +36,7 @@ Version 1.4.0-beta.2
         the contents of it will be copied into the root of `dest`. It it doesn't
         end with "/", the directory itself will be copied.
       * option `dest_dataset` has been deprecated and removed in favor
-         of the new option `dest_data_set`.
+        of the new option `dest_data_set`.
       * fixes a bug that when a directory is copied from the controller to the
         managed node and a mode is set, the mode is applied to the directory
         on the managed node. If the directory being copied contains files and

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -32,7 +32,10 @@ Version 1.4.0-beta.2
         data set `dest`` is NOT empty, the `dest` will be deleted and recreated
         with the `src` data set attributes, otherwise it will be recreated with
         the `dest` data set attributes.
-      *  option `dest_dataset` has been deprecated and removed in favor
+      * was enhanced for when `src` is a directory and ends with "/",
+        the contents of it will be copied into the root of `dest`. It it doesn't
+        end with "/", the directory itself will be copied.
+      * option `dest_dataset` has been deprecated and removed in favor
          of the new option `dest_data_set`.
       * fixes a bug that when a directory is copied from the controller to the
         managed node and a mode is set, the mode is applied to the directory
@@ -42,6 +45,9 @@ Version 1.4.0-beta.2
       * fixes a bug that did not create a data set on the specified volume.
       * fixes a bug where a number of attributes were not an option when using
         `dest_data_set`.
+      * fixes a bug where options were not defined in the module
+        argument spec that will result in error when running `ansible-core`
+        v2.11 and using options `force` or `mode`.
 
     * ``zos_operator``
 
@@ -54,7 +60,7 @@ Version 1.4.0-beta.2
 
     * ``module_utils``
 
-      * jobs.py - fixes a utility used by module zos_job_output that would
+      * jobs.py - fixes a utility used by module `zos_job_output` that would
         truncate the DD content.
 
   * Documentation

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -563,6 +563,7 @@ def run_module():
                 }
             ),
             ignore_sftp_stderr=dict(type="bool", default=False, required=False),
+            # This argument comes from the action plugin.
             local_charset=dict(type="str"),
         )
     )


### PR DESCRIPTION
Version 1.4.0-beta.2
===============

* Bug fixes and enhancements

  * Modules

    * ``zos_copy``

      * introduced an updated creation policy referred to as precedence rules
        that if `dest_data_set` is set, it will take precedence. If
        `dest` is an empty data set, the empty data set will be written with the
        expectation its attributes satisfy the copy. If no precedent rule
        has been exercised, `dest` will be created with the same attributes of
        `src`.
      * introduced new computation capabilities that if `dest` is a nonexistent
        data set, the attributes assigned will depend on the type of `src`. If
        `src` is a USS file, `dest` will have a Fixed Block (FB) record format
        and the remaining attributes will be computed. If `src` is binary,
        `dest` will have a Fixed Block (FB) record format with a record length
        of 80, block size of 32760, and the remaining attributes will be
        computed.
      * enhanced the force option when `force=true` and the remote file or
        data set `dest`` is NOT empty, the `dest` will be deleted and recreated
        with the `src` data set attributes, otherwise it will be recreated with
        the `dest` data set attributes.
      * was enhanced for when `src` is a directory and ends with "/",
        the contents of it will be copied into the root of `dest`. It it doesn't
        end with "/", the directory itself will be copied.
      * option `dest_dataset` has been deprecated and removed in favor
         of the new option `dest_data_set`.
      * fixes a bug that when a directory is copied from the controller to the
        managed node and a mode is set, the mode is applied to the directory
        on the managed node. If the directory being copied contains files and
        mode is set, mode will only be applied to the files being copied not the
        pre-existing files.
      * fixes a bug that did not create a data set on the specified volume.
      * fixes a bug where a number of attributes were not an option when using
        `dest_data_set`.
      * fixes a bug where options were not defined in the module
        argument spec that will result in error when running `ansible-core`
        v2.11 and using options `force` or `mode`.

    * ``zos_operator``

      * enhanced to allow for MVS operator `SET` command, `SET` is
        equivalent to the abbreviated `T` command.

    * ``zos_mount``

      * fixed option `tag_ccsid` to correctly allow for type int.

    * ``module_utils``

      * jobs.py - fixes a utility used by module `zos_job_output` that would
        truncate the DD content.

  * Documentation

    * Review `version 1.4.0-beta.1` release notes for additional content.

* Deprecated or removed

  * ``zos_copy`` module option **destination_dataset** has been renamed to
    **dest_data_set**.

    * Review `version 1.4.0-beta.1` release notes for additional content.


Availability
------------

* `Galaxy`
* `GitHub`

Reference
---------

* Supported by `z/OS V2R3` or later
* Supported by the `z/OS® shell`
* Supported by `IBM Open Enterprise SDK for Python` v3.8.2 -
  `IBM Open Enterprise SDK for Python` v3.9.5
* Supported by IBM `Z Open Automation Utilities 1.1.0`_ and
  `Z Open Automation Utilities 1.1.1`

Known Issues
------------

* Review `version 1.4.0-beta.1` release notes for additional content.

Deprecation Notices
-------------------
* Review `version 1.4.0-beta.1` release notes for additional content.
