### PR TITLE
Enable previously deprecated test cases for zos_operator and fix dependencyfinder

### DIFF
--- a/changelogs/fragments/546-enable-zos_operator-func-test.yml
+++ b/changelogs/fragments/546-enable-zos_operator-func-test.yml
@@ -1,0 +1,3 @@
+trivial:
+- Enables zos_operator functional tests after testing ZOAU fix in 1.2.1.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/546)

--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -528,6 +528,7 @@ def get_changed_plugins(path, branch="origin/dev"):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         cwd=path,
+        env={'COLUMNS':'500'},
     )
 
     stdout, stderr = get_diff_pr.communicate()

--- a/tests/functional/modules/test_zos_operator_action_query_func.py
+++ b/tests/functional/modules/test_zos_operator_action_query_func.py
@@ -18,296 +18,290 @@ __metaclass__ = type
 import pytest
 import unittest
 
+def test_zos_operator_action_query_no_options(ansible_zos_module):
+    hosts = ansible_zos_module
+    hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    results = hosts.all.zos_operator_action_query()
+    try:
+        for action in results.get("actions"):
+            if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
+                hosts.all.zos_operator(
+                    cmd="{0}cancel".format(action.get("number")))
+    except Exception:
+        pass
+    for result in results.contacted.values():
+        assert result.get("actions")
 
-class ModuleOperatorQueryTests(unittest.TestCase):
-    def setUp(self):
-        self.skipTest('Module tests disabled and waiting on ZOAU')
+def test_zos_operator_action_query_option_message_id(ansible_zos_module):
+    hosts = ansible_zos_module
+    hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    results = hosts.all.zos_operator_action_query(message_id="IEE094D")
+    try:
+        for action in results.get("actions"):
+            if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
+                hosts.all.zos_operator(
+                    cmd="{0}cancel".format(action.get("number")))
+    except Exception:
+        pass
+    for result in results.contacted.values():
+        assert result.get("actions")
 
-    def test_zos_operator_action_query_no_options(self, ansible_zos_module):
-        hosts = ansible_zos_module
-        hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
-        results = hosts.all.zos_operator_action_query()
-        try:
-            for action in results.get("actions"):
-                if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
-                    hosts.all.zos_operator(cmd="{0}cancel".format(action.get("number")))
-        except Exception:
-            pass
-        for result in results.contacted.values():
-            assert result.get("actions")
+def test_zos_operator_action_query_option_message_id_invalid_abbreviation(
+    ansible_zos_module
+):
+    hosts = ansible_zos_module
+    hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    results = hosts.all.zos_operator_action_query(message_id="IEE")
+    try:
+        for action in results.get("actions"):
+            if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
+                hosts.all.zos_operator(
+                    cmd="{0}cancel".format(action.get("number")))
+    except Exception:
+        pass
+    for result in results.contacted.values():
+        assert not result.get("actions")
 
-    def test_zos_operator_action_query_option_message_id(self, ansible_zos_module):
-        hosts = ansible_zos_module
-        hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
-        results = hosts.all.zos_operator_action_query(message_id="IEE094D")
-        try:
-            for action in results.get("actions"):
-                if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
-                    hosts.all.zos_operator(cmd="{0}cancel".format(action.get("number")))
-        except Exception:
-            pass
-        for result in results.contacted.values():
-            assert result.get("actions")
+@pytest.mark.parametrize("message_id", ["IEE*", "*"])
+def test_zos_operator_action_query_option_message_id_regex(
+    ansible_zos_module,
+    message_id
+):
+    hosts = ansible_zos_module
+    hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    results = hosts.all.zos_operator_action_query(message_id=message_id)
+    try:
+        for action in results.get("actions"):
+            if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
+                hosts.all.zos_operator(
+                    cmd="{0}cancel".format(action.get("number")))
+    except Exception:
+        pass
+    for result in results.contacted.values():
+        assert result.get("actions")
 
