### PR TITLE
Solve problem 619 about set mode on dest file

### DIFF
--- a/changelogs/fragments/746--Mode-set-for-files-is-applied-to-destination-directory.yml
+++ b/changelogs/fragments/746--Mode-set-for-files-is-applied-to-destination-directory.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- zos_copy - Fixed a bug where the module would change the mode for a directory when copying into it the contents of another.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/746)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1062,8 +1062,8 @@ class USSCopyHandler(CopyHandler):
             group = self.common_file_args.get("group")
             owner = self.common_file_args.get("owner")
             if mode is not None:
-                self.module.set_mode_if_different(dest, mode, False)
-
+                if not os.path.isdir(dest):
+                    self.module.set_mode_if_different(dest, mode, False)
                 if changed_files:
                     for filepath in changed_files:
                         self.module.set_mode_if_different(os.path.join(dest, filepath), mode, False)


### PR DESCRIPTION
##### SUMMARY
Mode set for files is applied to destination directory by change the logic of changing files

Fixed https://github.com/ansible-collections/ibm_zos_core/issues/619

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
Add logic if to verify the destiny folder to copy to only change mode to files not folder.

##### ADDITIONAL INFORMATION
When the only and last file of the copy is a folder does not apply the change of mode with and if statement.

<img width="1455" alt="Captura de pantalla 2023-04-18 a la(s) 12 00 18" src="https://user-images.githubusercontent.com/68956970/232864142-c9fb518d-1e9b-4f4a-98d9-b86bea245b47.png">

The PR in dev pass without test case, more than playbook results.
Add playbook
hosts : zvm
collections :

ibm.ibm_zos_core
gather_facts: no
vars:
ZOAU: "/zoau/v1.2.2"
PYZ: "/python2/usr/lpp/IBM/cyp/v3r2/pyz"
source: ./tests/
destt: /test/
environment: "{{ environment_vars }}"
tasks:

name: Delete al files inside folder dest
shell:
cmd: rm -r {{ destt }}

name: Create dest folder
shell:
cmd: mkdir {{ destt }}
register: result

name: Adjust mode of dest folder
shell:
cmd: chmod 755 {{ destt }}
register: result

name: Verify mode of destiny
shell:
cmd: ls -la {{ destt }}
register: result

name: Response
debug:
msg: "{{ result }}"

name: Copy remote text files zos_copy.
zos_copy:
src: "{{ source }}"
dest: "{{ destt }}"
mode: 644
force: true
remote_src: false

name: Response zos_copy
debug:
msg: "{{ result }}"

name: See permisions on dest
shell:
cmd: ls -la {{ destt }}
register: result

name: Response permissions after
debug:
msg: "{{ result }}"
This is the results before the change
<img width="1537" alt="Captura de pantalla 2023-04-18 a la(s) 12 01 55" src="https://user-images.githubusercontent.com/68956970/232864460-fe64dc2d-c91f-4e0b-a679-4ea215cce5a2.png">

After:

<img width="1615" alt="Captura de pantalla 2023-04-18 a la(s) 12 02 18" src="https://user-images.githubusercontent.com/68956970/232864551-d1b92a77-9209-4200-af68-46202fd7670f.png">
