### PR TITLE
Bugfix/717/uss tag encoding

### DIFF
--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -454,21 +454,21 @@ class EncodeUtils(object):
         return convert_rc
 
     def uss_tag_encoding(self, file_path, tag):
-         """Tag the file/directory specified with the given code set.
-         If `file_path` is a directory, all of the files and subdirectories will
-         be tagged recursively.
-         Arguments:
-             file_path {str} -- Absolute file path to tag.
-             tag {str} -- Code set to tag the file/directory.
-         Raises:
-             TaggingError: When the chtag command fails.
-         """
-         is_dir = os.path.isdir(file_path)
+        """Tag the file/directory specified with the given code set.
+        If `file_path` is a directory, all of the files and subdirectories will
+        be tagged recursively.
+        Arguments:
+            file_path {str} -- Absolute file path to tag.
+            tag {str} -- Code set to tag the file/directory.
+        Raises:
+            TaggingError: When the chtag command fails.
+        """
+        is_dir = os.path.isdir(file_path)
 
-         tag_cmd = "chtag -{0}c {1} {2}".format("R" if is_dir else "t", tag, file_path)
-         rc, out, err = self.module.run_command(tag_cmd)
-         if rc != 0:
-             raise TaggingError(file_path, tag, rc, out, err)
+        tag_cmd = "chtag -{0}c {1} {2}".format("R" if is_dir else "t", tag, file_path)
+        rc, out, err = self.module.run_command(tag_cmd)
+        if rc != 0:
+            raise TaggingError(file_path, tag, rc, out, err)
 
     def uss_file_tag(self, file_path):
         """Returns the current tag set for a file.

--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -453,6 +453,23 @@ class EncodeUtils(object):
 
         return convert_rc
 
+    def uss_tag_encoding(self, file_path, tag):
+         """Tag the file/directory specified with the given code set.
+         If `file_path` is a directory, all of the files and subdirectories will
+         be tagged recursively.
+         Arguments:
+             file_path {str} -- Absolute file path to tag.
+             tag {str} -- Code set to tag the file/directory.
+         Raises:
+             TaggingError: When the chtag command fails.
+         """
+         is_dir = os.path.isdir(file_path)
+
+         tag_cmd = "chtag -{0}c {1} {2}".format("R" if is_dir else "t", tag, file_path)
+         rc, out, err = self.module.run_command(tag_cmd)
+         if rc != 0:
+             raise TaggingError(file_path, tag, rc, out, err)
+
     def uss_file_tag(self, file_path):
         """Returns the current tag set for a file.
         Arguments:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added a missing function which was called in zos_encode encode utils. Apparently it was removed somewhere in between this two commits:

https://github.com/ansible-collections/ibm_zos_core/commit/7fcd62a7b5f9cb2de0447f89c70c830a4dd8ee0b

https://github.com/ansible-collections/ibm_zos_core/commit/98315a49d6ec631ba53eb9414087fa67046507a6

I don't have any idea why. Strangely, similar code snippets added in the merge were present but this function was not. We discovered this recently while modifying zos_copy code based off of dev branch.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #717 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_encode

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
