### PR TITLE
Update make file to read exported var VENV else default to 'venv'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,11 @@
 CURR_DIR := $(shell pwd)
 WHO := $(shell whoami)
 HOST_PYTHON = python3
-VENV = venv
+# VENV = venv
+# VENV := $(shell echo $$VENV)
+VENV := $(shell echo "$${VENV:-defaultValue}")
 VENV_BIN=$(VENV)/bin
+
 ZOS_PYTHON_DEFAULT=3.8
 ZOAU_DEFAULT=1.1.1
 # Test if docker is running

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ WHO := $(shell whoami)
 HOST_PYTHON = python3
 # VENV = venv
 # VENV := $(shell echo $$VENV)
-VENV := $(shell echo "$${VENV:-defaultValue}")
+VENV := $(shell echo "$${VENV:-venv}")
 VENV_BIN=$(VENV)/bin
 
 ZOS_PYTHON_DEFAULT=3.8


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

Overrides the original behavior of the Makefile that always expected one venv called 'venv'. By reading an exported var VENV, the make file and be used to interact with any number of virtual environments expediting localized testing. 

For example I will pass in my own requirements.txt then instruct the Makefile which make file and directory to build it for.
```
export VENV=venv-2.11
make vsetup req=requirements-ac-2.11.12.txt
```
```
ls -la 
drwxr-xr-x  10 ddimatos  staff     320 Jan 18 20:56 venv-2.11
```

Now I can do this:
```
ddimatos:[ ~/git/github/ibm_zos_core ]export VENV=venv-2.11
ddimatos:[ ~/git/github/ibm_zos_core ]make sanity version=3.8
Running sanity test "action-plugin-docs"
Running sanity test "ansible-doc"
```
or switch between other VENVs buy exporting the env var VENV , eg `export VENV=venv-2.14`

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
