### PR TITLE
Bugfix/558/zos copy backup v.1.5.0

### DIFF
--- a/changelogs/fragments/588-zos_copy-emergenxy-backup.yml
+++ b/changelogs/fragments/588-zos_copy-emergenxy-backup.yml
@@ -3,3 +3,4 @@ bugfixes:
    `force` is true, creating emergency backups meant to restore the system
    to its initial state in case of a module failure only when force is false.
    (https://github.com/ansible-collections/ibm_zos_core/pull/590)
+   

--- a/changelogs/fragments/588-zos_copy-emergenxy-backup.yml
+++ b/changelogs/fragments/588-zos_copy-emergenxy-backup.yml
@@ -1,0 +1,5 @@
+bugfixes:
+ - zos_copy - fixed wrongful creation of destination backups when module option
+   `force` is true, creating emergency backups meant to restore the system
+   to its initial state in case of a module failure only when force is false.
+   (https://github.com/ansible-collections/ibm_zos_core/pull/590)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2173,7 +2173,7 @@ def run_module(module, arg_def):
 
     # Creating an emergency backup or an empty data set to use as a model to
     # be able to restore the destination in case the copy fails.
-    if dest_exists:
+    if dest_exists and not force:
         if is_uss or not data_set.DataSet.is_empty(dest_name):
             use_backup = True
             if is_uss:
@@ -2201,7 +2201,7 @@ def run_module(module, arg_def):
                 volume=volume
             )
     except Exception as err:
-        if dest_exists:
+        if dest_exists and not force:
             restore_backup(dest_name, emergency_backup, dest_ds_type, use_backup)
             erase_backup(emergency_backup, dest_ds_type)
         module.fail_json(msg="Unable to allocate destination data set: {0}".format(str(err)))
@@ -2307,11 +2307,11 @@ def run_module(module, arg_def):
             res_args["changed"] = True
 
     except CopyOperationError as err:
-        if dest_exists:
+        if dest_exists and not force:
             restore_backup(dest_name, emergency_backup, dest_ds_type, use_backup)
         raise err
     finally:
-        if dest_exists:
+        if dest_exists and not force:
             erase_backup(emergency_backup, dest_ds_type)
 
     res_args.update(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #588 on v1.5.0 release. Same PR as #590 but based on release branch v1.5.0
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Removed the use of an emergency backup when Force=True. If a user wants a backup of the destination, the original backup code is still in the module and it's run when Force=False.
