### PR TITLE
Removed emergency backup when backup=False

### DIFF
--- a/changelogs/fragments/588-update-emergency-backup.yml
+++ b/changelogs/fragments/588-update-emergency-backup.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- zos_copy - enhanced to only create destination backups when module option
+  `backup` is true, removing emergency backups meant to restore the system
+  to its initial state in case of a module failure.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/589)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: ibm
 name: ibm_zos_core
 
 # The collection version
-version: 1.4.0
+version: 1.4.1
 
 # Collection README file
 readme: README.md


### PR DESCRIPTION
##### SUMMARY
Implements #588.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zos_copy

##### ADDITIONAL INFORMATION

Removed the use of an emergency backup. If a user wants a backup of the destination, the original backup code is still in the module and it's run when `backup=True`.