### PR TITLE
zos_blockinfile , can quotes in content can be supported

### DIFF
--- a/changelogs/fragments/417-can-quotes-in-content-can-be-supported.yml
+++ b/changelogs/fragments/417-can-quotes-in-content-can-be-supported.yml
@@ -1,3 +1,3 @@
 bugfixes:
-- The use of quotes for any sentence is now in use for the users in blockinfile module
-- The message for the user about a correct insertion includes the quotes
+- The use of quotes for any sentence it wasn't support in use for the users in blockinfile module
+- The message for the user about a correct insertion did not include the quotes

--- a/changelogs/fragments/417-can-quotes-in-content-can-be-supported.yml
+++ b/changelogs/fragments/417-can-quotes-in-content-can-be-supported.yml
@@ -1,3 +1,5 @@
 bugfixes:
-- The use of quotes for any sentence it wasn't support in use for the users in blockinfile module
-- The message for the user about a correct insertion did not include the quotes
+- zos_blockinfile - was unable to use double quotes which prevented some use
+  cases and did not display an approriate message. The fix now allows for
+  double quotes to be used with the module. 
+  (https://github.com/ansible-collections/ibm_zos_core/pull/680)

--- a/changelogs/fragments/417-can-quotes-in-content-can-be-supported.yml
+++ b/changelogs/fragments/417-can-quotes-in-content-can-be-supported.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- The use of quotes for any sentence is now in use for the users in blockinfile module
+- The message for the user about a correct insertion includes the quotes

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -567,6 +567,9 @@ def main():
         # Try to extract information from stdout
         ret = json.loads(stdout)
         ret['cmd'] = ret['cmd'].replace("u'",'"')
+        ret['changed'] = ret['changed'].replace("u'",'"')
+        ret['found'] = ret['found'].replace("u'",'"')
+
         result['cmd'] = ret['cmd']
         result['changed'] = ret['changed']
         result['found'] = ret['found']

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -389,6 +389,7 @@ def quotedString(string):
         return string
     return string.replace('"', "")
 
+
 def quotedString_outputJson(string):
     if not isinstance(string, str):
         return string
@@ -564,13 +565,12 @@ def main():
         stdout = stdout.replace('/i\\', '/i\\\\')
         stdout = stdout.replace('$ a\\', '$ a\\\\')
         stdout = stdout.replace('1 i\\', '1 i\\\\')
-
         if block:
-          stdout = stdout.replace(block, quotedString_outputJson(block))
+            stdout = stdout.replace(block, quotedString_outputJson(block))
         if ins_aft:
-          stdout = stdout.replace(ins_aft, quotedString_outputJson(ins_aft))
+            stdout = stdout.replace(ins_aft, quotedString_outputJson(ins_aft))
         if ins_bef:
-          stdout = stdout.replace(ins_bef, quotedString_outputJson(ins_bef))
+            stdout = stdout.replace(ins_bef, quotedString_outputJson(ins_bef))
         # Try to extract information from stdout
         ret = json.loads(stdout)
         ret['cmd'] = ret['cmd'].replace("u'", '"')

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -245,6 +245,14 @@ EXAMPLES = r'''
           RUN  PROGRAM(DSNTEP2) PLAN(DSNTEP12) -
           LIB('{{ DB2RUN }}.RUNLIB.LOAD')
     indentation: 16
+
+- name: Update a script with commands at the end
+  zos_blockinfile:
+    src: "/u/scripts/script.sh"
+    insertafter: "EOF"
+    block: |
+          cat "//'{{ DS_NAME }}'"
+          cat "//'{{ DS_NAME_2 }}'"
 '''
 
 RETURN = r"""

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -393,7 +393,6 @@ def quotedString_outputJson(string):
     if not isinstance(string, str):
         return string
     return string.replace('"', "u'")
-    #return string.replace('\', "")
 
 
 def main():
@@ -571,7 +570,7 @@ def main():
         if ins_aft:
           stdout = stdout.replace(ins_aft, quotedString_outputJson(ins_aft))
         if ins_bef:
-            stdout = stdout.replace(ins_bef, quotedString_outputJson(ins_bef))
+          stdout = stdout.replace(ins_bef, quotedString_outputJson(ins_bef))
         # Try to extract information from stdout
         ret = json.loads(stdout)
         ret['cmd'] = ret['cmd'].replace("u'",'"')
@@ -584,8 +583,8 @@ def main():
         if len(stderr):
             result['stderr'] = str(stderr)
             result['rc'] = rc
-    except Exception as e:
-        messageDict = dict(msg="ZOAU dmod return content is NOT in json format", stdout=str(stdout), stderr=str(stderr), rc=rc, e=e)
+    except Exception:
+        messageDict = dict(msg="ZOAU dmod return content is NOT in json format", stdout=str(stdout), stderr=str(stderr), rc=rc)
         if result.get('backup_name'):
             messageDict['backup_name'] = result['backup_name']
         module.fail_json(**messageDict)

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -246,7 +246,7 @@ EXAMPLES = r'''
           LIB('{{ DB2RUN }}.RUNLIB.LOAD')
     indentation: 16
 
-- name: Update a script with commands at the end
+- name: Update a script with commands containing quotes.
   zos_blockinfile:
     src: "/u/scripts/script.sh"
     insertafter: "EOF"
@@ -390,7 +390,7 @@ def quotedString(string):
     return string.replace('"', "")
 
 
-def quotedString_outputJson(string):
+def quoted_string_output_json(string):
     if not isinstance(string, str):
         return string
     return string.replace('"', "u'")
@@ -566,11 +566,11 @@ def main():
         stdout = stdout.replace('$ a\\', '$ a\\\\')
         stdout = stdout.replace('1 i\\', '1 i\\\\')
         if block:
-            stdout = stdout.replace(block, quotedString_outputJson(block))
+            stdout = stdout.replace(block, quoted_string_output_json(block))
         if ins_aft:
-            stdout = stdout.replace(ins_aft, quotedString_outputJson(ins_aft))
+            stdout = stdout.replace(ins_aft, quoted_string_output_json(ins_aft))
         if ins_bef:
-            stdout = stdout.replace(ins_bef, quotedString_outputJson(ins_bef))
+            stdout = stdout.replace(ins_bef, quoted_string_output_json(ins_bef))
         # Try to extract information from stdout
         ret = json.loads(stdout)
         ret['cmd'] = ret['cmd'].replace("u'", '"')

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -573,7 +573,7 @@ def main():
           stdout = stdout.replace(ins_bef, quotedString_outputJson(ins_bef))
         # Try to extract information from stdout
         ret = json.loads(stdout)
-        ret['cmd'] = ret['cmd'].replace("u'",'"')
+        ret['cmd'] = ret['cmd'].replace("u'", '"')
 
         result['cmd'] = ret['cmd']
         result['changed'] = ret['changed']

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -567,8 +567,6 @@ def main():
         # Try to extract information from stdout
         ret = json.loads(stdout)
         ret['cmd'] = ret['cmd'].replace("u'",'"')
-        ret['changed'] = ret['changed'].replace("u'",'"')
-        ret['found'] = ret['found'].replace("u'",'"')
 
         result['cmd'] = ret['cmd']
         result['changed'] = ret['changed']

--- a/tests/functional/modules/test_zos_blockinfile_func.py
+++ b/tests/functional/modules/test_zos_blockinfile_func.py
@@ -133,6 +133,16 @@ export PKG_CONFIG_PATH
 export PYTHON_HOME
 export _BPXK_AUTOCVT"""
 
+TEST_CONTENT_DOUBLEQUOTES = """//BPXSLEEP JOB MSGCLASS=A,MSGLEVEL=(1,1),NOTIFY=&SYSUID,REGION=0M
+//USSCMD EXEC PGM=BPXBATCH
+//STDERR  DD SYSOUT=*
+//STDOUT  DD SYSOUT=*
+//STDPARM DD *
+SH ls -la /;
+sleep 30;
+/*
+//"""
+
 # supported data set types
 # DS_TYPE = ['SEQ', 'PDS', 'PDSE']
 DS_TYPE = ['SEQ']
@@ -204,6 +214,9 @@ TEST_INFO = dict(
     test_uss_block_insert_with_indentation_level_specified=dict(
         insertafter="EOF", block="export ZOAU_ROOT\nexport ZOAU_HOME\nexport ZOAU_DIR",
         state="present", indentation=16),
+    test_uss_block_insert_with_doublequotes=dict(
+        insertafter="EOF", block=r"""cat "//'OMVSADMI.CAT'"\ncat "//'OMVSADM.COPYMEM.TESTS'" > test.txt""", 
+        state="present"),
     test_ds_block_insertafter_regex=dict(test_name="T1"),
     test_ds_block_insertbefore_regex=dict(test_name="T2"),
     test_ds_block_insertafter_eof=dict(test_name="T3"),
@@ -264,6 +277,19 @@ export PYTHONPATH
 export PKG_CONFIG_PATH
 export PYTHON_HOME
 export _BPXK_AUTOCVT""",
+                  test_uss_block_insert_with_doublequotes="""//BPXSLEEP JOB MSGCLASS=A,MSGLEVEL=(1,1),NOTIFY=&SYSUID,REGION=0M
+//USSCMD EXEC PGM=BPXBATCH
+//STDERR  DD SYSOUT=*
+//STDOUT  DD SYSOUT=*
+//STDPARM DD *
+SH ls -la /;
+sleep 30;
+/*
+//
+# BEGIN ANSIBLE MANAGED BLOCK
+cat "//'OMVSADMI.CAT'"
+cat "//'OMVSADM.COPYMEM.TESTS'" > test.txt
+# END ANSIBLE MANAGED BLOCK""",
                   test_uss_block_insertbefore_regex_defaultmarker="""if [ -z STEPLIB ] && tty -s;
 then
     export STEPLIB=none
@@ -1173,6 +1199,15 @@ def test_uss_block_insert_with_indentation_level_specified(ansible_zos_module):
         TEST_ENV, TEST_INFO["test_uss_block_insert_with_indentation_level_specified"],
         TEST_INFO["expected"]["test_uss_block_insert_with_indentation_level_specified"])
 
+
+@pytest.mark.uss
+def test_uss_block_insert_with_doublequotes(ansible_zos_module):
+    TEST_ENV["TEST_CONT"] = TEST_CONTENT_DOUBLEQUOTES
+    UssGeneral(
+        "test_uss_block_insert_with_doublequotes", ansible_zos_module,TEST_ENV, 
+        TEST_INFO["test_uss_block_insert_with_doublequotes"],
+        TEST_INFO["expected"]["test_uss_block_insert_with_doublequotes"])
+    TEST_ENV["TEST_CONT"] = TEST_CONTENT
 
 @pytest.mark.uss
 def test_uss_block_insertafter_eof_with_backup(ansible_zos_module):

--- a/tests/functional/modules/test_zos_blockinfile_func.py
+++ b/tests/functional/modules/test_zos_blockinfile_func.py
@@ -215,7 +215,7 @@ TEST_INFO = dict(
         insertafter="EOF", block="export ZOAU_ROOT\nexport ZOAU_HOME\nexport ZOAU_DIR",
         state="present", indentation=16),
     test_uss_block_insert_with_doublequotes=dict(
-        insertafter="EOF", block='cat \"//OMVSADMI.CAT\"\ncat \"//OMVSADM.COPYMEM.TESTS\" > test.txt', 
+        insertafter="sleep 30;", block='cat \"//OMVSADMI.CAT\"\ncat \"//OMVSADM.COPYMEM.TESTS\" > test.txt', 
         marker="// {mark} ANSIBLE MANAGED BLOCK",state="present"),
     test_ds_block_insertafter_regex=dict(test_name="T1"),
     test_ds_block_insertbefore_regex=dict(test_name="T2"),
@@ -284,12 +284,12 @@ export _BPXK_AUTOCVT""",
 //STDPARM DD *
 SH ls -la /;
 sleep 30;
-/*
-//
 // BEGIN ANSIBLE MANAGED BLOCK
 cat "//OMVSADMI.CAT"
 cat "//OMVSADM.COPYMEM.TESTS" > test.txt
-// END ANSIBLE MANAGED BLOCK""",
+// END ANSIBLE MANAGED BLOCK
+/*
+//""",
                   test_uss_block_insertbefore_regex_defaultmarker="""if [ -z STEPLIB ] && tty -s;
 then
     export STEPLIB=none
@@ -930,6 +930,16 @@ export _BPXK_AUTOCVT
 
 
 @pytest.mark.uss
+def test_uss_block_insert_with_doublequotes(ansible_zos_module):
+    TEST_ENV["TEST_CONT"] = TEST_CONTENT_DOUBLEQUOTES
+    UssGeneral(
+        "test_uss_block_insert_with_doublequotes", ansible_zos_module,TEST_ENV, 
+        TEST_INFO["test_uss_block_insert_with_doublequotes"],
+        TEST_INFO["expected"]["test_uss_block_insert_with_doublequotes"])
+    TEST_ENV["TEST_CONT"] = TEST_CONTENT
+
+
+@pytest.mark.uss
 def test_uss_block_insertafter_regex_defaultmarker(ansible_zos_module):
     UssGeneral(
         "test_uss_block_insertafter_regex_defaultmarker", ansible_zos_module, TEST_ENV,
@@ -1200,14 +1210,14 @@ def test_uss_block_insert_with_indentation_level_specified(ansible_zos_module):
         TEST_INFO["expected"]["test_uss_block_insert_with_indentation_level_specified"])
 
 
-@pytest.mark.uss
-def test_uss_block_insert_with_doublequotes(ansible_zos_module):
-    TEST_ENV["TEST_CONT"] = TEST_CONTENT_DOUBLEQUOTES
-    UssGeneral(
-        "test_uss_block_insert_with_doublequotes", ansible_zos_module,TEST_ENV, 
-        TEST_INFO["test_uss_block_insert_with_doublequotes"],
-        TEST_INFO["expected"]["test_uss_block_insert_with_doublequotes"])
-    TEST_ENV["TEST_CONT"] = TEST_CONTENT
+#@pytest.mark.uss
+#def test_uss_block_insert_with_doublequotes(ansible_zos_module):
+#    TEST_ENV["TEST_CONT"] = TEST_CONTENT_DOUBLEQUOTES
+#    UssGeneral(
+#        "test_uss_block_insert_with_doublequotes", ansible_zos_module,TEST_ENV, 
+#        TEST_INFO["test_uss_block_insert_with_doublequotes"],
+#        TEST_INFO["expected"]["test_uss_block_insert_with_doublequotes"])
+#    TEST_ENV["TEST_CONT"] = TEST_CONTENT
 
 @pytest.mark.uss
 def test_uss_block_insertafter_eof_with_backup(ansible_zos_module):

--- a/tests/functional/modules/test_zos_blockinfile_func.py
+++ b/tests/functional/modules/test_zos_blockinfile_func.py
@@ -215,8 +215,8 @@ TEST_INFO = dict(
         insertafter="EOF", block="export ZOAU_ROOT\nexport ZOAU_HOME\nexport ZOAU_DIR",
         state="present", indentation=16),
     test_uss_block_insert_with_doublequotes=dict(
-        insertafter="EOF", block=r"""cat "//'OMVSADMI.CAT'"\ncat "//'OMVSADM.COPYMEM.TESTS'" > test.txt""", 
-        state="present"),
+        insertafter="EOF", block='cat \"//OMVSADMI.CAT\"\ncat \"//OMVSADM.COPYMEM.TESTS\" > test.txt', 
+        marker="// {mark} ANSIBLE MANAGED BLOCK",state="present"),
     test_ds_block_insertafter_regex=dict(test_name="T1"),
     test_ds_block_insertbefore_regex=dict(test_name="T2"),
     test_ds_block_insertafter_eof=dict(test_name="T3"),
@@ -286,10 +286,10 @@ SH ls -la /;
 sleep 30;
 /*
 //
-# BEGIN ANSIBLE MANAGED BLOCK
-cat "//'OMVSADMI.CAT'"
-cat "//'OMVSADM.COPYMEM.TESTS'" > test.txt
-# END ANSIBLE MANAGED BLOCK""",
+// BEGIN ANSIBLE MANAGED BLOCK
+cat "//OMVSADMI.CAT"
+cat "//OMVSADM.COPYMEM.TESTS" > test.txt
+// END ANSIBLE MANAGED BLOCK""",
                   test_uss_block_insertbefore_regex_defaultmarker="""if [ -z STEPLIB ] && tty -s;
 then
     export STEPLIB=none

--- a/tests/functional/modules/test_zos_blockinfile_func.py
+++ b/tests/functional/modules/test_zos_blockinfile_func.py
@@ -930,16 +930,6 @@ export _BPXK_AUTOCVT
 
 
 @pytest.mark.uss
-def test_uss_block_insert_with_doublequotes(ansible_zos_module):
-    TEST_ENV["TEST_CONT"] = TEST_CONTENT_DOUBLEQUOTES
-    UssGeneral(
-        "test_uss_block_insert_with_doublequotes", ansible_zos_module,TEST_ENV, 
-        TEST_INFO["test_uss_block_insert_with_doublequotes"],
-        TEST_INFO["expected"]["test_uss_block_insert_with_doublequotes"])
-    TEST_ENV["TEST_CONT"] = TEST_CONTENT
-
-
-@pytest.mark.uss
 def test_uss_block_insertafter_regex_defaultmarker(ansible_zos_module):
     UssGeneral(
         "test_uss_block_insertafter_regex_defaultmarker", ansible_zos_module, TEST_ENV,
@@ -1210,14 +1200,14 @@ def test_uss_block_insert_with_indentation_level_specified(ansible_zos_module):
         TEST_INFO["expected"]["test_uss_block_insert_with_indentation_level_specified"])
 
 
-#@pytest.mark.uss
-#def test_uss_block_insert_with_doublequotes(ansible_zos_module):
-#    TEST_ENV["TEST_CONT"] = TEST_CONTENT_DOUBLEQUOTES
-#    UssGeneral(
-#        "test_uss_block_insert_with_doublequotes", ansible_zos_module,TEST_ENV, 
-#        TEST_INFO["test_uss_block_insert_with_doublequotes"],
-#        TEST_INFO["expected"]["test_uss_block_insert_with_doublequotes"])
-#    TEST_ENV["TEST_CONT"] = TEST_CONTENT
+@pytest.mark.uss
+def test_uss_block_insert_with_doublequotes(ansible_zos_module):
+    TEST_ENV["TEST_CONT"] = TEST_CONTENT_DOUBLEQUOTES
+    UssGeneral(
+        "test_uss_block_insert_with_doublequotes", ansible_zos_module,TEST_ENV, 
+        TEST_INFO["test_uss_block_insert_with_doublequotes"],
+        TEST_INFO["expected"]["test_uss_block_insert_with_doublequotes"])
+    TEST_ENV["TEST_CONT"] = TEST_CONTENT
 
 @pytest.mark.uss
 def test_uss_block_insertafter_eof_with_backup(ansible_zos_module):


### PR DESCRIPTION
##### SUMMARY
To verify dmod function support a block with double quotes for users to add a reference or commands that need it


Bugfix #417 can quotes in content be supported
##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
Delete the case for delete the quotes in the block statement and add the function to keep the quotes in the final message for the user to know the quotes are keep as part of the block,

##### ADDITIONAL INFORMATION
Add additional test case for double quotes included in the block space 
 test_uss_block_insert_with_doublequotes
 TEST_CONTENT_DOUBLEQUOTES 
 
Create function to keep the double quotes to json format and the get back for Ansible response format
 quotedString_outputJson
 

