### PR TITLE
Bugfix/619/mode set for files applied test case

### DIFF
--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1016,6 +1016,62 @@ def test_copy_non_existent_file_fails(ansible_zos_module, is_remote):
 
 
 @pytest.mark.uss
+@pytest.mark.parametrize("src", [
+    dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=False),
+    dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=True),])
+def test_copy_dest_directory_remain(ansible_zos_module, src):
+    hosts = ansible_zos_module
+    dest_path = "/tmp/test/"
+    try:
+        hosts.all.shell(cmd="mkdir -p {0}".format(dest_path))
+        hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
+        permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
+        hosts.all.zos_copy(content=src["src"], dest=dest_path, is_binary=src["is_binary"])
+        permissions = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
+
+        for before in permissions_before.contacted.values():
+            permissions_be_copy = before.get("stdout")
+            
+        for after in permissions.contacted.values():
+            permissions_af_copy = after.get("stdout") 
+
+        permissions_be_copy = permissions_be_copy.splitlines()[1].split()[0]
+        permissions_af_copy = permissions_af_copy.splitlines()[1].split()[0]
+                
+        assert permissions_be_copy == permissions_af_copy
+    finally:
+        hosts.all.shell(cmd="rm -r {0}".format(dest_path))
+
+
+@pytest.mark.uss
+@pytest.mark.parametrize("src", [
+    dict(src="/etc/", is_file=False, is_binary=False, is_remote=False),
+    dict(src="/etc/", is_file=False, is_binary=False, is_remote=True),])
+def test_copy_dest_folder_directory_remain(ansible_zos_module, src):
+    hosts = ansible_zos_module
+    dest_path = "/tmp/test/"
+    try:
+        hosts.all.shell(cmd="mkdir -p {0}".format(dest_path))
+        hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
+        permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
+        hosts.all.zos_copy(content=src["src"], dest=dest_path, is_binary=src["is_binary"])
+        permissions = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
+
+        for before in permissions_before.contacted.values():
+            permissions_be_copy = before.get("stdout")
+
+        for after in permissions.contacted.values():
+            permissions_af_copy = after.get("stdout") 
+
+        permissions_be_copy = permissions_be_copy.splitlines()[1].split()[0]
+        permissions_af_copy = permissions_af_copy.splitlines()[1].split()[0]
+                
+        assert permissions_be_copy == permissions_af_copy
+    finally:
+        hosts.all.shell(cmd="rm -r {0}".format(dest_path))
+        
+
+@pytest.mark.uss
 @pytest.mark.seq
 def test_copy_file_record_length_to_sequential_data_set(ansible_zos_module):
     hosts = ansible_zos_module
@@ -2631,64 +2687,4 @@ def test_copy_uss_file_to_existing_sequential_data_set_twice_with_tmphlq_option(
                 assert v_cp.get("rc") == 0
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
-
-
-@pytest.mark.uss
-@pytest.mark.parametrize("src", [
-    dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=False),
-    dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=True),])
-def test_copy_dest_directory_remain(ansible_zos_module, src):
-    hosts = ansible_zos_module
-    dest_path = "/tmp/test/"
-
-    try:
-        # Create the dest and adjust the permissions to compare in the assertion after the zos_copy execution
-        hosts.all.shell(cmd="mkdir -p {0}".format(dest_path))
-        hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
-        permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
-
-        hosts.all.zos_copy(content=src["src"], dest=dest_path, is_binary=src["is_binary"])
-        permissions = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
-
-        for before in permissions_before.contacted.values():
-            permissions_be_copy = before.get("stdout")
-        for after in permissions.contacted.values():
-            permissions_af_copy = after.get("stdout") 
-
-        permissions_be_copy = permissions_be_copy.splitlines()[1].split()[0]
-        permissions_af_copy = permissions_af_copy.splitlines()[1].split()[0]
-                
-        assert permissions_be_copy == permissions_af_copy
-    finally:
-        hosts.all.shell(cmd="rm -r {0}".format(dest_path))
-        
-
-@pytest.mark.uss
-@pytest.mark.parametrize("src", [
-    dict(src="/etc/", is_file=False, is_binary=False, is_remote=False),
-    dict(src="/etc/", is_file=False, is_binary=False, is_remote=True),])
-def test_copy_dest_folder_directory_remain(ansible_zos_module, src):
-    hosts = ansible_zos_module
-    dest_path = "/tmp/test/"
-
-    try:
-        # Create the dest and adjust the permissions to compare in the assertion after the zos_copy execution
-        hosts.all.shell(cmd="mkdir -p {0}".format(dest_path))
-        hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
-        permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
-
-        hosts.all.zos_copy(content=src["src"], dest=dest_path, is_binary=src["is_binary"])
-        permissions = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
-
-        for before in permissions_before.contacted.values():
-            permissions_be_copy = before.get("stdout")
-        for after in permissions.contacted.values():
-            permissions_af_copy = after.get("stdout") 
-
-        permissions_be_copy = permissions_be_copy.splitlines()[1].split()[0]
-        permissions_af_copy = permissions_af_copy.splitlines()[1].split()[0]
-                
-        assert permissions_be_copy == permissions_af_copy
-    finally:
-        hosts.all.shell(cmd="rm -r {0}".format(dest_path))
         

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1017,13 +1017,13 @@ def test_copy_non_existent_file_fails(ansible_zos_module, is_remote):
 
 @pytest.mark.uss
 @pytest.mark.parametrize("src", [
-    dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=False),
-    dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=True),])
-def test_copy_dest_directory_remain(ansible_zos_module, src):
+    dict(src="/etc/profile", is_remote=False),
+    dict(src="/etc/profile", is_remote=True),])
+def test_ensure_copy_file_dont_change_permission_on_dest(ansible_zos_module, src):
     hosts = ansible_zos_module
     dest_path = "/tmp/test/"
     try:
