### PR TITLE
Bugfix/619/v1.4.1/zos copy mode fix

### DIFF
--- a/changelogs/fragments/742_zos_copy-mode-is-applied-to-the-destination-directory-a-deviation-from-the-communtiy-module-behavior.yaml
+++ b/changelogs/fragments/742_zos_copy-mode-is-applied-to-the-destination-directory-a-deviation-from-the-communtiy-module-behavior.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- zos_copy - Fixed a bug where the module would change the mode for a directory when copying into it the contents of another.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/742)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1067,8 +1067,8 @@ class USSCopyHandler(CopyHandler):
             group = self.common_file_args.get("group")
             owner = self.common_file_args.get("owner")
             if mode is not None:
-                self.module.set_mode_if_different(dest, mode, False)
-
+                if not os.path.isdir(dest):
+                    self.module.set_mode_if_different(dest, mode, False)
                 if changed_files:
                     for filepath in changed_files:
                         self.module.set_mode_if_different(os.path.join(dest, filepath), mode, False)


### PR DESCRIPTION
##### SUMMARY
Mode set for files is applied to destination directory by change the logic of changing files

Fixed #619 
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Add logic if to verify the destiny folder to copy to only change mode to files not folder.

##### ADDITIONAL INFORMATION
When the only and last file of the copy is a folder does not apply the change of mode with and if statement.

The PR in dev pass without test case, more than playbook results.


