### PR TITLE
 zos_copy forward port a test case for symbols on a volume #739 

### DIFF
--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1868,6 +1868,47 @@ def test_copy_pds_loadlib_member_to_pds_loadlib_member(ansible_zos_module,):
 
 
 @pytest.mark.pdse
+def test_copy_pds_member_with_system_symbol(ansible_zos_module,):
+    """This test is for bug #543 in GitHub. In some versions of ZOAU,
+    datasets.listing can't handle system symbols in volume names and
+    therefore fails to get details from a dataset.
+    """
+    hosts = ansible_zos_module
+    # The volume for this dataset should use a system symbol.
+    # This dataset and member should be available on any z/OS system.
+    src = "SYS1.SAMPLIB(IZUPRM00)"
+    dest = "USER.TEST.PDS.DEST"
+
+    try:
+        hosts.all.zos_data_set(
+            name=dest,
+            state="present",
+            type="pdse",
+            replace=True
+        )
+
+        copy_res = hosts.all.zos_copy(src=src, dest=dest, remote_src=True)
+        verify_copy = hosts.all.shell(
+            cmd="mls {0}".format(dest),
+            executable=SHELL_EXECUTABLE
+        )
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest
+
+        for v_cp in verify_copy.contacted.values():
+            assert v_cp.get("rc") == 0
+            stdout = v_cp.get("stdout")
+            assert stdout is not None
+            assert len(stdout.splitlines()) == 1
+
+    finally:
+        hosts.all.zos_data_set(name=dest, state="absent")
+
+
+@pytest.mark.pdse
 def test_copy_multiple_data_set_members(ansible_zos_module):
     hosts = ansible_zos_module
     src = "USER.FUNCTEST.SRC.PDS"


### PR DESCRIPTION
##### SUMMARY
This adds a test for testing of special chars in a volume. This test cases verifies that zoau 1.2.2 has corrected the behavior hence we only pulled the test case forward from 1.4.0 and not the work around. 

Resolves  #738 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