-        hosts.all.shell(cmd="mkdir -p {0}".format(dest_path))
+        hosts.all.file(path=dest_path, state="directory")
         hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
         permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
         hosts.all.zos_copy(content=src["src"], dest=dest_path, is_binary=src["is_binary"])
@@ -1040,18 +1040,18 @@ def test_copy_dest_directory_remain(ansible_zos_module, src):
                 
         assert permissions_be_copy == permissions_af_copy
     finally:
-        hosts.all.shell(cmd="rm -r {0}".format(dest_path))
+        hosts.all.file(path=dest_path, state="absent")
 
 
 @pytest.mark.uss
 @pytest.mark.parametrize("src", [
-    dict(src="/etc/", is_file=False, is_binary=False, is_remote=False),
-    dict(src="/etc/", is_file=False, is_binary=False, is_remote=True),])
-def test_copy_dest_folder_directory_remain(ansible_zos_module, src):
+    dict(src="/etc/", is_remote=False),
+    dict(src="/etc/", is_remote=True),])
+def test_ensure_copy_folder_dont_change_permission_on_dest(ansible_zos_module, src):
     hosts = ansible_zos_module
     dest_path = "/tmp/test/"
     try:
-        hosts.all.shell(cmd="mkdir -p {0}".format(dest_path))
+        hosts.all.file(path=dest_path, state="directory")
         hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
         permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
         hosts.all.zos_copy(content=src["src"], dest=dest_path, is_binary=src["is_binary"])
@@ -1068,7 +1068,7 @@ def test_copy_dest_folder_directory_remain(ansible_zos_module, src):
                 
         assert permissions_be_copy == permissions_af_copy
     finally:
-        hosts.all.shell(cmd="rm -r {0}".format(dest_path))
+        hosts.all.file(path=dest_path, state="absent")
         
 
 @pytest.mark.uss

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2633,12 +2633,41 @@ def test_copy_uss_file_to_existing_sequential_data_set_twice_with_tmphlq_option(
         hosts.all.zos_data_set(name=dest, state="absent")
 
 
-# Test to ensure the zox_copy module work as community module 
 @pytest.mark.uss
 @pytest.mark.parametrize("src", [
     dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=False),
     dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=True),])
 def test_copy_dest_directory_remain(ansible_zos_module, src):
+    hosts = ansible_zos_module
+    dest_path = "/tmp/test/"
+
+    try:
+        # Create the dest and adjust the permissions to compare in the assertion after the zos_copy execution
+        hosts.all.shell(cmd="mkdir -p {0}".format(dest_path))
+        hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
+        permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
+
+        hosts.all.zos_copy(content=src["src"], dest=dest_path, is_binary=src["is_binary"])
+        permissions = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
+
+        for before in permissions_before.contacted.values():
+            permissions_be_copy = before.get("stdout")
+        for after in permissions.contacted.values():
+            permissions_af_copy = after.get("stdout") 
+
+        permissions_be_copy = permissions_be_copy.splitlines()[1].split()[0]
+        permissions_af_copy = permissions_af_copy.splitlines()[1].split()[0]
+                
+        assert permissions_be_copy == permissions_af_copy
+    finally:
+        hosts.all.shell(cmd="rm -r {0}".format(dest_path))
+        
+
+@pytest.mark.uss
+@pytest.mark.parametrize("src", [
+    dict(src="/etc/", is_file=False, is_binary=False, is_remote=False),
+    dict(src="/etc/", is_file=False, is_binary=False, is_remote=True),])
+def test_copy_dest_folder_directory_remain(ansible_zos_module, src):
     hosts = ansible_zos_module
     dest_path = "/tmp/test/"
 

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2631,3 +2631,31 @@ def test_copy_uss_file_to_existing_sequential_data_set_twice_with_tmphlq_option(
                 assert v_cp.get("rc") == 0
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
+
+@pytest.mark.uss
+@pytest.mark.parametrize("src", [
+    dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=False),
+    dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=True),])
+def test_copy_dest_directory_remain(ansible_zos_module, src):
+    hosts = ansible_zos_module
+    dest_path = "/tmp/test/"
+
+    try:
+        hosts.all.shell(cmd="mkdir -p {0}".format(dest_path))
+        hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
+        permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
+
+        hosts.all.zos_copy(content=src["src"], dest=dest_path, is_binary=src["is_binary"])
+        permissions = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
+
+        for before in permissions_before.contacted.values():
+            permissions_be_copy = before.get("stdout")
+        for after in permissions.contacted.values():
+            permissions_af_copy = after.get("stdout") 
+        permissions_be_copy = permissions_be_copy.splitlines()[1].split()[0]
+        permissions_af_copy = permissions_af_copy.splitlines()[1].split()[0]
+                
+        assert permissions_be_copy == permissions_af_copy
+    finally:
+        hosts.all.shell(cmd="rm -r {0}".format(dest_path))
+        

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1019,14 +1019,13 @@ def test_copy_non_existent_file_fails(ansible_zos_module, is_remote):
 @pytest.mark.parametrize("src", [
     dict(src="/etc/profile", is_remote=False),
     dict(src="/etc/profile", is_remote=True),])
