### PR TITLE
Expand what is ingored for venv to all venv's

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -81,7 +81,7 @@ build_ignore:
   - tests/requirements.txt
   - test_config.yml
   - changelogs
-  - venv
+  - venv*
   - make.env.encrypt
   - Makefile
   - make.env


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>
Minor update to ignore anything local that starts with venv with the added regular expression `*`.

##### SUMMARY
Without this, the make file pulled in another local venv2 that increased our build size. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

