### PR TITLE
Add max_rc support for module zos_tso_command

### DIFF
--- a/changelogs/fragments/565-zos_tsocommand_maxrc.yml
+++ b/changelogs/fragments/565-zos_tsocommand_maxrc.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - zos_tso_command - was enhanced to accept 'max_rc' as a value.
+    This value allows non-0 return codes to succeed, if the customer deems it appropriate.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/666)

--- a/changelogs/fragments/565-zos_tsocommand_maxrc.yml
+++ b/changelogs/fragments/565-zos_tsocommand_maxrc.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - zos_tso_command - was enhanced to accept 'max_rc' as a value.
-    This value allows non-0 return codes to succeed, if the customer deems it appropriate.
+  - zos_tso_command - was enhanced to accept `max_rc` as an option. This option
+    allows a non-zero return code to succeed as valid return code. 
     (https://github.com/ansible-collections/ibm_zos_core/pull/666)

--- a/changelogs/fragments/565-zos_tsocommand_maxrc.yml
+++ b/changelogs/fragments/565-zos_tsocommand_maxrc.yml
@@ -1,4 +1,0 @@
-minor_changes:
-  - zos_tso_command - was enhanced to accept `max_rc` as an option. This option
-    allows a non-zero return code to succeed as valid return code. 
-    (https://github.com/ansible-collections/ibm_zos_core/pull/666)

--- a/changelogs/fragments/666-zos_tso_command_maxrc.yml
+++ b/changelogs/fragments/666-zos_tso_command_maxrc.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - zos_tso_command - was enhanced to accept `max_rc` as an option. This option
+    allows a non-zero return code to succeed as a valid return code.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/666)

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -20,11 +20,12 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 module: zos_tso_command
 version_added: '1.1.0'
-author: "Xiao Yuan Ma (@bjmaxy)"
 short_description: Execute TSO commands
 description:
-    - Execute TSO commands on the target z/OS system with the provided options
-      and receive a structured response.
+    - Execute TSO commands on the target z/OS system with the provided options and receive a structured response.
+author:
+    - "Xiao Yuan Ma (@bjmaxy)"
+    - "Rich Parker (@richp405)"
 options:
   commands:
     description:
@@ -66,8 +67,7 @@ output:
         max_rc:
             description:
                 - Specifies the maximum return code allowed for a TSO command.
-                - If more than one TSO command is submitted, the I(max_rc) applies to all
-                TSO commands.
+                - If more than one TSO command is submitted, the I(max_rc) applies to all TSO commands.
             returned: always
             type: int
             sample: 0
@@ -239,7 +239,8 @@ def run_module():
 
         if errors_found:
             module.fail_json(
-                msg = "Some ({0}) command(s) failed:\n{1}".format(errors_found, result_string), **result
+                msg="Some ({0}) command(s) failed:\n{1}".format(errors_found, result_string),
+                **result
             )
 
         result["changed"] = True

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -36,7 +36,9 @@ options:
         - command
   max_rc:
     description:
-        - maximum allowable return code before an exception/failure is triggered
+        - Specifies the maximum return code allowed for a TSO command.
+        - If more than one TSO command is submitted, the I(max_rc) applies to all TSO commands.
+    default: 0
     required: false
     type: int
 
@@ -101,7 +103,7 @@ EXAMPLES = r"""
       commands:
            - LU TESTUSER
 
-- name: Execute TSO command to list databases (allow 4 for no cert found)
+- name: Execute TSO command to list dataset data (allow 4 for no dataset listed or cert found)
   zos_tso_command:
       commands:
            - listdsd
@@ -153,7 +155,7 @@ def copy_rexx_and_run_commands(script, commands, module, max_rc):
         command_results["rc"] = rc
         command_results["content"] = stdout.split("\n")
         command_results["lines"] = len(command_results.get("content", []))
-        command_results["stderror"] = stderr
+        command_results["stderr"] = stderr
         command_detail_json.append(command_results)
     return command_detail_json
 
@@ -181,7 +183,7 @@ def list_or_str_type(contents, dependencies):
 def run_module():
     module_args = dict(
         commands=dict(type="raw", required=True, aliases=["command"]),
-        max_rc=dict(type="int", required=False),
+        max_rc=dict(type="int", required=False, default=0),
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
@@ -191,7 +193,7 @@ def run_module():
 
     arg_defs = dict(
         commands=dict(type=list_or_str_type, required=True, aliases=["command"]),
-        max_rc=dict(type="int", required=False),
+        max_rc=dict(type="int", required=False, default=0),
     )
     try:
         parser = BetterArgParser(arg_defs)

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -176,7 +176,7 @@ def list_or_str_type(contents, dependencies):
 def run_module():
     module_args = dict(
         commands=dict(type="raw", required=True, aliases=["command"]),
-        max_rc=dict(type="int", required=False ),
+        max_rc=dict(type="int", required=False),
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2023
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -209,8 +209,12 @@ def run_module():
                     + '" execution failed.  RC was {0}; Max RC was {1}.'.format(cmd.get("rc"), max_rc),
                     **result
                 )
+            else:
+                cmd["changed"] = True
+                cmd["failed"] = False
 
         result["changed"] = True
+        result["failed"] = False
         module.exit_json(**result)
 
     except Exception as e:

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -224,7 +224,10 @@ def run_module():
             tmp_string = 'Command "' + cmd.get("command", "") + '" execution'
             if cmd.get("rc") > max_rc:
                 errors_found = True
-                result_list.append(tmp_string + "failed.  RC was {0}; max_rc was {1}".format(cmd.get("rc"), max_rc))
+                if max_rc > 0:
+                    result_list.append(tmp_string + "failed.  RC was {0}; max_rc was {1}".format(cmd.get("rc"), max_rc))
+                else:
+                    result_list.append(tmp_string + "failed.  RC was {0}.".format(cmd.get("rc")))
             else:
                 result_list.append(tmp_string + "succeeded.  RC was {0}.".format(cmd.get("rc")))
 

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -191,6 +191,7 @@ def run_module():
 
     arg_defs = dict(
         commands=dict(type=list_or_str_type, required=True, aliases=["command"]),
+        max_rc=dict(type="int", required=False),
     )
     try:
         parser = BetterArgParser(arg_defs)

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -218,11 +218,10 @@ def run_module():
         result["output"] = run_tso_command(commands, module, max_rc)
         result["max_rc"] = max_rc
         errors_found = False
-        result_string = ""
+        result_list = []
 
         for cmd in result.get("output"):
             tmp_string = 'Command "' + cmd.get("command", "") + '" execution'
-            tmp_string2 = ''
             if cmd.get("rc") > max_rc:
                 # module.fail_json(
                 #     msg='The TSO command "'
@@ -231,13 +230,13 @@ def run_module():
                 #     **result
                 # )
                 errors_found = True
-                tmp_string2 = tmp_string + "failed.  RC was {0}; Max RC was {1}".format(cmd.get("rc"), max_rc)
+                result_list.append(tmp_string + "failed.  RC was {0}; Max RC was {1}".format(cmd.get("rc"), max_rc))
             else:
-                tmp_string2 = tmp_string + "succeeded.  RC was {0}.".format(cmd.get("rc"))
-
-            result_string = result_string + "\n" + tmp_string2
+                result_list.append(tmp_string + "succeeded.  RC was {0}.".format(cmd.get("rc")))
 
         if errors_found:
+            result_string = "\n".join(result_list)
+
             module.fail_json(
                 msg="Some ({0}) command(s) failed:\n{1}".format(errors_found, result_string),
                 **result

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -101,10 +101,10 @@ EXAMPLES = r"""
       commands:
            - LU TESTUSER
 
-- name: Execute TSO command to list RACF Certificates (allow 4 for no cert found)
+- name: Execute TSO command to list databases (allow 4 for no cert found)
   zos_tso_command:
       commands:
-           - RADCERT LIST
+           - listdsd
       max_rc: 4
 
 """

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -223,14 +223,8 @@ def run_module():
         for cmd in result.get("output"):
             tmp_string = 'Command "' + cmd.get("command", "") + '" execution'
             if cmd.get("rc") > max_rc:
-                # module.fail_json(
-                #     msg='The TSO command "'
-                #     + cmd.get("command", "")
-                #     + '" execution failed.  RC was {0}; Max RC was {1}.'.format(cmd.get("rc"), max_rc),
-                #     **result
-                # )
                 errors_found = True
-                result_list.append(tmp_string + "failed.  RC was {0}; Max RC was {1}".format(cmd.get("rc"), max_rc))
+                result_list.append(tmp_string + "failed.  RC was {0}; max_rc was {1}".format(cmd.get("rc"), max_rc))
             else:
                 result_list.append(tmp_string + "succeeded.  RC was {0}.".format(cmd.get("rc")))
 

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -147,7 +147,7 @@ def copy_rexx_and_run_commands(script, commands, module, max_rc):
         command_results = {}
         command_results["command"] = command
         command_results["origrc"] = rc
-        if(rc <= max_rc):
+        if rc <= max_rc:
             rc = 0
             command_results["failed"] = False
         command_results["rc"] = rc

--- a/tests/functional/modules/test_zos_tso_command_func.py
+++ b/tests/functional/modules/test_zos_tso_command_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020
+# Copyright (c) IBM Corporation 2019, 2020, 2023
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/functional/modules/test_zos_tso_command_func.py
+++ b/tests/functional/modules/test_zos_tso_command_func.py
@@ -168,8 +168,6 @@ def test_zos_tso_command_maxrc(ansible_zos_module):
     hosts = ansible_zos_module
     results = hosts.all.zos_tso_command(commands=["LISTDSD"],max_rc=4)
     for result in results.contacted.values():
-        print( "=============================" )
-        print( result )
         for item in result.get("output"):
             print( item )
             assert item.get("rc") < 5

--- a/tests/functional/modules/test_zos_tso_command_func.py
+++ b/tests/functional/modules/test_zos_tso_command_func.py
@@ -166,7 +166,7 @@ def test_zos_tso_command_multiple_commands(ansible_zos_module):
 # The command that kicks off rc>0 which is allowed
 def test_zos_tso_command_maxrc(ansible_zos_module):
     hosts = ansible_zos_module
-    results = hosts.all.zos_tso_command(commands=["LISTDSD"],max_rc=4)
+    results = hosts.all.zos_tso_command(commands=["LISTDSD DATASET('HLQ.DATA.SET') ALL GENERIC"],max_rc=4)
     for result in results.contacted.values():
         for item in result.get("output"):
             print( item )

--- a/tests/functional/modules/test_zos_tso_command_func.py
+++ b/tests/functional/modules/test_zos_tso_command_func.py
@@ -160,3 +160,14 @@ def test_zos_tso_command_multiple_commands(ansible_zos_module):
         for item in result.get("output"):
             assert item.get("rc") == 0
         assert result.get("changed") is True
+
+
+# The positive test
+# The command that kicks off rc>0 which is allowed
+def test_zos_tso_command_maxrc(ansible_zos_module):
+    hosts = ansible_zos_module
+    results = hosts.all.zos_tso_command(commands=["LISTDSD"],max_rc=4)
+    for result in results.contacted.values():
+        for item in result.get("output"):
+            assert item.get("rc") < 5
+        assert result.get("changed") is True

--- a/tests/functional/modules/test_zos_tso_command_func.py
+++ b/tests/functional/modules/test_zos_tso_command_func.py
@@ -168,6 +168,9 @@ def test_zos_tso_command_maxrc(ansible_zos_module):
     hosts = ansible_zos_module
     results = hosts.all.zos_tso_command(commands=["LISTDSD"],max_rc=4)
     for result in results.contacted.values():
+        print( "=============================" )
+        print( result )
         for item in result.get("output"):
+            print( item )
             assert item.get("rc") < 5
         assert result.get("changed") is True


### PR DESCRIPTION
##### SUMMARY
Added max_rc as a parameter to tso_command
This allows return codes > 0 to pass:
  + (changed becomes true, 
  + failed becomes false
  + original rc in origrc
  + rc set to 0

Includes a new test that lists databases (that are not on ec's) to force an rc=4

Ticket #565 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zos_tso_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

Build passed:
![image](https://user-images.githubusercontent.com/39140439/224775718-2d7026bb-0b2c-4213-bea8-56df939c1d78.png)

