### PR TITLE
[Bug] [zos_copy] Updated backup path used when copying directories

### DIFF
--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2074,7 +2074,10 @@ def run_module(module, arg_def):
                 if dest.startswith("//"):
                     dest = dest.replace("//", "/")
 
-            dest_exists = os.path.exists(dest)
+            if is_src_dir and not src.endswith("/"):
+                dest_exists = os.path.exists(os.path.normpath("{0}/{1}".format(dest, os.path.basename(src))))
+            else:
+                dest_exists = os.path.exists(dest)
 
             if dest_exists and not os.access(dest, os.W_OK):
                 module.fail_json(msg="Destination {0} is not writable".format(dest))
@@ -2193,8 +2196,17 @@ def run_module(module, arg_def):
         if is_uss or not data_set.DataSet.is_empty(dest_name):
             use_backup = True
             if is_uss:
+                # When copying a directory without a trailing slash,
+                # appending the source's base name to the backup path to
+                # avoid backing up the whole parent directory that won't
+                # be modified.
+                src_basename = os.path.basename(src) if src else ''
+                backup_dest = "{0}/{1}".format(dest, src_basename) if is_src_dir and not src.endswith("/") else dest
+                backup_dest = os.path.normpath(backup_dest)
+
                 emergency_backup = tempfile.mkdtemp()
-                emergency_backup = backup_data(dest, dest_ds_type, emergency_backup)
+                emergency_backup = backup_data(backup_dest, dest_ds_type, emergency_backup)
+
             else:
                 if not (dest_ds_type in data_set.DataSet.MVS_PARTITIONED and src_member and not dest_member_exists):
                     emergency_backup = backup_data(dest, dest_ds_type, None)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1727,6 +1727,7 @@ def test_copy_multiple_data_set_members_in_loop(ansible_zos_module):
         hosts.all.zos_data_set(name=src, state="absent")
         hosts.all.zos_data_set(name=dest, state="absent")
 
+
 @pytest.mark.uss
 @pytest.mark.pdse
 @pytest.mark.parametrize("ds_type", ["pds", "pdse"])


### PR DESCRIPTION
##### SUMMARY

Fixes an issue discovered by a client where `zos_copy` would try to backup the parent directory of the destination when copying a source directory without using a trailing slash. Now the module creates an emergency backup of the directory it'll replace, and not of the whole parent directory.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zos_copy

##### ADDITIONAL INFORMATION

Related to #554. The bugfix for that issue unearthed this one.
