### PR TITLE
Ansible-core versions with updated ignore file pass

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9,<2.12'
+requires_ansible: '>=2.9,<2.15'

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -58,6 +58,7 @@ plugins/modules/zos_job_submit.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
 plugins/modules/zos_job_submit.py validate-modules:undocumented-parameter # Passing args from action plugin
+plugins/modules/zos_job_submit.py pylint:catching-non-exception # False positive, Exception is inherited
 plugins/modules/zos_lineinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_lineinfile.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_lineinfile.py import-2.6!skip # Python 2.6 is unsupported
@@ -82,3 +83,4 @@ plugins/modules/zos_tso_command.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_gather_facts.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_gather_facts.py import-2.6!skip # Python 2.6 is unsupported
+plugins/modules/zos_job_submit.py pylint:catching-non-exception

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -83,4 +83,3 @@ plugins/modules/zos_tso_command.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_gather_facts.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_gather_facts.py import-2.6!skip # Python 2.6 is unsupported
-plugins/modules/zos_job_submit.py pylint:catching-non-exception

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -58,6 +58,7 @@ plugins/modules/zos_job_submit.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
 plugins/modules/zos_job_submit.py validate-modules:undocumented-parameter # Passing args from action plugin
+plugins/modules/zos_job_submit.py pylint:catching-non-exception # False positive, Exception is inherited
 plugins/modules/zos_lineinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_lineinfile.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_lineinfile.py import-2.6!skip # Python 2.6 is unsupported

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -58,6 +58,7 @@ plugins/modules/zos_job_submit.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
 plugins/modules/zos_job_submit.py validate-modules:undocumented-parameter # Passing args from action plugin
+plugins/modules/zos_job_submit.py pylint:catching-non-exception # False positive, Exception is inherited
 plugins/modules/zos_lineinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_lineinfile.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_lineinfile.py import-2.6!skip # Python 2.6 is unsupported

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -58,6 +58,7 @@ plugins/modules/zos_job_submit.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
 plugins/modules/zos_job_submit.py validate-modules:undocumented-parameter # Passing args from action plugin
+plugins/modules/zos_job_submit.py pylint:catching-non-exception # False positive, Exception is inherited
 plugins/modules/zos_lineinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_lineinfile.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_lineinfile.py import-2.6!skip # Python 2.6 is unsupported

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -58,6 +58,7 @@ plugins/modules/zos_job_submit.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
 plugins/modules/zos_job_submit.py validate-modules:undocumented-parameter # Passing args from action plugin
+plugins/modules/zos_job_submit.py pylint:catching-non-exception # False positive, Exception is inherited
 plugins/modules/zos_lineinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_lineinfile.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_lineinfile.py import-2.6!skip # Python 2.6 is unsupported

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -58,6 +58,7 @@ plugins/modules/zos_job_submit.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_job_submit.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
 plugins/modules/zos_job_submit.py validate-modules:undocumented-parameter # Passing args from action plugin
+plugins/modules/zos_job_submit.py pylint:catching-non-exception # False positive, Exception is inherited
 plugins/modules/zos_lineinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_lineinfile.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_lineinfile.py import-2.6!skip # Python 2.6 is unsupported
@@ -82,3 +83,4 @@ plugins/modules/zos_tso_command.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_gather_facts.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_gather_facts.py import-2.6!skip # Python 2.6 is unsupported
+plugins/modules/zos_job_submit.py pylint:catching-non-exception

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -83,4 +83,3 @@ plugins/modules/zos_tso_command.py import-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_gather_facts.py compile-2.6!skip # Python 2.6 is unsupported
 plugins/modules/zos_gather_facts.py import-2.6!skip # Python 2.6 is unsupported
-plugins/modules/zos_job_submit.py pylint:catching-non-exception


### PR DESCRIPTION
Signed-off-by: ddimatos <dimatos@gmail.com>

I locally validated that collection `ibm_zos_core` version 1.5.0-beta.1 have passed ansible-core ansible-test for versions 2.11, 2.12, 2.13, 2.14.

