### PR TITLE
Bugfix/560/zos copy backup

### DIFF
--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2170,6 +2170,7 @@ def run_module(module, arg_def):
 
     # Creating an emergency backup or an empty data set to use as a model to
     # be able to restore the destination in case the copy fails.
+    emergency_backup = ""
     if dest_exists:
         if is_uss or not data_set.DataSet.is_empty(dest_name):
             use_backup = True
@@ -2177,7 +2178,8 @@ def run_module(module, arg_def):
                 emergency_backup = tempfile.mkdtemp()
                 emergency_backup = backup_data(dest, dest_ds_type, emergency_backup)
             else:
-                emergency_backup = backup_data(dest, dest_ds_type, None)
+                if not (dest_ds_type in data_set.DataSet.MVS_PARTITIONED and src_member and not dest_member_exists):
+                    emergency_backup = backup_data(dest, dest_ds_type, None)
         # If dest is an empty data set, instead create a data set to
         # use as a model when restoring.
         else:

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1617,6 +1617,53 @@ def test_copy_multiple_data_set_members(ansible_zos_module):
         hosts.all.zos_data_set(name=dest, state="absent")
 
 
+@pytest.mark.pdse
+def test_copy_multiple_data_set_members_in_loop(ansible_zos_module):
+    """
+    This test case was included in case the module is called inside a loop,
+    issue was discovered in https://github.com/ansible-collections/ibm_zos_core/issues/560.
+    """
+    hosts = ansible_zos_module
+    src = "USER.FUNCTEST.SRC.PDS"
+    src_wildcard = "{0}(ABC*)".format(src)
+
+    dest = "USER.FUNCTEST.DEST.PDS"
+    member_list = ["MEMBER1", "ABCXYZ", "ABCASD"]
+    src_ds_list = ["{0}({1})".format(src, member) for member in member_list]
+    dest_ds_list = ["{0}({1})".format(dest, member) for member in member_list]
+
+    try:
+        hosts.all.zos_data_set(name=src, type="pds")
+        hosts.all.zos_data_set(name=dest, type="pds")
+
+        for src_member in src_ds_list:
+            hosts.all.shell(
+                cmd="decho '{0}' '{1}'".format(DUMMY_DATA, src_member),
+                executable=SHELL_EXECUTABLE
+            )
+
+        for src_member, dest_member in zip(src_ds_list, dest_ds_list):
+            copy_res = hosts.all.zos_copy(src=src_member, dest=dest_member, remote_src=True)
+            for result in copy_res.contacted.values():
+                assert result.get("msg") is None
+                assert result.get("changed") is True
+                assert result.get("dest") == dest_member
+
+        verify_copy = hosts.all.shell(
+            cmd="mls {0}".format(dest),
+            executable=SHELL_EXECUTABLE
+        )
+
+        for v_cp in verify_copy.contacted.values():
+            assert v_cp.get("rc") == 0
+            stdout = v_cp.get("stdout")
+            assert stdout is not None
+            assert len(stdout.splitlines()) == 2
+
+    finally:
+        hosts.all.zos_data_set(name=src, state="absent")
+        hosts.all.zos_data_set(name=dest, state="absent")
+
 @pytest.mark.uss
 @pytest.mark.pdse
 @pytest.mark.parametrize("ds_type", ["pds", "pdse"])

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1625,7 +1625,6 @@ def test_copy_multiple_data_set_members_in_loop(ansible_zos_module):
     """
     hosts = ansible_zos_module
     src = "USER.FUNCTEST.SRC.PDS"
-    src_wildcard = "{0}(ABC*)".format(src)
 
     dest = "USER.FUNCTEST.DEST.PDS"
     member_list = ["MEMBER1", "ABCXYZ", "ABCASD"]
@@ -1658,7 +1657,7 @@ def test_copy_multiple_data_set_members_in_loop(ansible_zos_module):
             assert v_cp.get("rc") == 0
             stdout = v_cp.get("stdout")
             assert stdout is not None
-            assert len(stdout.splitlines()) == 2
+            assert len(stdout.splitlines()) == 3
 
     finally:
         hosts.all.zos_data_set(name=src, state="absent")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enhanced a condition for when to create an emergency backup if the PDS/PDSE exists but dest_member does not, this will avoid trying to create a backup on a non existent dataset member.

Plus added a test case that copies multiple dataset members each in an independent zos_copy invocation, just like in issue #560.

Fixes #560 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/backup.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
