### PR TITLE
Bugfix/769/1.6/zos copy does not overwrite permission on overwriten copy as comunity module

### DIFF
--- a/changelogs/fragments/790_overwrite_permissions_on_copy.yml
+++ b/changelogs/fragments/790_overwrite_permissions_on_copy.yml
@@ -1,5 +1,4 @@
 bugfixes:
-- zos_copy - kept permissions on target directory when copy overwrite
-  pre-existing files. The fix now ensure the pre-exiting content on target
-  change permissions if the mode is given by the user.
+- zos_copy - kept permissions on target directory when copy overwrote
+  files. The fix now set permissions when mode is given.
   (https://github.com/ansible-collections/ibm_zos_core/pull/790)

--- a/changelogs/fragments/790_overwrite_permissions_on_copy.yml
+++ b/changelogs/fragments/790_overwrite_permissions_on_copy.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- zos_copy - kept permissions on target directory when copy overwrite
+  pre-existing files. The fix now ensure the pre-exiting content on target
+  change permissions if the mode is given by the user.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/790)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1200,8 +1200,8 @@ class USSCopyHandler(CopyHandler):
             else:
                 files_to_change.append(relative_path)
 
-        # This change ensure that is overwriting a dir the files were already in
-        # will ge changed mode if mode is give by the user.
+        # This change adds to the files_to_change variable any file that accord with
+        # a name found in the source copy
         files_to_change.extend(existing_files)
         # Creating tuples with (filename, permissions).
         original_permissions = [

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1186,27 +1186,30 @@ class USSCopyHandler(CopyHandler):
                      for the files and directories already present on the
                      destination.
         """
-        copied_files = self._walk_uss_tree(src)
+        files_to_copy = self._walk_uss_tree(src)
 
         # It's not needed to normalize the path because it was already normalized
         # on _copy_to_dir.
         parent_dir = os.path.basename(src) if copy_directory else ''
 
-        changed_files = []
-        original_files = []
-        for relative_path in copied_files:
+        files_to_change = []
+        existing_files = []
+        for relative_path in files_to_copy:
             if os.path.exists(os.path.join(dest, parent_dir, relative_path)):
-                original_files.append(relative_path)
+                existing_files.append(relative_path)
             else:
-                changed_files.append(relative_path)
+                files_to_change.append(relative_path)
 
+        # This change ensure that is overwriting a dir the files were already in
+        # will ge changed mode if mode is give by the user.
+        files_to_change.extend(existing_files)
         # Creating tuples with (filename, permissions).
         original_permissions = [
             (filepath, os.stat(os.path.join(dest, parent_dir, filepath)).st_mode)
-            for filepath in original_files
+            for filepath in existing_files
         ]
 
-        return changed_files, original_permissions
+        return files_to_change, original_permissions
 
     def _walk_uss_tree(self, dir):
         """Walks the tree directory for dir and returns all relative paths

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -853,7 +853,7 @@ def test_copy_local_dir_and_change_mode(ansible_zos_module, copy_directory):
         for result in stat_overwritten_file_res.contacted.values():
             assert result.get("stat").get("exists") is True
             assert result.get("stat").get("isdir") is False
-            assert result.get("stat").get("mode") == dest_mode
+            assert result.get("stat").get("mode") == mode
 
         for result in stat_new_file_res.contacted.values():
             assert result.get("stat").get("exists") is True
@@ -947,7 +947,7 @@ def test_copy_uss_dir_and_change_mode(ansible_zos_module, copy_directory):
         for result in stat_overwritten_file_res.contacted.values():
             assert result.get("stat").get("exists") is True
             assert result.get("stat").get("isdir") is False
-            assert result.get("stat").get("mode") == dest_mode
+            assert result.get("stat").get("mode") == mode
 
         for result in stat_new_file_res.contacted.values():
             assert result.get("stat").get("exists") is True

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -809,42 +809,58 @@ def test_data_set_temp_data_set_name_batch(ansible_zos_module):
     ["HFS", "ZFS"],
 )
 def test_filesystem_create_and_mount(ansible_zos_module, filesystem):
+    fulltest = True
+    hosts = ansible_zos_module
+
     try:
-        hosts = ansible_zos_module
         hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
-        results = hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, type=filesystem)
-        temp_dir_name = make_tempfile(hosts, directory=True)
-        results2 = hosts.all.command(
-            cmd="mount -t {0} -f {1} {2}".format(
-                filesystem, DEFAULT_DATA_SET_NAME, temp_dir_name
+
+        if filesystem == "HFS":
+            result0 = hosts.all.shell(cmd="zinfo -t sys")
+            for result in result0.contacted.values():
+                sys_info = result.get("stdout_lines")
+            product_version = sys_info[4].split()[1].strip("'")
+            product_release = sys_info[5].split()[1].strip("'")
+            if product_release >= "05" or product_version > "02":
+                fulltest = False
+                print( "skipping HFS test: zOS > 02.04" )
+
+        if fulltest:
+            hosts = ansible_zos_module
+            hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
+            results = hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, type=filesystem)
+            temp_dir_name = make_tempfile(hosts, directory=True)
+            results2 = hosts.all.command(
+                cmd="mount -t {0} -f {1} {2}".format(
+                    filesystem, DEFAULT_DATA_SET_NAME, temp_dir_name
+                )
             )
-        )
-        results3 = hosts.all.shell(cmd="cd {0} ; df .".format(temp_dir_name))
+            results3 = hosts.all.shell(cmd="cd {0} ; df .".format(temp_dir_name))
 