A false positive did come from pylint , i updated the version as well and still continued to get "Catching an exception which doesn't inherit from Exception" see [doc](https://pylint.pycqa.org/en/latest/user_guide/messages/error/catching-non-exception.html).

I reviewed the source in ZOAU that was being raised and it was correct. I think the issue is pylint can't find the ZOAU API which is on the managed node not the local machine. 
##### SUMMARY
Notes taken during validation:
```
ddimatos:[ ~/git/github/ibm_zos_core ]make build
====================================================================
Building Ansible collection based on local branch and installing.
====================================================================
Created collection for ibm.ibm_zos_core at /Users/ddimatos/git/github/ibm_zos_core/ibm-ibm_zos_core-1.5.0-beta.1.tar.gz
Starting galaxy collection install process
[WARNING]: Collection at '/Users/ddimatos/.ansible/collections/ansible_collections/playbooks/group_vars' does not have a MANIFEST.json file, nor
has it galaxy.yml: cannot detect version.
[WARNING]: Collection at '/Users/ddimatos/.ansible/collections/ansible_collections/playbooks/files' does not have a MANIFEST.json file, nor has it
galaxy.yml: cannot detect version.
Process install dependency map
Starting collection install process
Installing 'ibm.ibm_zos_core:1.5.0-beta.1' to '/Users/ddimatos/.ansible/collections/ansible_collections/ibm/ibm_zos_core'
ibm.ibm_zos_core:1.5.0-beta.1 was installed successfully


====================================================================
ansible-test , ansible-core 2.11
====================================================================
ddimatos:[ ~/git/github/ibm_zos_core ]venv-2.11/bin/ansible --version
ansible [core 2.11.12]
  config file = /Users/ddimatos/git/github/ibm_zos_core/ansible.cfg
  configured module search path = ['/Users/ddimatos/.ansible/collections/ansible_collections/ibm/ibm_zos_core/plugins/modules']
  ansible python module location = /Users/ddimatos/git/github/ibm_zos_core/venv-2.11/lib/python3.8/site-packages/ansible
  ansible collection location = /Users/ddimatos/.ansible/collections:/usr/share/ansible/collections
  executable location = venv-2.11/bin/ansible
  python version = 3.8.13 (default, Jun 14 2022, 23:29:22) [Clang 13.0.0 (clang-1300.0.27.3)]
  jinja version = 3.1.2
  libyaml = True
  
ddimatos:[ ~/git/github/ibm_zos_core ]export VENV=venv-2.11
ddimatos:[ ~/git/github/ibm_zos_core ]make sanity version=3.8
Running sanity test 'action-plugin-docs' with Python 3.8
Running sanity test 'ansible-doc' with Python 3.8
Running sanity test 'changelog' with Python 3.8
Running sanity test 'compile' with Python 3.8
Running sanity test 'empty-init' with Python 3.8
Running sanity test 'future-import-boilerplate' with Python 3.8
Running sanity test 'ignores'
Running sanity test 'import' with Python 3.8
Collecting cryptography<3.4
  Using cached cryptography-3.3.2-cp36-abi3-macosx_10_10_x86_64.whl (1.8 MB)
Collecting six>=1.4.1
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting cffi>=1.12
  Using cached cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl (178 kB)
Collecting pycparser
  Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)
Installing collected packages: six, pycparser, cffi, cryptography
Successfully installed cffi-1.15.1 cryptography-3.3.2 pycparser-2.21 six-1.16.0
^[[ARunning sanity test 'line-endings' with Python 3.8
Running sanity test 'metaclass-boilerplate' with Python 3.8
Running sanity test 'no-assert' with Python 3.8
Running sanity test 'no-basestring' with Python 3.8
Running sanity test 'no-dict-iteritems' with Python 3.8
Running sanity test 'no-dict-iterkeys' with Python 3.8
Running sanity test 'no-dict-itervalues' with Python 3.8
Running sanity test 'no-get-exception' with Python 3.8
Running sanity test 'no-illegal-filenames' with Python 3.8
Running sanity test 'no-main-display' with Python 3.8
Running sanity test 'no-smart-quotes' with Python 3.8
Running sanity test 'no-unicode-literals' with Python 3.8
Running sanity test 'pep8' with Python 3.8
Running sanity test 'pslint'
Running sanity test 'pylint' with Python 3.8
Running sanity test 'replace-urlopen' with Python 3.8
Running sanity test 'runtime-metadata' with Python 3.8
Running sanity test 'shebang' with Python 3.8
Running sanity test 'shellcheck'
Running sanity test 'symlinks' with Python 3.8
Running sanity test 'use-argspec-type-path' with Python 3.8
Running sanity test 'use-compat-six' with Python 3.8
Running sanity test 'validate-modules' with Python 3.8
Running sanity test 'yamllint' with Python 3.8

====================================================================
ansible-test , ansible-core 2.12
====================================================================
ddimatos:[ ~/git/github/ibm_zos_core ]venv-2.12/bin/ansible --version
ansible [core 2.12.10]
  config file = /Users/ddimatos/git/github/ibm_zos_core/ansible.cfg
  configured module search path = ['/Users/ddimatos/.ansible/collections/ansible_collections/ibm/ibm_zos_core/plugins/modules']
  ansible python module location = /Users/ddimatos/git/github/ibm_zos_core/venv-2.12/lib/python3.8/site-packages/ansible
  ansible collection location = /Users/ddimatos/.ansible/collections:/usr/share/ansible/collections
  executable location = venv-2.12/bin/ansible
  python version = 3.8.13 (default, Jun 14 2022, 23:29:22) [Clang 13.0.0 (clang-1300.0.27.3)]
  jinja version = 3.1.2
  libyaml = True
  
ddimatos:[ ~/git/github/ibm_zos_core ]export VENV=venv-2.12
ddimatos:[ ~/git/github/ibm_zos_core ]make sanity version=3.8
Running sanity test 'action-plugin-docs' with Python 3.8
Running sanity test 'ansible-doc' with Python 3.8
Running sanity test 'changelog' with Python 3.8
Running sanity test 'compile' with Python 3.8
Running sanity test 'empty-init' with Python 3.8
Running sanity test 'future-import-boilerplate' with Python 3.8
Running sanity test 'ignores'
Running sanity test 'import' with Python 3.8
Collecting cryptography<3.4
  Using cached cryptography-3.3.2-cp36-abi3-macosx_10_10_x86_64.whl (1.8 MB)
Collecting cffi>=1.12
  Using cached cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl (178 kB)
Collecting six>=1.4.1
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting pycparser
  Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)
Installing collected packages: six, pycparser, cffi, cryptography
Successfully installed cffi-1.15.1 cryptography-3.3.2 pycparser-2.21 six-1.16.0
Running sanity test 'line-endings' with Python 3.8
Running sanity test 'metaclass-boilerplate' with Python 3.8
Running sanity test 'no-assert' with Python 3.8
Running sanity test 'no-basestring' with Python 3.8
Running sanity test 'no-dict-iteritems' with Python 3.8
Running sanity test 'no-dict-iterkeys' with Python 3.8
Running sanity test 'no-dict-itervalues' with Python 3.8
Running sanity test 'no-get-exception' with Python 3.8
Running sanity test 'no-illegal-filenames' with Python 3.8
Running sanity test 'no-main-display' with Python 3.8
Running sanity test 'no-smart-quotes' with Python 3.8
Running sanity test 'no-unicode-literals' with Python 3.8
Running sanity test 'pep8' with Python 3.8
Running sanity test 'pslint'
Running sanity test 'pylint' with Python 3.8
Running sanity test 'replace-urlopen' with Python 3.8
Running sanity test 'runtime-metadata' with Python 3.8
Running sanity test 'shebang' with Python 3.8
Running sanity test 'shellcheck'
Running sanity test 'symlinks' with Python 3.8
Running sanity test 'use-argspec-type-path' with Python 3.8
Running sanity test 'use-compat-six' with Python 3.8
Running sanity test 'validate-modules' with Python 3.8
Running sanity test 'yamllint' with Python 3.8

====================================================================
ansible-test , ansible-core 2.13
====================================================================
ddimatos:[ ~/git/github/ibm_zos_core ]venv-2.13/bin/ansible --version
ansible [core 2.13.7]
  config file = /Users/ddimatos/git/github/ibm_zos_core/ansible.cfg
  configured module search path = ['/Users/ddimatos/.ansible/collections/ansible_collections/ibm/ibm_zos_core/plugins/modules']
  ansible python module location = /Users/ddimatos/git/github/ibm_zos_core/venv-2.13/lib/python3.8/site-packages/ansible
  ansible collection location = /Users/ddimatos/.ansible/collections:/usr/share/ansible/collections
  executable location = venv-2.13/bin/ansible
  python version = 3.8.13 (default, Jun 14 2022, 23:29:22) [Clang 13.0.0 (clang-1300.0.27.3)]
  jinja version = 3.1.2
  libyaml = True
  
ddimatos:[ ~/git/github/ibm_zos_core ]export VENV=venv-2.13
ddimatos:[ ~/git/github/ibm_zos_core ]make sanity version=3.8
Running sanity test 'action-plugin-docs' with Python 3.8
Running sanity test 'ansible-doc' with Python 3.8
Running sanity test 'changelog' with Python 3.8
Running sanity test 'compile' with Python 3.8
Running sanity test 'empty-init' with Python 3.8
Running sanity test 'future-import-boilerplate' with Python 3.8
Running sanity test 'ignores'
Running sanity test 'import' with Python 3.8
Collecting cryptography<3.4
  Using cached cryptography-3.3.2-cp36-abi3-macosx_10_10_x86_64.whl (1.8 MB)
Collecting six>=1.4.1
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting cffi>=1.12
  Using cached cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl (178 kB)
Collecting pycparser
  Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)
Installing collected packages: six, pycparser, cffi, cryptography
Successfully installed cffi-1.15.1 cryptography-3.3.2 pycparser-2.21 six-1.16.0
Running sanity test 'line-endings' with Python 3.8
Running sanity test 'metaclass-boilerplate' with Python 3.8
Running sanity test 'no-assert' with Python 3.8
Running sanity test 'no-basestring' with Python 3.8
Running sanity test 'no-dict-iteritems' with Python 3.8
Running sanity test 'no-dict-iterkeys' with Python 3.8
Running sanity test 'no-dict-itervalues' with Python 3.8
Running sanity test 'no-get-exception' with Python 3.8
Running sanity test 'no-illegal-filenames' with Python 3.8
Running sanity test 'no-main-display' with Python 3.8
Running sanity test 'no-smart-quotes' with Python 3.8
Running sanity test 'no-unicode-literals' with Python 3.8
Running sanity test 'pep8' with Python 3.8
Running sanity test 'pslint'
Running sanity test 'pylint' with Python 3.8
Running sanity test 'replace-urlopen' with Python 3.8
Running sanity test 'runtime-metadata' with Python 3.8
Running sanity test 'shebang' with Python 3.8
Running sanity test 'shellcheck'
Running sanity test 'symlinks' with Python 3.8
Running sanity test 'use-argspec-type-path' with Python 3.8
Running sanity test 'use-compat-six' with Python 3.8
Running sanity test 'validate-modules' with Python 3.8
Running sanity test 'yamllint' with Python 3.8
ddimatos:[ ~/git/github/ibm_zos_core ]make sanity version=3.8

====================================================================
ansible-test , ansible-core 2.14
====================================================================
ddimatos:[ ~/git/github/ibm_zos_core ]venv-2.14/bin/ansible --version
ansible [core 2.14.1]
  config file = /Users/ddimatos/git/github/ibm_zos_core/ansible.cfg
  configured module search path = ['/Users/ddimatos/.ansible/collections/ansible_collections/ibm/ibm_zos_core/plugins/modules']
  ansible python module location = /Users/ddimatos/git/github/ibm_zos_core/venv-2.14/lib/python3.9/site-packages/ansible
  ansible collection location = /Users/ddimatos/.ansible/collections:/usr/share/ansible/collections
  executable location = venv-2.14/bin/ansible
  python version = 3.9.0 (default, Jun 15 2022, 14:18:57) [Clang 13.0.0 (clang-1300.0.27.3)] (/Users/ddimatos/git/github/ibm_zos_core/venv-2.14/bin/python3)
  jinja version = 3.1.2
  libyaml = True
  
ddimatos:[ ~/git/github/ibm_zos_core ]echo $VENV
venv-2.14
ddimatos:[ ~/git/github/ibm_zos_core ]make sanity version=3.8
Running sanity test 'action-plugin-docs' with Python 3.8
Running sanity test 'ansible-doc' with Python 3.8
Running sanity test 'changelog' with Python 3.8
Running sanity test 'compile' with Python 3.8
Running sanity test 'empty-init' with Python 3.8
Running sanity test 'future-import-boilerplate' with Python 3.8
Running sanity test 'ignores'
Running sanity test 'import' with Python 3.8
Collecting cryptography<3.4
  Using cached cryptography-3.3.2-cp36-abi3-macosx_10_10_x86_64.whl (1.8 MB)
Collecting cffi>=1.12
  Using cached cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl (178 kB)
Collecting six>=1.4.1
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting pycparser
  Using cached pycparser-2.21-py2.py3-none-any.whl (118 kB)
Installing collected packages: six, pycparser, cffi, cryptography
Successfully installed cffi-1.15.1 cryptography-3.3.2 pycparser-2.21 six-1.16.0
Running sanity test 'line-endings' with Python 3.8
Running sanity test 'metaclass-boilerplate' with Python 3.8
Running sanity test 'no-assert' with Python 3.8
Running sanity test 'no-basestring' with Python 3.8
Running sanity test 'no-dict-iteritems' with Python 3.8
Running sanity test 'no-dict-iterkeys' with Python 3.8
Running sanity test 'no-dict-itervalues' with Python 3.8
Running sanity test 'no-get-exception' with Python 3.8
Running sanity test 'no-illegal-filenames' with Python 3.8
Running sanity test 'no-main-display' with Python 3.8
Running sanity test 'no-smart-quotes' with Python 3.8
Running sanity test 'no-unicode-literals' with Python 3.8
Running sanity test 'pep8' with Python 3.8
Running sanity test 'pslint'
Running sanity test 'pylint' with Python 3.8
Running sanity test 'replace-urlopen' with Python 3.8
Running sanity test 'runtime-metadata' with Python 3.8
Running sanity test 'shebang' with Python 3.8
Running sanity test 'shellcheck'
Running sanity test 'symlinks' with Python 3.8
Running sanity test 'use-argspec-type-path' with Python 3.8
Running sanity test 'use-compat-six' with Python 3.8
Running sanity test 'validate-modules' with Python 3.8
Running sanity test 'yamllint' with Python 3.8

```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
