### PR TITLE
Bugfix/601 copy lib member 1.5.0

### DIFF
--- a/changelogs/fragments/601-copy-loadlib-member.yml
+++ b/changelogs/fragments/601-copy-loadlib-member.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- zos_copy - fixes a bug where copying a member from a loadlib to another
+  loadlib fails. (https://github.com/ansible-collections/ibm_zos_core/pull/640)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1359,7 +1359,7 @@ class PDSECopyHandler(CopyHandler):
             # both program object members and data members. This can be
             # resolved by copying the program object with a "-X" flag.
             # *****************************************************************
-            if "FSUM8976" in err and "EDC5091I" in err:
+            if ("FSUM8976" in err and "EDC5091I" in err) or ("FSUM8976" in out and "EDC5091I" in out):
                 opts["options"] = "-X"
                 response = datasets._copy(src, dest, None, **opts)
                 rc, out, err = response.rc, response.stdout_response, response.stderr_response


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed error when a load lib member was copied to another load lib. Apparently error is found in stdout instead of err.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #601 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