-    def test_zos_operator_action_query_option_message_id_invalid_abbreviation(
-        self,
-        ansible_zos_module
-    ):
-        hosts = ansible_zos_module
-        hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
-        results = hosts.all.zos_operator_action_query(message_id="IEE")
-        try:
-            for action in results.get("actions"):
-                if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
-                    hosts.all.zos_operator(cmd="{0}cancel".format(action.get("number")))
-        except Exception:
-            pass
-        for result in results.contacted.values():
-            assert not result.get("actions")
+def test_zos_operator_action_query_option_system(ansible_zos_module):
+    hosts = ansible_zos_module
+    sysinfo = hosts.all.shell(cmd="uname -n")
+    system_name = ""
+    for result in sysinfo.contacted.values():
+        system_name = result.get("stdout", "").strip()
+    results = hosts.all.zos_operator_action_query(system=system_name)
+    for result in results.contacted.values():
+        assert result.get("actions")
 
-    @pytest.mark.parametrize("message_id", ["IEE*", "*"])
-    def test_zos_operator_action_query_option_message_id_regex(
-        self,
-        ansible_zos_module,
-        message_id
-    ):
-        hosts = ansible_zos_module
-        hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
-        results = hosts.all.zos_operator_action_query(message_id=message_id)
-        try:
-            for action in results.get("actions"):
-                if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
-                    hosts.all.zos_operator(cmd="{0}cancel".format(action.get("number")))
-        except Exception:
-            pass
-        for result in results.contacted.values():
-            assert result.get("actions")
+def test_zos_operator_action_query_option_system_invalid_abbreviation(
+    ansible_zos_module
+):
+    hosts = ansible_zos_module
+    sysinfo = hosts.all.shell(cmd="uname -n")
+    system_name = ""
+    for result in sysinfo.contacted.values():
+        system_name = result.get("stdout", "").strip()
+    results = hosts.all.zos_operator_action_query(system=system_name[:-1])
+    for result in results.contacted.values():
+        assert not result.get("actions")
 
