### PR TITLE
Remove duplicate function uss_tag_encoding from encode utils

### DIFF
--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -496,25 +496,6 @@ class EncodeUtils(object):
         except Exception:
             return None
 
-    def uss_tag_encoding(self, file_path, tag):
-        """Tag the file/directory specified with the given code set.
-        If `file_path` is a directory, all of the files and subdirectories will
-        be tagged recursively.
-
-        Arguments:
-            file_path {str} -- Absolute file path to tag.
-            tag {str} -- Code set to tag the file/directory.
-
-        Raises:
-            TaggingError: When the chtag command fails.
-        """
-        is_dir = os.path.isdir(file_path)
-
-        tag_cmd = "chtag -{0}c {1} {2}".format("R" if is_dir else "t", tag, file_path)
-        rc, out, err = self.module.run_command(tag_cmd)
-        if rc != 0:
-            raise TaggingError(file_path, tag, rc, out, err)
-
 
 class EncodeError(Exception):
     def __init__(self, message):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is a duplicated function in line 456 and line 499 `uss_tag_encoding`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Trivial Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/encode.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The linter somehow doesn't seem to complain about the fact that there are two functions with the same name.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
