### PR TITLE
Bugfix/660/zos operator reported failure caused by unrelated error response messages

### DIFF
--- a/changelogs/fragments/762-zos-operator-reported-failure-caused-by-unrelated-error-response.yaml
+++ b/changelogs/fragments/762-zos-operator-reported-failure-caused-by-unrelated-error-response.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zos_operator - Reported a failure caused by unrelated error response.
+    Fix now gives a transparent response of the operator to avoid false negatives.   
+    (https://github.com/ansible-collections/ibm_zos_core/pull/762).

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -244,14 +244,13 @@ def run_module():
             else:
                 module.fail_json(msg="Expected response to be more than 2 lines.", **result)
         else:
-            module.fail_json(
-                              msg=("A non-zero return code was received : {0}. Review the response for more details.").format(result["rc"]),
-                              cmd=result["cmd"],
-                              elapsed_time=result["elapsed"],
-                              wait_time_s=result["wait_time_s"],
-                              stderr=str(error) if error != None else result["content"],
-                              stderr_lines=str(error).splitlines() if error != None else result["content"],
-                              changed=result["changed"],)
+            module.fail_json(msg=("A non-zero return code was received : {0}. Review the response for more details.").format(result["rc"]),
+                            cmd=result["cmd"],
+                            elapsed_time=result["elapsed"],
+                            wait_time_s=result["wait_time_s"],
+                            stderr=str(error) if error is not None else result["content"],
+                            stderr_lines=str(error).splitlines() if error is not None else result["content"],
+                            changed=result["changed"],)
     except Error as e:
         module.fail_json(msg=repr(e), **result)
     except Exception as e:

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -219,14 +219,14 @@ def run_module():
         result["content"] = []
         stdout = rc_message.get("stdout")
         if stdout is not None:
-          for out in stdout.split("\n"):
-            result["content"].append(out)
+            for out in stdout.split("\n"):
+                result["content"].append(out)
         stderr = rc_message.get("stderr")
         error = []
         if stderr is not None:
-          for err in stderr.split("\n"):
-            error.append(err)
-            result["content"].append(err)
+            for err in stderr.split("\n"):
+                error.append(err)
+                result["content"].append(err)
         # call is returned from run_operator_command, specifying what was run.
         # result["cmd"] = new_params.get("cmd")
         result["cmd"] = rc_message.get("call")
@@ -243,7 +243,7 @@ def run_module():
                 module.fail_json(msg="Expected response to be more than 2 lines.", **result)
         else:
             module.fail_json(
-                msg="Non-zero response received: " + str(result["rc"] + "\n" +". Stderr: " + str(error)), **result
+                msg="Non-zero response received: " + str(result["rc"] + "\n" + ". Stderr: " + str(error)), **result
             )
     except Error as e:
         module.fail_json(msg=repr(e), **result)

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -245,12 +245,12 @@ def run_module():
                 module.fail_json(msg="Expected response to be more than 2 lines.", **result)
         else:
             module.fail_json(msg=("A non-zero return code was received : {0}. Review the response for more details.").format(result["rc"]),
-                            cmd=result["cmd"],
-                            elapsed_time=result["elapsed"],
-                            wait_time_s=result["wait_time_s"],
-                            stderr=str(error) if error is not None else result["content"],
-                            stderr_lines=str(error).splitlines() if error is not None else result["content"],
-                            changed=result["changed"],)
+                             cmd=result["cmd"],
+                             elapsed_time=result["elapsed"],
+                             wait_time_s=result["wait_time_s"],
+                             stderr=str(error) if error is not None else result["content"],
+                             stderr_lines=str(error).splitlines() if error is not None else result["content"],
+                             changed=result["changed"],)
     except Error as e:
         module.fail_json(msg=repr(e), **result)
     except Exception as e:

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -220,13 +220,15 @@ def run_module():
         stdout = rc_message.get("stdout")
         if stdout is not None:
             for out in stdout.split("\n"):
-                result["content"].append(out)
+                if out:
+                    result["content"].append(out)
         stderr = rc_message.get("stderr")
         error = []
         if stderr is not None:
             for err in stderr.split("\n"):
-                error.append(err)
-                result["content"].append(err)
+                if err:
+                    error.append(err)
+                    result["content"].append(err)
         # call is returned from run_operator_command, specifying what was run.
         # result["cmd"] = new_params.get("cmd")
         result["cmd"] = rc_message.get("call")

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -245,8 +245,13 @@ def run_module():
                 module.fail_json(msg="Expected response to be more than 2 lines.", **result)
         else:
             module.fail_json(
-                msg="Non-zero response received: " + str(result["rc"] + "\n" + ". Stderr: " + str(error)), **result
-            )
+                              msg=("A non-zero return code was received : {0}. Review the response for more details.").format(result["rc"]),
+                              cmd=result["cmd"],
+                              elapsed_time=result["elapsed"],
+                              wait_time_s=result["wait_time_s"],
+                              stderr=str(error) if error != None else result["content"],
+                              stderr_lines=str(error).splitlines() if error != None else result["content"],
+                              changed=result["changed"],)
     except Error as e:
         module.fail_json(msg=repr(e), **result)
     except Exception as e:

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -217,38 +217,16 @@ def run_module():
         # short_str is local, and just to check for problem response values.
         # ssctr is a limit variable so we don't pull more than 5 lines of each.
         result["content"] = []
