### PR TITLE
Enhancement/v1.4.0/zos copy dirs

### DIFF
--- a/docs/source/modules/zos_copy.rst
+++ b/docs/source/modules/zos_copy.rst
@@ -68,7 +68,7 @@ dest
 
   ``dest`` can be a USS file, directory or MVS data set name.
 
-  If ``src`` and ``dest`` are files and if the parent directory of ``dest`` does not exist, then the task will fail
+  If ``dest`` has missing parent directories, they will be created.
 
   If ``dest`` is a nonexistent USS file, it will be created.
 

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2037,6 +2037,9 @@ def run_module(module, arg_def):
         # If temp_path, the plugin has copied a file from the controller to USS.
         if temp_path or "/" in src:
             src_ds_type = "USS"
+
+            if remote_src and os.path.isdir(src):
+                is_src_dir = True
         else:
             if data_set.DataSet.data_set_exists(src_name):
                 if src_member and not data_set.DataSet.data_set_member_exists(src):
@@ -2062,8 +2065,9 @@ def run_module(module, arg_def):
 
         if is_uss:
             dest_ds_type = "USS"
-            if not is_src_dir and (dest.endswith("/") or os.path.isdir(dest)):
-                dest = os.path.normpath("{0}/{1}".format(dest, os.path.basename(src)))
+            if src_ds_type == "USS" and not is_src_dir and (dest.endswith("/") or os.path.isdir(dest)):
+                src_basename = os.path.basename(src) if src else "inline_copy"
+                dest = os.path.normpath("{0}/{1}".format(dest, src_basename))
 
                 if dest.startswith("//"):
                     dest = dest.replace("//", "/")

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -244,6 +244,29 @@ def test_copy_file_to_uss_dir(ansible_zos_module, src):
 
 
 @pytest.mark.uss
+def test_copy_file_to_uss_dir_missing_parents(ansible_zos_module):
+    hosts = ansible_zos_module
+    src = "/etc/profile"
+    dest_dir = "/tmp/parent_dir"
+    dest = "{0}/subdir/profile".format(dest_dir)
+
+    try:
+        hosts.all.file(path=dest_dir, state="absent")
+        copy_res = hosts.all.zos_copy(src=src, dest=dest)
+        stat_res = hosts.all.stat(path=dest)
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest
+            assert result.get("state") == "file"
+        for st in stat_res.contacted.values():
+            assert st.get("stat").get("exists") is True
+    finally:
+        hosts.all.file(path=dest_dir, state="absent")
+
+
+@pytest.mark.uss
 def test_copy_local_symlink_to_uss_file(ansible_zos_module):
     hosts = ansible_zos_module
     src_lnk = "/tmp/etclnk"


### PR DESCRIPTION
##### SUMMARY

Fixes #553 and #554.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

zos_copy

##### ADDITIONAL INFORMATION

For #553: added a test case for the creation of missing parents.
For #554: the module now only gets the original permissions for files and subdirectories that will be overwritten, instead of walking the whole directory tree for the destination.

Additionally, when the source is a file and the destination is a directory, the module computes the final destination path before trying to backup. Before this change, it tried to backup the whole destination directory, when it only needed to backup one file.
