### PR TITLE
 Added additional D SYMBOLS example to zos_operator documentation

### DIFF
--- a/changelogs/fragments/729-zos_operator-example-added.yml
+++ b/changelogs/fragments/729-zos_operator-example-added.yml
@@ -1,0 +1,4 @@
+trivial:
+- zos_operator - had a need for more command examples. This change adds the
+  D SYMBOLS example.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/730)

--- a/docs/source/modules/zos_operator.rst
+++ b/docs/source/modules/zos_operator.rst
@@ -101,6 +101,10 @@ Examples
        cmd: 'd a,all'
        wait_time_s: 7
 
+   - name: Display the system symbols and associated substitution texts.
+     zos_operator:
+       cmd: 'D SYMBOLS'
+
 
 
 

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -90,6 +90,10 @@ EXAMPLES = r"""
   zos_operator:
     cmd: 'd a,all'
     wait_time_s: 7
+
+- name: Display the system symbols and associated substitution texts.
+  zos_operator:
+    cmd: 'D SYMBOLS'
 """
 
 RETURN = r"""


### PR DESCRIPTION
##### SUMMARY

Fixes #612 to add the `D SYMBOLS` command to the examples.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