-        check_error = []
         stdout = rc_message.get("stdout")
         if stdout is not None:
           for out in stdout.split("\n"):
             result["content"].append(out)
-            check_error.append(out)
-
-        """short_str = []
-        ssctr = 0
-        tstr = rc_message.get("stdout")
-        if tstr is not None:
-            for s in tstr.split("\n"):
-                if s:
-                    result["content"].append(s)
-                if ssctr < 5:
-                    short_str.append(s)
-                    ssctr += 1"""
         stderr = rc_message.get("stderr")
         error = []
         if stderr is not None:
           for err in stderr.split("\n"):
             error.append(err)
-        """ssctr = 0
-        tstr = rc_message.get("stderr")
-        if tstr is not None:
-            for s in tstr.split("\n"):
-                if s:
-                    result["content"].append(s)
-                if ssct < 5:
-                    short_str.append(s)
-                    ssctr += 1"""
-
+            result["content"].append(err)
         # call is returned from run_operator_command, specifying what was run.
         # result["cmd"] = new_params.get("cmd")
         result["cmd"] = rc_message.get("call")
@@ -261,23 +239,6 @@ def run_module():
         if int(result["rc"]) == 0:
             if len(result["content"]) > 2:
                 result["changed"] = True
-
-                for linetocheck in check_error:
-                    if "invalid" in linetocheck.lower():
-                        result["exception"] = "Invalid detected: " + linetocheck
-                        #result["exception"] = "Invalid detected: " + linetocheck
-                        #result["changed"] = False
-                        #module.fail_json(msg=result["exception"], **result)
-                    elif "error" in linetocheck.lower():
-                        result["exception"] = "Error detected: " + linetocheck
-                        #result["exception"] = "Error detected: " + linetocheck
-                        #result["changed"] = False
-                        #module.fail_json(msg=result["exception"], **result)
-                    elif "unidentifiable" in linetocheck.lower():
-                        result["exception"] = "Unidentifiable detected: " + linetocheck
-                        #result["exception"] = "Unidentifiable detected: " + linetocheck
-                        #result["changed"] = False
-                        #module.fail_json(msg=result["exception"], **result)
             else:
                 module.fail_json(msg="Expected response to be more than 2 lines.", **result)
         else:

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -49,8 +49,18 @@ def test_zos_operator_invalid_command(ansible_zos_module):
     hosts = ansible_zos_module
     results = hosts.all.zos_operator(cmd="invalid,command", verbose=False)
     for result in results.contacted.values():
-        assert result.get("changed") is False
-        assert result.get("exception") is not None
+        assert result.get("changed") is True
+
+
+def test_zos_operator_invalid_command_to_ensure_transparency(ansible_zos_module):
+    hosts = ansible_zos_module
+    results = hosts.all.zos_operator(cmd="DUMP COMM=('ERROR DUMP')", verbose=False)
+    for result in results.contacted.values():
+        assert result.get("changed") is True
+    transparency = False
+    if any('DUMP COMMAND' in str for str in result.get("content")):
+            transparency = True
+    assert transparency
 
 
 def test_zos_operator_positive_path(ansible_zos_module):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change zos_operator module by delete the search of keywords as triggers for failures in a a send operator.

Fixed bugfix with option one #660 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Separate the response and delete search of keywords.

##### ADDITIONAL INFORMATION
Separate the stdout and stderr response to send in a fail only the stderr. Delete the search of keywords as error in the stdout.

```
ok: [zvm] => {
    "msg": {
        "changed": true,
        "cmd": "DUMP COMM=('ERROR DUMP')",
        "content": [
            "EC01147A   2023118  15:05:26.00             ISF031I CONSOLE OMVS0000 ACTIVATED",
            "EC01147A   2023118  15:05:26.00            -DUMP COMM=('ERROR DUMP') ",
            "EC01147A   2023118  15:05:26.00             09 IEE094D SPECIFY OPERAND(S) FOR DUMP COMMAND"
        ],
        "elapsed": 5.81,
        "failed": false,
        "rc": 0,
        "wait_time_s": 1
    }
}
```
<img width="900" alt="Captura de pantalla 2023-05-01 a la(s) 20 44 54" src="https://user-images.githubusercontent.com/68956970/235568777-f2d221ad-e62a-4f7f-91bd-dadc46fe197b.png">