-        # clean up
-        results4 = hosts.all.command(cmd="unmount {0}".format(temp_dir_name))
-        results5 = hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
-        results6 = hosts.all.file(path=temp_dir_name, state="absent")
+            # clean up
+            results4 = hosts.all.command(cmd="unmount {0}".format(temp_dir_name))
+            results5 = hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
+            results6 = hosts.all.file(path=temp_dir_name, state="absent")
 
-        for result in results.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("module_stderr") is None
-        for result in results2.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("stderr") == ""
-        for result in results3.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("stderr") == ""
-            assert DEFAULT_DATA_SET_NAME.upper() in result.get("stdout", "")
-        for result in results4.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("stderr") == ""
-        for result in results5.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("module_stderr") is None
-        for result in results6.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("module_stderr") is None
+            for result in results.contacted.values():
+                assert result.get("changed") is True
+                assert result.get("module_stderr") is None
+            for result in results2.contacted.values():
+                assert result.get("changed") is True
+                assert result.get("stderr") == ""
+            for result in results3.contacted.values():
+                assert result.get("changed") is True
+                assert result.get("stderr") == ""
+                assert DEFAULT_DATA_SET_NAME.upper() in result.get("stdout", "")
+            for result in results4.contacted.values():
+                assert result.get("changed") is True
+                assert result.get("stderr") == ""
+            for result in results5.contacted.values():
+                assert result.get("changed") is True
+                assert result.get("module_stderr") is None
+            for result in results6.contacted.values():
+                assert result.get("changed") is True
+                assert result.get("module_stderr") is None
     finally:
         hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
 


### PR DESCRIPTION
##### SUMMARY
Add files that are found in the destination that are coming from a previous copy of same dest to the change permissions loop by add to array of list of files to change mode. 

Fixes #769 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
A line of code that add everything that is inside the target folder that also is found in origin folder to the array to change mode.

##### ADDITIONAL INFORMATION
Also change names of variables in the function _get_changed_files to make easy to read and clear the description with present names not names in past because the information haven't been transform in the function.
Change 3 test cases to ensure the overwrite also works on mode if is send. 
Playbook to test:


```
   tasks:
    - name: Copy files to non existing directory.
      zos_copy:
        src: ./tests/
        dest: /tests/

    - name: Get permissions.
      ansible.builtin.command:
        cmd: "ls -la /tests/"
      register: Output
    - name: Response 
      debug:
        msg: "{{ Output }}"

    - name: Overwrite files with different permissions.
      zos_copy:
        src: ./tests/
        dest: /tests/
        force: true
        mode: "777"

    - name: Get permissions.
      ansible.builtin.command:
        cmd: "ls -la /tests/"
      register: Output
    - name: Response 
      debug:
        msg: "{{ Output }}"
```

Output:

```
PLAY [zvm] *********************************************************************************************************************************************************************

TASK [Copy files to non existing directory.] ***********************************************************************************************************************************

changed: [zvm]

TASK [Get permissions.] ********************************************************************************************************************************************************

changed: [zvm]

TASK [Response] ****************************************************************************************************************************************************************

ok: [zvm] => {
    "msg": {
        "changed": true,
        "cmd": [
            "ls",
            "-la",
            "/tests/"
        ],
        "delta": "0:00:15.042574",
        "end": "2023-06-02 23:10:51.225764",
        "failed": false,
        "rc": 0,
        "start": "2023-06-02 23:10:36.183190",
        "stderr": "",
        "stderr_lines": [],
        "stdout": "total 32\ndrwxr-xr-x   2 BPXROOT  SYS1        8192 Jun  2 23:07 .\ndrwxr-xr-x  18 BPXROOT  SYS1        8192 Jun  2 23:08 ..\n-rw-r--r--   1 BPXROOT  SYS1           0 Jun  2 23:07 my.jcl",
        "stdout_lines": [
            "total 32",
            "drwxr-xr-x   2 BPXROOT  SYS1        8192 Jun  2 23:07 .",
            "drwxr-xr-x  18 BPXROOT  SYS1        8192 Jun  2 23:08 ..",
            "-rw-r--r--   1 BPXROOT  SYS1           0 Jun  2 23:07 my.jcl"
        ]
    }
}

TASK [Overwrite files with different permissions.] *****************************************************************************************************************************

changed: [zvm]

TASK [Get permissions.] ********************************************************************************************************************************************************

changed: [zvm]

TASK [Response] ****************************************************************************************************************************************************************

ok: [zvm] => {
    "msg": {
        "changed": true,
        "cmd": [
            "ls",
            "-la",
            "/tests/"
        ],
        "delta": "0:00:24.939784",
        "end": "2023-06-02 23:16:03.241356",
        "failed": false,
        "rc": 0,
        "start": "2023-06-02 23:15:38.301572",
        "stderr": "",
        "stderr_lines": [],
        "stdout": "total 32\ndrwxr-xr-x   2 BPXROOT  SYS1        8192 Jun  2 23:14 .\ndrwxr-xr-x  18 BPXROOT  SYS1        8192 Jun  2 23:08 ..\n-rwxrwxrwx   1 BPXROOT  SYS1           0 Jun  2 23:14 my.jcl",
        "stdout_lines": [
            "total 32",
            "drwxr-xr-x   2 BPXROOT  SYS1        8192 Jun  2 23:14 .",
            "drwxr-xr-x  18 BPXROOT  SYS1        8192 Jun  2 23:08 ..",
            "-rwxrwxrwx   1 BPXROOT  SYS1           0 Jun  2 23:14 my.jcl"
        ]
    }
}
```
<img width="1455" alt="Captura de pantalla 2023-06-07 a la(s) 16 02 43" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/8ad9ab6b-a5ac-4c95-9fb7-57914c8b2541">