-    def test_zos_operator_action_query_option_system(self, ansible_zos_module):
-        hosts = ansible_zos_module
-        sysinfo = hosts.all.shell(cmd="uname -n")
-        system_name = ""
-        for result in sysinfo.contacted.values():
-            system_name = result.get("stdout", "").strip()
-        results = hosts.all.zos_operator_action_query(system=system_name)
-        for result in results.contacted.values():
-            assert result.get("actions")
-
-    def test_zos_operator_action_query_option_system_invalid_abbreviation(
-        self,
-        ansible_zos_module
-    ):
-        hosts = ansible_zos_module
-        sysinfo = hosts.all.shell(cmd="uname -n")
-        system_name = ""
-        for result in sysinfo.contacted.values():
-            system_name = result.get("stdout", "").strip()
-        results = hosts.all.zos_operator_action_query(system=system_name[:-1])
-        for result in results.contacted.values():
-            assert not result.get("actions")
-
-    @pytest.mark.parametrize("message_id", ["IEE*", "IEE094D", "*"])
-    def test_zos_operator_action_query_option_system_and_message_id(
-        self,
-        ansible_zos_module,
-        message_id
-    ):
-        hosts = ansible_zos_module
-        sysinfo = hosts.all.shell(cmd="uname -n")
-        system_name = ""
-        for result in sysinfo.contacted.values():
-            system_name = result.get("stdout", "").strip()
-        results = hosts.all.zos_operator_action_query(
-            system=system_name, message_id=message_id
-        )
-        for result in results.contacted.values():
-            assert result.get("actions")
-
-    def test_zos_operator_action_query_option_system_regex(self, ansible_zos_module):
-        hosts = ansible_zos_module
-        hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
-        sysinfo = hosts.all.shell(cmd="uname -n")
-        system_name = "   "
-        for result in sysinfo.contacted.values():
-            system_name = result.get("stdout", "   ").strip()
-        results = hosts.all.zos_operator_action_query(system=system_name[:3] + "*")
-        try:
-            for action in results.get("actions"):
-                if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
-                    hosts.all.zos_operator(cmd="{0}cancel".format(action.get("number")))
-        except Exception:
-            pass
-        for result in results.contacted.values():
-            assert result.get("actions")
-
-    @pytest.mark.parametrize("message_id", ["IEE*", "IEE094D", "*"])
-    def test_zos_operator_action_query_option_system_regex_and_message_id(
-        self,
-        ansible_zos_module,
-        message_id
-    ):
-        hosts = ansible_zos_module
-        hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
-        sysinfo = hosts.all.shell(cmd="uname -n")
-        system_name = "   "
-        for result in sysinfo.contacted.values():
-            system_name = result.get("stdout", "   ").strip()
-        results = hosts.all.zos_operator_action_query(
-            system=system_name[:3] + "*", message_id=message_id
-        )
-        try:
-            for action in results.get("actions"):
-                if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
-                    hosts.all.zos_operator(cmd="{0}cancel".format(action.get("number")))
-        except Exception:
-            pass
-        for result in results.contacted.values():
-            assert result.get("actions")
-
-    @pytest.mark.parametrize("system", ["", "OVER8CHARS", "--BADNM", "invalid-system"])
-    def test_zos_operator_action_query_invalid_option_system(
-        self,
-        ansible_zos_module,
-        system
-    ):
-        hosts = ansible_zos_module
-        results = hosts.all.zos_operator_action_query(system=system)
-        for result in results.contacted.values():
-            assert result.get("actions") is None
-
-    @pytest.mark.parametrize("message_id", ["IEE*", "IEE094D", "*"])
-    def test_zos_operator_action_query_valid_message_id_invalid_option_system(
-        self,
-        ansible_zos_module,
-        message_id
-    ):
-        hosts = ansible_zos_module
-        results = hosts.all.zos_operator_action_query(
-            system="invalid-system", message_id=message_id
-        )
-        for result in results.contacted.values():
-            assert result.get("actions") is None
-
-    @pytest.mark.parametrize("message_id", ["", "--BADNM", "invalid-message"])
-    def test_zos_operator_action_query_invalid_option_message_id(
-        self,
-        ansible_zos_module,
-        message_id
-    ):
-        hosts = ansible_zos_module
-        results = hosts.all.zos_operator_action_query(message_id=message_id)
-        for result in results.contacted.values():
-            assert result.get("actions") is None
-
-    def test_zos_operator_action_query_valid_option_system_invalid_option_message_id(
-        self,
-        ansible_zos_module
-    ):
-        hosts = ansible_zos_module
-        sysinfo = hosts.all.shell(cmd="uname -n")
-        system_name = ""
-        for result in sysinfo.contacted.values():
-            system_name = result.get("stdout", "").strip()
-        results = hosts.all.zos_operator_action_query(
-            system=system_name, message_id="invalid-message"
-        )
-        for result in results.contacted.values():
-            assert result.get("actions") is None
-
-    def test_zos_operator_action_query_invalid_option_job_name(self, ansible_zos_module):
-        hosts = ansible_zos_module
-        results = hosts.all.zos_operator_action_query(job_name="invalid-job-name")
-        for result in results.contacted.values():
-            assert result.get("actions") is None
-
-    @pytest.mark.parametrize(
-        "message_filter",
-        [
-            {"filter": "DUMP"},
-            {"filter": "DUMP", "use_regex": False},
-            {"filter": "^.*DUMP.*$", "use_regex": True},
-            {"filter": "^.*OPERAND\\(S\\).*$", "use_regex": True}
-        ]
+@pytest.mark.parametrize("message_id", ["IEE*", "IEE094D", "*"])
+def test_zos_operator_action_query_option_system_and_message_id(
+    ansible_zos_module,
+    message_id
+):
+    hosts = ansible_zos_module
+    sysinfo = hosts.all.shell(cmd="uname -n")
+    system_name = ""
+    for result in sysinfo.contacted.values():
+        system_name = result.get("stdout", "").strip()
+    results = hosts.all.zos_operator_action_query(
+        system=system_name, message_id=message_id
     )
-    def test_zos_operator_action_query_option_message_filter_one_match(
-        self,
-        ansible_zos_module,
-        message_filter
-    ):
-        hosts = ansible_zos_module
-        hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
-        results = hosts.all.zos_operator_action_query(message_filter=message_filter)
-        try:
-            for action in results.get("actions"):
-                if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
-                    hosts.all.zos_operator(cmd="{0}cancel".format(action.get("number")))
-        except Exception:
-            pass
-        for result in results.contacted.values():
-            assert result.get("actions")
+    for result in results.contacted.values():
+        assert result.get("actions")
 
-    @pytest.mark.parametrize(
-        "message_filter",
-        [
-            {"filter": "DUMP"},
-            {"filter": "DUMP", "use_regex": False},
-            {"filter": "^.*DUMP.*$", "use_regex": True},
-            {"filter": "^.*OPERAND\\(S\\).*$", "use_regex": True}
-        ]
+def test_zos_operator_action_query_option_system_regex(ansible_zos_module):
+    hosts = ansible_zos_module
+    hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    sysinfo = hosts.all.shell(cmd="uname -n")
+    system_name = "   "
+    for result in sysinfo.contacted.values():
+        system_name = result.get("stdout", "   ").strip()
+    results = hosts.all.zos_operator_action_query(
+        system=system_name[:3] + "*")
+    try:
+        for action in results.get("actions"):
+            if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
+                hosts.all.zos_operator(
+                    cmd="{0}cancel".format(action.get("number")))
+    except Exception:
+        pass
+    for result in results.contacted.values():
+        assert result.get("actions")
+
+@pytest.mark.parametrize("message_id", ["IEE*", "IEE094D", "*"])
+def test_zos_operator_action_query_option_system_regex_and_message_id(
+    ansible_zos_module,
+    message_id
+):
+    hosts = ansible_zos_module
+    hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    sysinfo = hosts.all.shell(cmd="uname -n")
+    system_name = "   "
+    for result in sysinfo.contacted.values():
+        system_name = result.get("stdout", "   ").strip()
+    results = hosts.all.zos_operator_action_query(
+        system=system_name[:3] + "*", message_id=message_id
     )
-    def test_zos_operator_action_query_option_message_filter_multiple_matches(
-        self,
-        ansible_zos_module,
-        message_filter
-    ):
-        hosts = ansible_zos_module
-        hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
-        hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    try:
+        for action in results.get("actions"):
+            if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
+                hosts.all.zos_operator(
+                    cmd="{0}cancel".format(action.get("number")))
+    except Exception:
+        pass
+    for result in results.contacted.values():
+        assert result.get("actions")
 
-        results = hosts.all.zos_operator_action_query(message_filter=message_filter)
+@pytest.mark.parametrize("system", ["", "OVER8CHARS", "--BADNM", "invalid-system"])
+def test_zos_operator_action_query_invalid_option_system(
+    ansible_zos_module,
+    system
+):
+    hosts = ansible_zos_module
+    results = hosts.all.zos_operator_action_query(system=system)
+    for result in results.contacted.values():
+        assert result.get("actions") is None
 
-        try:
-            for action in results.get("actions"):
-                if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
-                    hosts.all.zos_operator(cmd="{0}cancel".format(action.get("number")))
-        except Exception:
-            pass
-
-        for result in results.contacted.values():
-            print(result.get("actions"))
-            assert result.get("actions")
-            assert len(result.get("actions")) > 1
-
-    @pytest.mark.parametrize(
-        "message_filter",
-        [
-            {"filter": "IMS"},
-            {"filter": "IMS", "use_regex": False},
-            {"filter": "^.*IMS.*$", "use_regex": True},
-        ]
+@pytest.mark.parametrize("message_id", ["IEE*", "IEE094D", "*"])
+def test_zos_operator_action_query_valid_message_id_invalid_option_system(
+    ansible_zos_module,
+    message_id
+):
+    hosts = ansible_zos_module
+    results = hosts.all.zos_operator_action_query(
+        system="invalid-system", message_id=message_id
     )
-    def test_zos_operator_action_query_option_message_filter_no_match(
-        self,
-        ansible_zos_module,
-        message_filter
-    ):
-        hosts = ansible_zos_module
-        hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
-        results = hosts.all.zos_operator_action_query(message_filter=message_filter)
-        try:
-            for action in results.get("actions"):
-                if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
-                    hosts.all.zos_operator(cmd="{0}cancel".format(action.get("number")))
-        except Exception:
-            pass
-        for result in results.contacted.values():
-            assert not result.get("actions")
+    for result in results.contacted.values():
+        assert result.get("actions") is None
 
-    def test_zos_operator_action_query_invalid_option_message_filter(
-        self,
-        ansible_zos_module
-    ):
-        hosts = ansible_zos_module
-        results = hosts.all.zos_operator_action_query(message_filter={"filter": "*DUMP", "use_regex": True})
-        for result in results.contacted.values():
-            assert result.get("actions") is None
+@pytest.mark.parametrize("message_id", ["", "--BADNM", "invalid-message"])
+def test_zos_operator_action_query_invalid_option_message_id(
+    ansible_zos_module,
+    message_id
+):
+    hosts = ansible_zos_module
+    results = hosts.all.zos_operator_action_query(message_id=message_id)
+    for result in results.contacted.values():
+        assert result.get("actions") is None
+
+def test_zos_operator_action_query_valid_option_system_invalid_option_message_id(
+    ansible_zos_module
+):
+    hosts = ansible_zos_module
+    sysinfo = hosts.all.shell(cmd="uname -n")
+    system_name = ""
+    for result in sysinfo.contacted.values():
+        system_name = result.get("stdout", "").strip()
+    results = hosts.all.zos_operator_action_query(
+        system=system_name, message_id="invalid-message"
+    )
+    for result in results.contacted.values():
+        assert result.get("actions") is None
+
+def test_zos_operator_action_query_invalid_option_job_name(ansible_zos_module):
+    hosts = ansible_zos_module
+    results = hosts.all.zos_operator_action_query(
+        job_name="invalid-job-name")
+    for result in results.contacted.values():
+        assert result.get("actions") is None
+
+@pytest.mark.parametrize(
+    "message_filter",
+    [
+        {"filter": "DUMP"},
+        {"filter": "DUMP", "use_regex": False},
+        {"filter": "^.*DUMP.*$", "use_regex": True},
+        {"filter": "^.*OPERAND\\(S\\).*$", "use_regex": True}
+    ]
+)
+def test_zos_operator_action_query_option_message_filter_one_match(
+    ansible_zos_module,
+    message_filter
+):
+    hosts = ansible_zos_module
+    hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    results = hosts.all.zos_operator_action_query(
+        message_filter=message_filter)
+    try:
+        for action in results.get("actions"):
+            if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
+                hosts.all.zos_operator(
+                    cmd="{0}cancel".format(action.get("number")))
+    except Exception:
+        pass
+    for result in results.contacted.values():
+        assert result.get("actions")
+
+@pytest.mark.parametrize(
+    "message_filter",
+    [
+        {"filter": "DUMP"},
+        {"filter": "DUMP", "use_regex": False},
+        {"filter": "^.*DUMP.*$", "use_regex": True},
+        {"filter": "^.*OPERAND\\(S\\).*$", "use_regex": True}
+    ]
+)
+def test_zos_operator_action_query_option_message_filter_multiple_matches(
+    ansible_zos_module,
+    message_filter
+):
+    hosts = ansible_zos_module
+    hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    results = hosts.all.zos_operator_action_query(
+        message_filter=message_filter)
+    try:
+        for action in results.get("actions"):
+            if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
+                hosts.all.zos_operator(
+                    cmd="{0}cancel".format(action.get("number")))
+    except Exception:
+        pass
+    for result in results.contacted.values():
+        print(result.get("actions"))
+        assert result.get("actions")
+        assert len(result.get("actions")) > 1
+
+@pytest.mark.parametrize(
+    "message_filter",
+    [
+        {"filter": "IMS"},
+        {"filter": "IMS", "use_regex": False},
+        {"filter": "^.*IMS.*$", "use_regex": True},
+    ]
+)
+def test_zos_operator_action_query_option_message_filter_no_match(
+    ansible_zos_module,
+    message_filter
+):
+    hosts = ansible_zos_module
+    hosts.all.zos_operator(cmd="DUMP COMM=('test dump')")
+    results = hosts.all.zos_operator_action_query(
+        message_filter=message_filter)
+    try:
+        for action in results.get("actions"):
+            if "SPECIFY OPERAND(S) FOR DUMP" in action.get("message_text", ""):
+                hosts.all.zos_operator(
+                    cmd="{0}cancel".format(action.get("number")))
+    except Exception:
+        pass
+    for result in results.contacted.values():
+        assert not result.get("actions")
+
+def test_zos_operator_action_query_invalid_option_message_filter(
+    ansible_zos_module
+):
+    hosts = ansible_zos_module
+    results = hosts.all.zos_operator_action_query(
+        message_filter={"filter": "*DUMP", "use_regex": True})
+    for result in results.contacted.values():
+        assert result.get("actions") is None


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

##### SUMMARY
This pull request will re-enable the test_zos_operator_func.py based on the fact they have been tested locally with zoau 1.2.1 such that now the issue #379  is resolved in ZOAU. 
![image](https://user-images.githubusercontent.com/25803172/197378511-fe7efb6b-9fcc-4d1e-a717-6849dc036641.png)

This issues also resolves #547 which fixes a bug in the dependencyfinder where subprocess would return a truncated relative path because the columns value was not large enough. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


