### PR TITLE
Corrects zos_data_set default record format FB breaking VSAM

### DIFF
--- a/changelogs/fragments/647-zos_data_set_record_format.yml
+++ b/changelogs/fragments/647-zos_data_set_record_format.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- zos_data_set - fixes a bug where the default record format FB was actually
+  never enforced and when enforced it would cause VSAM creation to fail with a
+  Dynalloc failure. This also cleans up some of the options that are set by
+  default when they have no bearing for batch. 
+  (https://github.com/ansible-collections/ibm_zos_core/pull/647)

--- a/docs/source/modules/zos_data_set.rst
+++ b/docs/source/modules/zos_data_set.rst
@@ -132,6 +132,8 @@ record_format
 
   Choices are case-insensitive.
 
+  When *type=KSDS*, *type=ESDS*, *type=RRDS*, *type=LDS* or *type=ZFS* then *record_format=None*, these types do not have a default *record_format*.
+
   | **required**: False
   | **type**: str
   | **default**: FB
@@ -378,6 +380,8 @@ batch
     The format of the data set. (e.g ``FB``)
 
     Choices are case-insensitive.
+
+    When *type=KSDS*, *type=ESDS*, *type=RRDS*, *type=LDS* or *type=ZFS* then *record_format=None*, these types do not have a default *record_format*.
 
     | **required**: False
     | **type**: str

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1238,7 +1238,6 @@ def run_module():
             # For VSAM types set the value to nothing and let the code manage it
             module.params["record_format"] = None
 
-
     if not module.check_mode:
         try:
             # Update the dictionary for use by better arg parser by adding the

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -141,6 +141,9 @@ options:
     description:
       - The format of the data set. (e.g C(FB))
       - Choices are case-insensitive.
+      - When I(type=KSDS), I(type=ESDS), I(type=RRDS), I(type=LDS) or I(type=ZFS)
+        then I(record_format=None), these types do not have a default
+        I(record_format).
     required: false
     choices:
       - FB
@@ -366,6 +369,9 @@ options:
         description:
           - The format of the data set. (e.g C(FB))
           - Choices are case-insensitive.
+          - When I(type=KSDS), I(type=ESDS), I(type=RRDS), I(type=LDS) or
+            I(type=ZFS) then I(record_format=None), these types do not have a
+            default I(record_format).
         required: false
         choices:
           - FB

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -631,6 +631,14 @@ DEFAULT_RECORD_LENGTHS = {
     "U": 0,
 }
 
+DATA_SET_TYPES_VSAM = [
+    "KSDS",
+    "ESDS",
+    "RRDS",
+    "LDS",
+    "ZFS",
+]
+
 # ------------- Functions to validate arguments ------------- #
 
 
@@ -1203,6 +1211,33 @@ def run_module():
     result = dict(changed=False, message="", names=[])
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    # This evaluation will always occur as a result of the limitation on the
+    # better arg parser, this will serve as a solution for now and ensure
+    # the non-batch and batch arguments are correctly set
+    if module.params.get("batch") is not None:
+        for entry in module.params.get("batch"):
+            if entry.get('type') is not None and entry.get("type").upper() in DATA_SET_TYPES_VSAM:
+                entry["record_format"] = None
+        if module.params.get("type") is not None:
+            module.params["type"] = None
+        if module.params.get("state") is not None:
+            module.params["state"] = None
+        if module.params.get("space_type") is not None:
+            module.params["space_type"] = None
+        if module.params.get("space_primary") is not None:
+            module.params["space_primary"] = None
+        if module.params.get("space_secondary") is not None:
+            module.params["space_secondary"] = None
+        if module.params.get("replace") is not None:
+            module.params["replace"] = None
+        if module.params.get("record_format") is not None:
+            module.params["record_format"] = None
+    elif module.params.get("type") is not None:
+        if module.params.get("type").upper() in DATA_SET_TYPES_VSAM:
+            # For VSAM types set the value to nothing and let the code manage it
+            module.params["record_format"] = None
+
 
     if not module.check_mode:
         try:

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -149,6 +149,7 @@ options:
       - VBA
       - U
     type: str
+    default: FB
   sms_storage_class:
     description:
       - The storage class for an SMS-managed dataset.
@@ -373,6 +374,7 @@ options:
           - VBA
           - U
         type: str
+        default: FB
       sms_storage_class:
         description:
           - The storage class for an SMS-managed dataset.
@@ -1118,7 +1120,7 @@ def run_module():
                 space_type=dict(type="str", required=False, default="M"),
                 space_primary=dict(type="int", required=False, aliases=["size"], default=5),
                 space_secondary=dict(type="int", required=False, default=3),
-                record_format=dict(type="str", required=False, aliases=["format"]),
+                record_format=dict(type="str", required=False, aliases=["format"], default="FB"),
                 sms_management_class=dict(type="str", required=False),
                 # I know this alias is odd, ZOAU used to document they supported
                 # SMS data class when they were actually passing as storage class
@@ -1162,7 +1164,7 @@ def run_module():
         space_type=dict(type="str", required=False, default="M"),
         space_primary=dict(type="raw", required=False, aliases=["size"], default=5),
         space_secondary=dict(type="int", required=False, default=3),
-        record_format=dict(type="str", required=False, aliases=["format"]),
+        record_format=dict(type="str", required=False, aliases=["format"], default="FB"),
         sms_management_class=dict(type="str", required=False),
         # I know this alias is odd, ZOAU used to document they supported
         # SMS data class when they were actually passing as storage class

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def z_python_interpreter(request):
 def clean_logs(adhoc):
     """Attempt to clean up logs and messages on the system."""
     # purge logs
-    # adhoc.all.command(cmd="opercmd '$PJ(*)'")
+    adhoc.all.command(cmd="opercmd '$PJ(*)'")
     # clean up wtor messages
     results = adhoc.all.command(cmd="uname -n")
     system_name = ""


### PR DESCRIPTION
##### SUMMARY
This addresses issues #638 and #646 such that when the default value for record format FB was set it was was also set for VSAM and this would break VSAM data set creation. It did not make sense to not have a default so it was added back after going through the changes enforced by ansible 2.14. This code adds the correcting behavior.
```
BGYSC1402E Dynalloc ' 'Failure. Error Code: ' '0x9700, Information Code: '"0x00\\n
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME


See git issue #646 for more detals

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