-def test_ensure_copy_file_dont_change_permission_on_dest(ansible_zos_module, src):
+def test_ensure_copy_file_does_not_change_permission_on_dest(ansible_zos_module, src):
     hosts = ansible_zos_module
     dest_path = "/tmp/test/"
     try:
-        hosts.all.file(path=dest_path, state="directory")
-        hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
+        hosts.all.file(path=dest_path, state="directory", mode="750")
         permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
-        hosts.all.zos_copy(content=src["src"], dest=dest_path, is_binary=src["is_binary"])
+        hosts.all.zos_copy(content=src["src"], dest=dest_path)
         permissions = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
 
         for before in permissions_before.contacted.values():
@@ -1047,14 +1046,13 @@ def test_ensure_copy_file_dont_change_permission_on_dest(ansible_zos_module, src
 @pytest.mark.parametrize("src", [
     dict(src="/etc/", is_remote=False),
     dict(src="/etc/", is_remote=True),])
-def test_ensure_copy_folder_dont_change_permission_on_dest(ansible_zos_module, src):
+def test_ensure_copy_directory_does_not_change_permission_on_dest(ansible_zos_module, src):
     hosts = ansible_zos_module
     dest_path = "/tmp/test/"
     try:
-        hosts.all.file(path=dest_path, state="directory")
-        hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
+        hosts.all.file(path=dest_path, state="directory", mode="750")
         permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
-        hosts.all.zos_copy(content=src["src"], dest=dest_path, is_binary=src["is_binary"])
+        hosts.all.zos_copy(content=src["src"], dest=dest_path)
         permissions = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
 
         for before in permissions_before.contacted.values():

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2632,6 +2632,8 @@ def test_copy_uss_file_to_existing_sequential_data_set_twice_with_tmphlq_option(
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
 
+
+# Test to ensure the zox_copy module work as community module 
 @pytest.mark.uss
 @pytest.mark.parametrize("src", [
     dict(src="/etc/profile", is_file=False, is_binary=False, is_remote=False),
@@ -2641,6 +2643,7 @@ def test_copy_dest_directory_remain(ansible_zos_module, src):
     dest_path = "/tmp/test/"
 
     try:
+        # Create the dest and adjust the permissions to compare in the assertion after the zos_copy execution
         hosts.all.shell(cmd="mkdir -p {0}".format(dest_path))
         hosts.all.shell(cmd="chmod 750 {0}".format(dest_path))
         permissions_before = hosts.all.shell(cmd="ls -la {0}".format(dest_path))
@@ -2652,6 +2655,7 @@ def test_copy_dest_directory_remain(ansible_zos_module, src):
             permissions_be_copy = before.get("stdout")
         for after in permissions.contacted.values():
             permissions_af_copy = after.get("stdout") 
+
         permissions_be_copy = permissions_be_copy.splitlines()[1].split()[0]
         permissions_af_copy = permissions_af_copy.splitlines()[1].split()[0]
                 


### PR DESCRIPTION
##### SUMMARY
Add test case to ensure consistency and keep the bug fix #619 to not applied the change of mode to destination folder.


##### ISSUE TYPE
- Test case Pull Request

##### COMPONENT NAME
Test cases for zoo_copy one from file to folder and the other folder to folder.

##### ADDITIONAL INFORMATION
The test case create a dest folder and adjust to mode 750 that value of permissions is the one that will compare after the copy module is executed, after execute check permissions of dest folder to made the assertion.


Run pipeline
<img width="1456" alt="Captura de pantalla 2023-04-25 a la(s) 12 02 27" src="https://user-images.githubusercontent.com/68956970/234373277-7c2236bc-4390-4f0e-b9b4-20aa1caeb607.png">

