### PR TITLE
zos_operator documentation escape example correction

### DIFF
--- a/changelogs/fragments/728-zos_operator-example-updates.yml
+++ b/changelogs/fragments/728-zos_operator-example-updates.yml
@@ -1,0 +1,4 @@
+trivial:
+- zos_operator - had errors in some of the commands and unnecessary escapes.
+  This change corrects the commands, escaping and adds one new example command.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/728)

--- a/docs/source/modules/zos_operator.rst
+++ b/docs/source/modules/zos_operator.rst
@@ -83,30 +83,32 @@ Examples
 .. code-block:: yaml+jinja
 
    
-   - name: Execute an operator command to show active jobs
+   - name: Execute an operator command to show device status and allocation
      zos_operator:
-       cmd: 'd u,all'
+       cmd: 'd u'
 
-   - name: Execute an operator command to show active jobs with verbose information
+   - name: Execute an operator command to show device status and allocation with verbose information
      zos_operator:
-       cmd: 'd u,all'
+       cmd: 'd u'
        verbose: true
 
    - name: Execute an operator command to purge all job logs (requires escaping)
      zos_operator:
-       cmd: "\\$PJ(*)"
+       cmd: "$PJ(*)"
 
    - name: Execute operator command to show jobs, waiting up to 5 seconds for response
      zos_operator:
-       cmd: 'd u,all'
+       cmd: 'd a,all'
        wait_time_s: 5
-       wait: false
 
    - name: Execute operator command to show jobs, always waiting 7 seconds for response
      zos_operator:
-       cmd: 'd u,all'
+       cmd: 'd a,all'
        wait_time_s: 7
-       wait: true
+
+   - name: Display the system symbols and associated substitution texts.
+     zos_operator:
+       cmd: 'D SYMBOLS'
 
 
 

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -71,30 +71,32 @@ options:
 """
 
 EXAMPLES = r"""
-- name: Execute an operator command to show active jobs
+- name: Execute an operator command to show device status and allocation
   zos_operator:
-    cmd: 'd u,all'
+    cmd: 'd u'
 
-- name: Execute an operator command to show active jobs with verbose information
+- name: Execute an operator command to show device status and allocation with verbose information
   zos_operator:
-    cmd: 'd u,all'
+    cmd: 'd u'
     verbose: true
 
 - name: Execute an operator command to purge all job logs (requires escaping)
   zos_operator:
-    cmd: "\\$PJ(*)"
+    cmd: "$PJ(*)"
 
 - name: Execute operator command to show jobs, waiting up to 5 seconds for response
   zos_operator:
-    cmd: 'd u,all'
+    cmd: 'd a,all'
     wait_time_s: 5
-    wait: false
 
 - name: Execute operator command to show jobs, always waiting 7 seconds for response
   zos_operator:
-    cmd: 'd u,all'
+    cmd: 'd a,all'
     wait_time_s: 7
-    wait: true
+
+- name: Display the system symbols and associated substitution texts.
+  zos_operator:
+    cmd: 'D SYMBOLS'
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY
Fixes #612 to correct the example commands in the doc.

##### ISSUE TYPE
- Docs Pull Request
