### PR TITLE
Update zos_data_set member description created

### DIFF
--- a/ac
+++ b/ac
@@ -361,6 +361,9 @@ ac_test(){
         done
     fi
 
+    # Clean up the collections folder after running the tests, temporary work around.
+    rm -rf collections/ansible_collections
+
     #cd ${CURR_DIR}
 }
 

--- a/changelogs/fragments/791-doc-zos_data_set-member-update.yml
+++ b/changelogs/fragments/791-doc-zos_data_set-member-update.yml
@@ -1,0 +1,5 @@
+trivial:
+- zos_data_set - when a member is created by the module, the format is type
+  data which is not suitable for executables. This change describes the
+  format used when creating member.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/791)

--- a/changelogs/fragments/791-doc-zos_data_set-member-update.yml
+++ b/changelogs/fragments/791-doc-zos_data_set-member-update.yml
@@ -1,5 +1,0 @@
-trivial:
-- zos_data_set - when a member is created by the module, the format is type
-  data which is not suitable for executables. This change describes the
-  format used when creating member.
-  (https://github.com/ansible-collections/ibm_zos_core/pull/791)

--- a/changelogs/fragments/791-zos_data_set-update-vsam.yml
+++ b/changelogs/fragments/791-zos_data_set-update-vsam.yml
@@ -7,11 +7,11 @@ trivial:
   now removes the unwanted files.
   (https://github.com/ansible-collections/ibm_zos_core/pull/791)
 bugfixes:
-- zos_copy - Reported a failure caused when `present=absent` for a VSAM
+- zos_data_set - Reported a failure caused when `present=absent` for a VSAM
   data set leaving behind cluster components. Fix introduces a new logical
   flow that will evaluate the volumes, compare it to the provided value and
   if necessary catalog and delete.
-  (https://github.com/ansible-collections/ibm_zos_core/pull/762).
+  (https://github.com/ansible-collections/ibm_zos_core/pull/791).
 - module_utils - data_set.py - Reported a failure caused when cataloging a
   VSAM data set. Fix now corrects how VSAM data sets are cataloged.
-  (https://github.com/ansible-collections/ibm_zos_core/pull/762).
+  (https://github.com/ansible-collections/ibm_zos_core/pull/791).

--- a/changelogs/fragments/791-zos_data_set-update-vsam.yml
+++ b/changelogs/fragments/791-zos_data_set-update-vsam.yml
@@ -1,0 +1,17 @@
+trivial:
+- zos_data_set - when a member is created by the module, the format is type
+  data which is not suitable for executables. This change describes the
+  format used when creating member.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/791)
+- ac - Reported an issue when functional tests ran leaving behind files. Fix
+  now removes the unwanted files.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/791)
+bugfixes:
+- zos_copy - Reported a failure caused when `present=absent` for a VSAM
+  data set leaving behind cluster components. Fix introduces a new logical
+  flow that will evaluate the volumes, compare it to the provided value and
+  if necessary catalog and delete.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/762).
+- module_utils - data_set.py - Reported a failure caused when cataloging a
+  VSAM data set. Fix now corrects how VSAM data sets are cataloged.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/762).

--- a/docs/source/modules/zos_data_set.rst
+++ b/docs/source/modules/zos_data_set.rst
@@ -65,6 +65,9 @@ state
   If *state=present* and *replace=False* and the data set is present on the managed node, no action taken, module completes successfully with *changed=False*.
 
 
+  If *state=present* and *type=MEMBER* and the member does not exist in the data set, create a member formatted to store data, module completes successfully with *changed=True*. Note, a PDSE does not allow a mixture of formats such that there is executables (program objects) and data. The member created is formatted to store data, not an executable.
+
+
   If *state=cataloged* and *volumes* is provided and the data set is already cataloged, no action taken, module completes successfully with *changed=False*.
 
 
@@ -74,7 +77,7 @@ state
   If *state=cataloged* and *volumes* is provided and the data set is not cataloged, module attempts to perform catalog using supplied *name* and *volumes*. If the attempt to catalog the data set catalog fails, returns failure with *changed=False*.
 
 
-  If *state=uncataloged* and the data set is not found, no action taken , module completes successfully with *changed=False*.
+  If *state=uncataloged* and the data set is not found, no action taken, module completes successfully with *changed=False*.
 
 
   If *state=uncataloged* and the data set is found, the data set is uncataloged, module completes successfully with *changed=True*.
@@ -330,6 +333,9 @@ batch
     If *state=present* and *replace=False* and the data set is present on the managed node, no action taken, module completes successfully with *changed=False*.
 
 
+    If *state=present* and *type=MEMBER* and the member does not exist in the data set, create a member formatted to store data, module completes successfully with *changed=True*. Note, a PDSE does not allow a mixture of formats such that there is executables (program objects) and data. The member created is formatted to store data, not an executable.
+
+
     If *state=cataloged* and *volumes* is provided and the data set is already cataloged, no action taken, module completes successfully with *changed=False*.
 
 
@@ -339,7 +345,7 @@ batch
     If *state=cataloged* and *volumes* is provided and the data set is not cataloged, module attempts to perform catalog using supplied *name* and *volumes*. If the attempt to catalog the data set catalog fails, returns failure with *changed=False*.
 
 
-    If *state=uncataloged* and the data set is not found, no action taken , module completes successfully with *changed=False*.
+    If *state=uncataloged* and the data set is not found, no action taken, module completes successfully with *changed=False*.
 
 
     If *state=uncataloged* and the data set is found, the data set is uncataloged, module completes successfully with *changed=True*.
@@ -352,7 +358,7 @@ batch
 
 
   type
-    The data set type to be used when creating a data set. (e.g ``pdse``)
+    The data set type to be used when creating a data set. (e.g ``PDSE``)
 
     ``MEMBER`` expects to be used with an existing partitioned data set.
 

--- a/docs/source/modules/zos_data_set.rst
+++ b/docs/source/modules/zos_data_set.rst
@@ -56,6 +56,9 @@ state
   If *state=absent* and *volumes* is provided, and the data set is not found in the catalog, the module attempts to perform catalog using supplied *name* and *volumes*. If the attempt to catalog the data set catalog fails, then no action is taken. Module completes successfully with *changed=False*.
 
 
+  If *state=absent* and *volumes* is provided, and the data set is found in the catalog, the module compares the catalog volume attributes to the provided *volumes*. If they volume attributes are different, the cataloged data set will be uncataloged temporarily while the requested data set be deleted is cataloged. The module will catalog the original data set on completion, if the attempts to catalog fail, no action is taken. Module completes successfully with *changed=False*.
+
+
   If *state=present* and the data set does not exist on the managed node, create and catalog the data set, module completes successfully with *changed=True*.
 
 
@@ -322,6 +325,9 @@ batch
 
 
     If *state=absent* and *volumes* is provided, and the data set is not found in the catalog, the module attempts to perform catalog using supplied *name* and *volumes*. If the attempt to catalog the data set catalog fails, then no action is taken. Module completes successfully with *changed=False*.
+
+
+    If *state=absent* and *volumes* is provided, and the data set is found in the catalog, the module compares the catalog volume attributes to the provided *volumes*. If they volume attributes are different, the cataloged data set will be uncataloged temporarily while the requested data set be deleted is cataloged. The module will catalog the original data set on completion, if the attempts to catalog fail, no action is taken. Module completes successfully with *changed=False*.
 
 
     If *state=present* and the data set does not exist on the managed node, create and catalog the data set, module completes successfully with *changed=True*.

--- a/docs/source/modules/zos_job_query.rst
+++ b/docs/source/modules/zos_job_query.rst
@@ -133,19 +133,31 @@ jobs
 
         [
             {
+                "asid": 0,
+                "creation_datetime": "20230503T121300",
+                "job_class": "K",
                 "job_id": "JOB01427",
                 "job_name": "LINKJOB",
                 "owner": "ADMIN",
-                "ret_code": "null"
+                "priority": 1,
+                "queue_position": 3,
+                "ret_code": "null",
+                "svc_class": "?"
             },
             {
+                "asid": 4,
+                "creation_datetime": "20230503T121400",
+                "job_class": "A",
                 "job_id": "JOB16577",
                 "job_name": "LINKCBL",
                 "owner": "ADMIN",
+                "priority": 0,
+                "queue_position": 0,
                 "ret_code": {
                     "code": "null",
                     "msg": "CANCELED"
-                }
+                },
+                "svc_class": "E"
             }
         ]
 
@@ -231,6 +243,41 @@ jobs
         | **type**: int
 
 
+
+  job_class
+    Letter indicating job class for this job.
+
+    | **type**: str
+    | **sample**: A
+
+  svc_class
+    Character indicating service class for this job.
+
+    | **type**: str
+    | **sample**: C
+
+  priority
+    A numeric indicator of the job priority assigned through JES.
+
+    | **type**: int
+    | **sample**: 4
+
+  asid
+    An identifier created by JES.
+
+    | **type**: int
+
+  creation_datetime
+    Date and time, local to the target system, when the job was created.
+
+    | **type**: str
+    | **sample**: 20230504T141500
+
+  queue_position
+    Integer of the position within the job queue where this jobs resided.
+
+    | **type**: int
+    | **sample**: 3
 
 
 message

--- a/docs/source/modules/zos_job_submit.rst
+++ b/docs/source/modules/zos_job_submit.rst
@@ -223,8 +223,10 @@ jobs
 
         [
             {
+                "asid": 0,
                 "class": "K",
                 "content_type": "JOB",
+                "creation_datetime": "20230503T121300",
                 "ddnames": [
                     {
                         "byte_count": "677",
@@ -419,9 +421,12 @@ jobs
                         "stepname": "DLORD6"
                     }
                 ],
+                "job_class": "K",
                 "job_id": "JOB00361",
                 "job_name": "DBDGEN00",
                 "owner": "OMVSADM",
+                "priority": 1,
+                "queue_position": 3,
                 "ret_code": {
                     "code": 0,
                     "msg": "CC 0000",
@@ -434,7 +439,8 @@ jobs
                         }
                     ]
                 },
-                "subsystem": "STL1"
+                "subsystem": "STL1",
+                "svc_class": "?"
             }
         ]
 
@@ -587,6 +593,41 @@ jobs
         | **type**: int
 
 
+
+  job_class
+    Letter indicating job class for this job.
+
+    | **type**: str
+    | **sample**: A
+
+  svc_class
+    Character indicating service class for this job.
+
+    | **type**: str
+    | **sample**: C
+
+  priority
+    A numeric indicator of the job priority assigned through JES.
+
+    | **type**: int
+    | **sample**: 4
+
+  asid
+    An identifier created by JES.
+
+    | **type**: int
+
+  creation_datetime
+    Date and time, local to the target system, when the job was created.
+
+    | **type**: str
+    | **sample**: 20230504T141500
+
+  queue_position
+    Integer of the position within the job queue where this jobs resided.
+
+    | **type**: int
+    | **sample**: 3
 
 
 message

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9,<2.15'
+requires_ansible: '>=2.9,<2.16'

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -210,9 +210,7 @@ class DataSet(object):
         Returns:
             changed (bool) -- Indicates if changes were made.
         """
-
-        changed, present =  DataSet.attempt_catalog_if_necessary_and_delete(name, volumes)
-
+        changed, present = DataSet.attempt_catalog_if_necessary_and_delete(name, volumes)
         return changed
 
     # ? should we do additional check to ensure member was actually created?
@@ -350,7 +348,7 @@ class DataSet(object):
 
         if volumes:
             cataloged_volume_list = DataSet.data_set_cataloged_volume_list(name) or []
-            if bool(set(volumes) & set (cataloged_volume_list)):
+            if bool(set(volumes) & set(cataloged_volume_list)):
                 return True
         else:
             if re.search(r"-\s" + name + r"\s*\n\s+IN-CAT", stdout):
@@ -729,7 +727,7 @@ class DataSet(object):
                     except DatasetCatalogError:
                         try:
                             # A failure, so recatalog the original data set on the original volumes
-                            DataSet.catalog(name,cataloged_volume_list_original)
+                            DataSet.catalog(name, cataloged_volume_list_original)
                         except DatasetCatalogError:
                             pass
                         return changed, present
@@ -745,12 +743,12 @@ class DataSet(object):
                                 DataSet.uncatalog(name)
                             except DatasetUncatalogError:
                                 try:
-                                    DataSet.catalog(name,cataloged_volume_list_original)
+                                    DataSet.catalog(name, cataloged_volume_list_original)
                                 except DatasetCatalogError:
                                     pass
                             return changed, present
                         try:
-                            DataSet.catalog(name,cataloged_volume_list_original)
+                            DataSet.catalog(name, cataloged_volume_list_original)
                             changed = True
                             present = False
                         except DatasetCatalogError:
@@ -1113,13 +1111,13 @@ class DataSet(object):
         data_set_name = name.upper()
         success = False
         command_rc = 0
-        command =""
+        command = ""
 
         # In order to catalog a uncataloged data set, we can't rely on LISTCAT
         # so using the VTOC entries we can make some assumptions of if the data set
         # is indexed, linear etc.
-        ds_vtoc_data_entry = vtoc.get_data_set_entry(name+".DATA", volumes[0])
-        ds_vtoc_index_entry = vtoc.get_data_set_entry(name+".INDEX", volumes[0])
+        ds_vtoc_data_entry = vtoc.get_data_set_entry(name + ".DATA", volumes[0])
+        ds_vtoc_index_entry = vtoc.get_data_set_entry(name + ".INDEX", volumes[0])
 
         if ds_vtoc_data_entry and ds_vtoc_index_entry:
             data_set_type_vsam = "INDEXED"

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import pprint
 import re
 import tempfile
 from os import path, walk
@@ -40,11 +39,9 @@ except ImportError:
     vtoc = MissingImport("vtoc")
 
 try:
-    from zoautil_py import datasets, mvscmd, types
+    from zoautil_py import datasets
 except ImportError:
     datasets = MissingZOAUImport()
-    mvscmd = MissingZOAUImport()
-    types = MissingZOAUImport()
 
 
 class DataSet(object):

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import pprint
 import re
 import tempfile
 from os import path, walk
@@ -68,25 +69,18 @@ class DataSet(object):
     }
 
     _VSAM_CATALOG_COMMAND_NOT_INDEXED = """ DEFINE CLUSTER -
-        (NAME('{0}') -
-        VOLUMES({1} -
-        ) -
-        RECATALOG -
-        {2}) -
-    DATA( -
-        NAME('{0}.DATA'))
+    (NAME('{0}') -
+    VOLUMES({1}) -
+    RECATALOG {2}) -
+    DATA(NAME('{0}.DATA'))
     """
 
     _VSAM_CATALOG_COMMAND_INDEXED = """ DEFINE CLUSTER -
-        (NAME('{0}') -
-        VOLUMES({1} -
-        ) -
-        RECATALOG -
-        {2}) -
-    DATA( -
-        NAME('{0}.DATA')) -
-    INDEX( -
-        NAME('{0}.INDEX'))
+    (NAME('{0}') -
+    VOLUMES({1}) -
+    RECATALOG {2}) -
+    DATA(NAME('{0}.DATA')) -
+    INDEX(NAME('{0}.INDEX'))
     """
 
     _NON_VSAM_UNCATALOG_COMMAND = " UNCATLG DSNAME={0}"
@@ -214,22 +208,14 @@ class DataSet(object):
             name (str) -- The name of the data set to ensure is absent.
             volumes (list[str]) -- The volumes the data set may reside on.
         Returns:
-            bool -- Indicates if changes were made.
+            changed (bool) -- Indicates if changes were made.
         """
-        if volumes:
-            changed, present, pending_to_catalog_and_delete = DataSet.attempt_to_delete_uncataloged_data_set_if_necessary(
-                name, volumes)
-            if not pending_to_catalog_and_delete:
-                return changed
 
-        present, changed = DataSet.attempt_catalog_if_necessary(name, volumes)
-        if present:
-            DataSet.delete(name)
-            return True
-        return False
+        changed, present =  DataSet.attempt_catalog_if_necessary_and_delete(name, volumes)
+
+        return changed
 
     # ? should we do additional check to ensure member was actually created?
-
     @staticmethod
     def ensure_member_present(name, replace=False):
         """Creates data set member if it does not already exist.
@@ -270,7 +256,7 @@ class DataSet(object):
         Returns:
             bool -- If changes were made.
         """
-        if DataSet.data_set_cataloged(name):
+        if DataSet.data_set_cataloged(name, None):
             return False
         try:
             DataSet.catalog(name, volumes)
@@ -345,7 +331,7 @@ class DataSet(object):
             raise MVSCmdExecError(rc, out, err)
 
     @staticmethod
-    def data_set_cataloged(name):
+    def data_set_cataloged(name, volumes=None):
         """Determine if a data set is in catalog.
 
         Arguments:
@@ -354,18 +340,26 @@ class DataSet(object):
         Returns:
             bool -- If data is is cataloged.
         """
+
         name = name.upper()
         module = AnsibleModuleHelper(argument_spec={})
         stdin = " LISTCAT ENTRIES('{0}')".format(name)
         rc, stdout, stderr = module.run_command(
             "mvscmdauth --pgm=idcams --sysprint=* --sysin=stdin", data=stdin
         )
-        if re.search(r"-\s" + name + r"\s*\n\s+IN-CAT", stdout):
-            return True
+
+        if volumes:
+            cataloged_volume_list = DataSet.data_set_cataloged_volume_list(name) or []
+            if bool(set(volumes) & set (cataloged_volume_list)):
+                return True
+        else:
+            if re.search(r"-\s" + name + r"\s*\n\s+IN-CAT", stdout):
+                return True
+
         return False
 
     @staticmethod
-    def get_volume_list_for_cataloged_data_set(name):
+    def data_set_cataloged_volume_list(name):
         """Get the volume list for a cataloged dataset name.
         Arguments:
             name (str) -- The data set name to check if cataloged.
@@ -380,8 +374,8 @@ class DataSet(object):
         )
         delimiter = 'VOLSER------------'
         arr = stdout.split(delimiter)
-        # If a volume serial is not always of lenght 6 we could use ":x.find(' ')" here instead of that index.
-        volume_list = [x[:x.find(' ')] for x in arr[1:]]
+        # A volume serial (VOLSER) is not always of fixed length, use ":x.find(' ')" here instead of arr[index].
+        volume_list = list(set([x[:x.find(' ')] for x in arr[1:]]))
         return volume_list
 
     @staticmethod
@@ -421,71 +415,6 @@ class DataSet(object):
         return True
 
     @staticmethod
-    def delete_uncataloged_dataset(name, volumes):
-        """Delete an uncataloged dataset by specifying volumes.
-        Arguments:
-            name (str) -- The data set name to check if cataloged.
-            volumes (list[str]) -- The volumes the data set may reside on.
-        Returns:
-            bool -- Return code from the mvs_cmd, if 0 then it was successful.
-        """
-
-        # NVR specifies that the object to be deleted is an SMS-managed non-VSAM
-        # volume record (NVR) entry. This parameter must be specified to delete
-        # an NVR from a VSAM volume data set (VVDS) and its corresponding record
-        # from the VTOC. The NVR/VTOC entries are deleted only if the related
-        # non-VSAM object catalog entry does not exist.
-
-        # VVR specifies that the objects to be deleted are one or more unrelated
-        # VSAM volume record (VVR) entries. To delete a VVR from both the VSAM
-        # volume data set (VVDS) and from the VTOC, you must specify this parameter.
-
-        # To delete a VSAM DS that is not cataloged you must delete each VSAM record
-        # for that VSAM type and use VVR and FILE. You can simulate a uncataloged DS
-        # with commands:
-        # - echo "  DELETE IBMUSER.VSAM.KSDS CLUSTER NOSCRATCH NOPURGE" |
-        #    mvscmdauth --pgm=IDCAMS --sysprint=* --sysin=stdin
-        # echo "  DELETE IBMUSER.DATASET NOSCRATCH" | mvscmdauth --pgm=IDCAMS
-        #   --sysprint=* --sysin=stdin
-
-        if DataSet.is_vsam(name, volumes):
-            vol_record_entry = 'VVR'
-            # Delete the DATA record of a VSAM, applies to KSDS, RRDS, ESDS, LDS
-            vsam_name_extension = '.DATA'
-            command = " DELETE {0} FILE(DD1) {1}".format(name + vsam_name_extension, vol_record_entry)
-            dds = dict(DD1=',vol,'.join(volumes) + ',vol')
-            rc, stdout, stderr = mvs_cmd.idcams(cmd=command, dds=dds, authorized=True)
-            # RC 8 occurs when the VSAM Record does not exist, thus acceptable
-            if rc > 8:
-                raise DatasetDeleteError(name, rc)
-
-            # Delete the INDEX record of a VSAM, this does NOT apply to RRDS, ESDS, LDS but
-            # the VASAM is not in catalog so we can't detect the type of VSAM so we
-            # can expect an RC 8 to appear for non KSDS types.
-            vsam_name_extension = '.INDEX'
-            command = " DELETE {0} FILE(DD1) {1}".format(name + vsam_name_extension, vol_record_entry)
-            dds = dict(DD1=',vol,'.join(volumes) + ',vol')
-            rc, stdout, stderr = mvs_cmd.idcams(cmd=command, dds=dds, authorized=True)
-            # RC 8 occurs when the VSAM Record does exist, thus acceptable
-            if rc > 8:
-                raise DatasetDeleteError(name, rc)
-        else:
-            vol_record_entry = 'NVR'
-            command = " DELETE {0} FILE(DD1) {1}".format(name, vol_record_entry)
-            dds = dict(DD1=',vol,'.join(volumes) + ',vol')
-            rc, stdout, stderr = mvs_cmd.idcams(cmd=command, dds=dds, authorized=True)
-            # RC 8 occurs when the VSAM Record does not exist, thus acceptable
-            if rc > 8:
-                raise DatasetDeleteError(name, rc)
-
-        # Callers expect a RC 0 to evaluate if there was a change, so normalize
-        # to rc 0
-        if rc <= 8:
-            rc = 0
-
-        return rc
-
-    @staticmethod
     def data_set_shared_members(src, dest):
         """Checks for the existence of members from a source data set in
         a destination data set.
@@ -504,45 +433,6 @@ class DataSet(object):
                 return True
 
         return False
-
-    @staticmethod
-    def attempt_to_delete_uncataloged_data_set_if_necessary(name, volumes):
-        """Attempt to delete any uncataloged dataset if exists on any user provided volumes
-           and there is a cataloged dataset with the same name.
-        Arguments:
-            name (str) -- The data set name to check if cataloged.
-            volumes (list[str]) -- The volumes the data set may reside on.
-        Returns:
-            bool -- If any action was performed on the data.
-            bool -- If the dataset is still present.
-            bool -- If given the volumes list and dataset name we need to continue with deleting the dataset as usual,
-            either by cataloging it and deleting or deleting a cataloged dataset.
-        """
-        changed = False
-        present = True
-        pending_to_delete_cataloged_dataset = False
-        # Get the list of volumes that the dataset is catalogued in.
-        cataloged_volume_list = DataSet.get_volume_list_for_cataloged_data_set(name)
-        if len(cataloged_volume_list) == 0:
-            return changed, present, True
-
-        # If a volume provided (volumes) is not in the list cataloged_volume_list, we need to
-        # delete them from the cataloged_volume_list, this leaves us with with uncataloged data sets that
-        # correspond to the volumes argument.
-        volumes_for_uncataloged_dataset = list(filter(lambda vol: vol not in cataloged_volume_list, volumes))
-
-        # If any volume provided (volumes) is in the list we will delete from catalog as normal.
-        pending_to_delete_cataloged_dataset = any(vol in volumes for vol in cataloged_volume_list)
-
-        if len(volumes_for_uncataloged_dataset) > 0:
-            volumes = list(filter(lambda vol: DataSet._is_in_vtoc(name, vol), volumes))
-            if len(volumes) > 0:
-                present = DataSet.delete_uncataloged_dataset(name, volumes)
-                changed = present == 0
-            else:
-                changed = False
-
-        return changed, present, pending_to_delete_cataloged_dataset
 
     @staticmethod
     def get_member_name_from_file(file_name):
@@ -623,7 +513,7 @@ class DataSet(object):
 
     @staticmethod
     def data_set_type(name, volume=None):
-        """Checks the type of a data set.
+        """Checks the type of a data set, data sets must be cataloged.
 
         Arguments:
             name (str) -- The name of the data set.
@@ -782,6 +672,114 @@ class DataSet(object):
                 changed = True
                 present = True
         return present, changed
+
+    @staticmethod
+    def attempt_catalog_if_necessary_and_delete(name, volumes):
+        """Attempts to catalog a data set if not already cataloged, then deletes
+           the data set.
+           This is helpful when a data set currently cataloged is not the data
+           set needing to be deleted, meaning the one in the provided volumes
+           is needing to be deleted.. Recall, you can have a data set in
+           two different volumes, and only one cataloged.
+
+        Arguments:
+            name (str) -- The name of the data set.
+            volumes (list[str]) -- The volumes the data set may reside on.
+
+        Returns:
+            changed (bool) -- Whether changes were made.
+            present (bool) -- Whether the data set is now present.
+        """
+
+        changed = False
+        present = True
+
+        if volumes:
+            # Check if the data set is cataloged
+            present = DataSet.data_set_cataloged(name)
+
+            if present:
+                # Data set is cataloged, now check it its cataloged on the provided volumes
+                # If it is, we just delete because the DS is the right one wanting deletion.
+                present = DataSet.data_set_cataloged(name, volumes)
+
+                if present:
+                    DataSet.delete(name)
+                    changed = True
+                    present = False
+                else:
+                    # It appears that what is in catalog does not match the provided
+                    # volumes, therefore the user wishes we delete a data set on a
+                    # particular volue, NOT what is in catalog.
+                    # for the provided volumes
+
+                    # We need to identify the volumes where the current cataloged data set
+                    # is located for use later when we recatalog. Code is strategically
+                    # placed before the uncatalog.
+                    cataloged_volume_list_original = DataSet.data_set_cataloged_volume_list(name)
+
+                    try:
+                        DataSet.uncatalog(name)
+                    except DatasetUncatalogError:
+                        return changed, present
+
+                    # Catalog the data set for the provided volumes
+                    try:
+                        DataSet.catalog(name, volumes)
+                    except DatasetCatalogError:
+                        try:
+                            # A failure, so recatalog the original data set on the original volumes
+                            DataSet.catalog(name,cataloged_volume_list_original)
+                        except DatasetCatalogError:
+                            pass
+                        return changed, present
+
+                    # Check the recatalog, ensure it cataloged before we try to remove
+                    present = DataSet.data_set_cataloged(name, volumes)
+
+                    if present:
+                        try:
+                            DataSet.delete(name)
+                        except DatasetDeleteError:
+                            try:
+                                DataSet.uncatalog(name)
+                            except DatasetUncatalogError:
+                                try:
+                                    DataSet.catalog(name,cataloged_volume_list_original)
+                                except DatasetCatalogError:
+                                    pass
+                            return changed, present
+                        try:
+                            DataSet.catalog(name,cataloged_volume_list_original)
+                            changed = True
+                            present = False
+                        except DatasetCatalogError:
+                            changed = True
+                            present = False
+                            return changed, present
+            else:
+                try:
+                    DataSet.catalog(name, volumes)
+                except DatasetCatalogError:
+                    return changed, present
+
+                present = DataSet.data_set_cataloged(name, volumes)
+
+                if present:
+                    DataSet.delete(name)
+                    changed = True
+                    present = False
+        else:
+            present = DataSet.data_set_cataloged(name, None)
+            if present:
+                try:
+                    DataSet.delete(name)
+                    changed = True
+                    present = False
+                except DatasetDeleteError:
+                    return changed, present
+
+        return changed, present
 
     @staticmethod
     def _is_in_vtoc(name, volume):
@@ -1115,25 +1113,53 @@ class DataSet(object):
         data_set_name = name.upper()
         success = False
         command_rc = 0
-        for data_set_type in ["", "LINEAR", "INDEXED", "NONINDEXED", "NUMBERED"]:
-            if data_set_type != "INDEXED":
-                command = DataSet._VSAM_CATALOG_COMMAND_NOT_INDEXED.format(
-                    data_set_name,
-                    DataSet._build_volume_string_idcams(volumes),
-                    data_set_type,
-                )
-            else:
-                command = DataSet._VSAM_CATALOG_COMMAND_INDEXED.format(
-                    data_set_name,
-                    DataSet._build_volume_string_idcams(volumes),
-                    data_set_type,
-                )
-            command_rc, stdout, stderr = module.run_command(
-                "mvscmdauth --pgm=idcams --sysprint=* --sysin=stdin", data=command
+        command =""
+
+        # In order to catalog a uncataloged data set, we can't rely on LISTCAT
+        # so using the VTOC entries we can make some assumptions of if the data set
+        # is indexed, linear etc.
+        ds_vtoc_data_entry = vtoc.get_data_set_entry(name+".DATA", volumes[0])
+        ds_vtoc_index_entry = vtoc.get_data_set_entry(name+".INDEX", volumes[0])
+
+        if ds_vtoc_data_entry and ds_vtoc_index_entry:
+            data_set_type_vsam = "INDEXED"
+        else:
+            data_set_type_vsam = "NONINDEXED"
+
+        if data_set_type_vsam != "INDEXED":
+            command = DataSet._VSAM_CATALOG_COMMAND_NOT_INDEXED.format(
+                data_set_name,
+                DataSet._build_volume_string_idcams(volumes),
+                data_set_type_vsam,
             )
+        else:
+            command = DataSet._VSAM_CATALOG_COMMAND_INDEXED.format(
+                data_set_name,
+                DataSet._build_volume_string_idcams(volumes),
+                data_set_type_vsam,
+            )
+
+        command_rc, stdout, stderr = module.run_command(
+            "mvscmdauth --pgm=idcams --sysprint=* --sysin=stdin", data=command)
+
+        if command_rc == 0:
+            success = True
+            # break
+
+        if not success:
+            # Liberty taken such that here we can assume  its a LINEAR VSAM
+            command = DataSet._VSAM_CATALOG_COMMAND_NOT_INDEXED.format(
+                data_set_name,
+                DataSet._build_volume_string_idcams(volumes),
+                "LINEAR",
+            )
+
+            command_rc, stdout, stderr = module.run_command(
+                "mvscmdauth --pgm=idcams --sysprint=* --sysin=stdin", data=command)
+
             if command_rc == 0:
                 success = True
-                break
+
         if not success:
             raise DatasetCatalogError(
                 name,

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -311,6 +311,13 @@ options:
             I(name) and I(volumes). If the attempt to catalog the data set catalog fails,
             then no action is taken. Module completes successfully with I(changed=False).
           - >
+            If I(state=absent) and I(volumes) is provided, and the data set is found in
+            the catalog, the module compares the catalog volume attributes to the provided
+            I(volumes). If they volume attributes are different, the cataloged data set
+            will be uncataloged temporarily while the requested data set be deleted is cataloged.
+            The module will catalog the original data set on completion, if the attempts to
+            catalog fail, no action is taken. Module completes successfully with I(changed=False).
+          - >
             If I(state=present) and the data set does not exist on the managed node,
             create and catalog the data set, module completes successfully with I(changed=True).
           - >

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -58,6 +58,13 @@ options:
         I(name) and I(volumes). If the attempt to catalog the data set catalog fails,
         then no action is taken. Module completes successfully with I(changed=False).
       - >
+        If I(state=absent) and I(volumes) is provided, and the data set is found in
+        the catalog, the module compares the catalog volume attributes to the provided
+        I(volumes). If they volume attributes are different, the cataloged data set
+        will be uncataloged temporarily while the requested data set be deleted is cataloged.
+        The module will catalog the original data set on completion, if the attempts to
+        catalog fail, no action is taken. Module completes successfully with I(changed=False).
+      - >
         If I(state=present) and the data set does not exist on the managed node,
         create and catalog the data set, module completes successfully with I(changed=True).
       - >

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -68,6 +68,12 @@ options:
         If I(state=present) and I(replace=False) and the data set is present
         on the managed node, no action taken, module completes successfully with I(changed=False).
       - >
+        If I(state=present) and I(type=MEMBER) and the member does not exist in the data set,
+        create a member formatted to store data, module completes successfully with I(changed=True).
+        Note, a PDSE does not allow a mixture of formats such that there is
+        executables (program objects) and data. The member created is formatted to store data,
+        not an executable.
+      - >
         If I(state=cataloged) and I(volumes) is provided and the data set is already cataloged,
         no action taken, module completes successfully with I(changed=False).
       - >
@@ -79,11 +85,11 @@ options:
         module attempts to perform catalog using supplied I(name) and I(volumes). If the attempt to
         catalog the data set catalog fails, returns failure with I(changed=False).
       - >
-        If I(state=uncataloged) and the data set is not found,
-        no action taken , module completes successfully with I(changed=False).
+        If I(state=uncataloged) and the data set is not found, no action taken,
+        module completes successfully with I(changed=False).
       - >
-        If I(state=uncataloged) and the data set is found,
-        the data set is uncataloged, module completes successfully with I(changed=True).
+        If I(state=uncataloged) and the data set is found, the data set is uncataloged,
+        module completes successfully with I(changed=True).
     required: false
     type: str
     default: present
@@ -315,6 +321,12 @@ options:
             If I(state=present) and I(replace=False) and the data set is present
             on the managed node, no action taken, module completes successfully with I(changed=False).
           - >
+            If I(state=present) and I(type=MEMBER) and the member does not exist in the data set,
+            create a member formatted to store data, module completes successfully with I(changed=True).
+            Note, a PDSE does not allow a mixture of formats such that there is
+            executables (program objects) and data. The member created is formatted to store data,
+            not an executable.
+          - >
             If I(state=cataloged) and I(volumes) is provided and the data set is already cataloged,
             no action taken, module completes successfully with I(changed=False).
           - >
@@ -326,11 +338,11 @@ options:
             module attempts to perform catalog using supplied I(name) and I(volumes). If the attempt to
             catalog the data set catalog fails, returns failure with I(changed=False).
           - >
-            If I(state=uncataloged) and the data set is not found,
-            no action taken , module completes successfully with I(changed=False).
+            If I(state=uncataloged) and the data set is not found, no action taken,
+            module completes successfully with I(changed=False).
           - >
-            If I(state=uncataloged) and the data set is found,
-            the data set is uncataloged, module completes successfully with I(changed=True).
+            If I(state=uncataloged) and the data set is found, the data set is uncataloged,
+            module completes successfully with I(changed=True).
         required: false
         type: str
         default: present
@@ -341,7 +353,7 @@ options:
           - uncataloged
       type:
         description:
-          - The data set type to be used when creating a data set. (e.g C(pdse))
+          - The data set type to be used when creating a data set. (e.g C(PDSE))
           - C(MEMBER) expects to be used with an existing partitioned data set.
           - Choices are case-insensitive.
         required: false

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -327,7 +327,7 @@ def test_data_set_absent_when_uncataloged_and_same_name_cataloged_is_present(ans
 
     hosts.all.file(path=TEMP_PATH, state="directory")
     hosts.all.shell(cmd=ECHO_COMMAND.format(quote(jcl), TEMP_PATH))
-    hosts.all.zos_job_submit(src=TEMP_PATH + "/SAMPLE", location="USS", wait=True)
+    results =hosts.all.zos_job_submit(src=TEMP_PATH + "/SAMPLE", location="USS", wait=True)
 
     # verify data set creation was successful
     for result in results.contacted.values():

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -34,8 +34,8 @@ data_set_types = [
     ("lds"),
 ]
 
-DEFAULT_VOLUME = "000000"
-DEFAULT_VOLUME2 = "222222"
+VOLUME_000000 = "000000"
+VOLUME_222222 = "222222"
 DEFAULT_DATA_SET_NAME = "USER.PRIVATE.TESTDS"
 DEFAULT_DATA_SET_NAME_WITH_MEMBER = "USER.PRIVATE.TESTDS(TESTME)"
 TEMP_PATH = "/tmp/jcl"
@@ -140,6 +140,9 @@ def retrieve_data_set_names(results):
                     data_set_names.append(name)
     return data_set_names
 
+def print_results(results):
+    for result in results.contacted.values():
+        pprint(result)
 
 @pytest.mark.parametrize(
     "jcl",
@@ -149,7 +152,7 @@ def test_data_set_catalog_and_uncatalog(ansible_zos_module, jcl):
     try:
         hosts = ansible_zos_module
         hosts.all.zos_data_set(
-            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=DEFAULT_VOLUME
+            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=VOLUME_000000
         )
         hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
 
@@ -160,13 +163,10 @@ def test_data_set_catalog_and_uncatalog(ansible_zos_module, jcl):
         )
         # verify data set creation was successful
         for result in results.contacted.values():
-            pprint(result)
             if(result.get("jobs")[0].get("ret_code") is None):
                 submitted_job_id = result.get("jobs")[0].get("job_id")
                 assert submitted_job_id is not None
                 results = hosts.all.zos_job_output(job_id=submitted_job_id)
-                print("Getting failed JOB")
-                pprint(vars(results))
             assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
         # verify first uncatalog was performed
         results = hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="uncataloged")
@@ -178,13 +178,13 @@ def test_data_set_catalog_and_uncatalog(ansible_zos_module, jcl):
             assert result.get("changed") is False
         # recatalog the data set
         results = hosts.all.zos_data_set(
-            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=DEFAULT_VOLUME
+            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=VOLUME_000000
         )
         for result in results.contacted.values():
             assert result.get("changed") is True
         # verify second catalog shows catalog already performed
         results = hosts.all.zos_data_set(
-            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=DEFAULT_VOLUME
+            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=VOLUME_000000
         )
         for result in results.contacted.values():
             assert result.get("changed") is False
@@ -192,7 +192,7 @@ def test_data_set_catalog_and_uncatalog(ansible_zos_module, jcl):
         # clean up
         hosts.all.file(path=TEMP_PATH, state="absent")
         # Added volumes to force a catalog in case they were somehow uncataloged to avoid an duplicate on volume error
-        hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent", volumes=[DEFAULT_VOLUME, DEFAULT_VOLUME2])
+        hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent", volumes=[VOLUME_000000, VOLUME_222222])
 
 
 @pytest.mark.parametrize(
@@ -203,9 +203,10 @@ def test_data_set_present_when_uncataloged(ansible_zos_module, jcl):
     try:
         hosts = ansible_zos_module
         hosts.all.zos_data_set(
-            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=DEFAULT_VOLUME
+            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=VOLUME_000000
         )
         hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
+
         hosts.all.file(path=TEMP_PATH, state="directory")
         hosts.all.shell(cmd=ECHO_COMMAND.format(quote(jcl), TEMP_PATH))
         results = hosts.all.zos_job_submit(
@@ -216,7 +217,7 @@ def test_data_set_present_when_uncataloged(ansible_zos_module, jcl):
             assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
         # ensure data set present
         results = hosts.all.zos_data_set(
-            name=DEFAULT_DATA_SET_NAME, state="present", volumes=DEFAULT_VOLUME
+            name=DEFAULT_DATA_SET_NAME, state="present", volumes=VOLUME_000000
         )
         for result in results.contacted.values():
             assert result.get("changed") is False
@@ -226,13 +227,13 @@ def test_data_set_present_when_uncataloged(ansible_zos_module, jcl):
             assert result.get("changed") is True
         # ensure data set present
         results = hosts.all.zos_data_set(
-            name=DEFAULT_DATA_SET_NAME, state="present", volumes=DEFAULT_VOLUME
+            name=DEFAULT_DATA_SET_NAME, state="present", volumes=VOLUME_000000
         )
         for result in results.contacted.values():
             assert result.get("changed") is True
     finally:
         hosts.all.file(path=TEMP_PATH, state="absent")
-        hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent", volumes=DEFAULT_VOLUME)
+        hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent", volumes=VOLUME_000000)
 
 
 @pytest.mark.parametrize(
@@ -243,9 +244,10 @@ def test_data_set_replacement_when_uncataloged(ansible_zos_module, jcl):
     try:
         hosts = ansible_zos_module
         hosts.all.zos_data_set(
-            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=DEFAULT_VOLUME
+            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=VOLUME_000000
         )
         hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
+
         hosts.all.file(path=TEMP_PATH, state="directory")
         hosts.all.shell(cmd=ECHO_COMMAND.format(quote(jcl), TEMP_PATH))
         results = hosts.all.zos_job_submit(
@@ -256,7 +258,7 @@ def test_data_set_replacement_when_uncataloged(ansible_zos_module, jcl):
             assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
         # ensure data set present
         results = hosts.all.zos_data_set(
-            name=DEFAULT_DATA_SET_NAME, state="present", volumes=DEFAULT_VOLUME
+            name=DEFAULT_DATA_SET_NAME, state="present", volumes=VOLUME_000000
         )
         for result in results.contacted.values():
             assert result.get("changed") is False
@@ -268,7 +270,7 @@ def test_data_set_replacement_when_uncataloged(ansible_zos_module, jcl):
         results = hosts.all.zos_data_set(
             name=DEFAULT_DATA_SET_NAME,
             state="present",
-            volumes=DEFAULT_VOLUME,
+            volumes=VOLUME_000000,
             replace=True,
         )
         for result in results.contacted.values():
@@ -286,9 +288,10 @@ def test_data_set_absent_when_uncataloged(ansible_zos_module, jcl):
     try:
         hosts = ansible_zos_module
         hosts.all.zos_data_set(
-            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=DEFAULT_VOLUME
+            name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=VOLUME_000000
         )
         hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
+
         hosts.all.file(path=TEMP_PATH, state="directory")
         hosts.all.shell(cmd=ECHO_COMMAND.format(quote(jcl), TEMP_PATH))
         results = hosts.all.zos_job_submit(
@@ -303,7 +306,7 @@ def test_data_set_absent_when_uncataloged(ansible_zos_module, jcl):
             assert result.get("changed") is True
         # ensure data set absent
         results = hosts.all.zos_data_set(
-            name=DEFAULT_DATA_SET_NAME, state="absent", volumes=DEFAULT_VOLUME
+            name=DEFAULT_DATA_SET_NAME, state="absent", volumes=VOLUME_000000
         )
         for result in results.contacted.values():
             assert result.get("changed") is True
@@ -318,40 +321,44 @@ def test_data_set_absent_when_uncataloged(ansible_zos_module, jcl):
 )
 def test_data_set_absent_when_uncataloged_and_same_name_cataloged_is_present(ansible_zos_module, jcl):
     hosts = ansible_zos_module
-    hosts.all.zos_data_set(
-        name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=DEFAULT_VOLUME
-    )
+    hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="cataloged", volumes=VOLUME_000000)
+
     hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
+
     hosts.all.file(path=TEMP_PATH, state="directory")
     hosts.all.shell(cmd=ECHO_COMMAND.format(quote(jcl), TEMP_PATH))
-    results = hosts.all.zos_job_submit(
-        src=TEMP_PATH + "/SAMPLE", location="USS", wait=True
-    )
+    hosts.all.zos_job_submit(src=TEMP_PATH + "/SAMPLE", location="USS", wait=True)
+
     # verify data set creation was successful
     for result in results.contacted.values():
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
+
     # uncatalog the data set
     results = hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="uncataloged")
     for result in results.contacted.values():
         assert result.get("changed") is True
+
     # Create the same dataset name in different volume
-    jcl = jcl.replace(DEFAULT_VOLUME, DEFAULT_VOLUME2)
+    jcl = jcl.replace(VOLUME_000000, VOLUME_222222)
+
     hosts.all.file(path=TEMP_PATH + "/SAMPLE", state="absent")
     hosts.all.shell(cmd=ECHO_COMMAND.format(quote(jcl), TEMP_PATH))
-    results = hosts.all.zos_job_submit(
-        src=TEMP_PATH + "/SAMPLE", location="USS", wait=True
-    )
+    results = hosts.all.zos_job_submit(src=TEMP_PATH + "/SAMPLE", location="USS", wait=True)
+
     # verify data set creation was successful
     for result in results.contacted.values():
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
+
     hosts.all.file(path=TEMP_PATH, state="absent")
+
     # ensure data set absent
-    results = hosts.all.zos_data_set(
-        name=DEFAULT_DATA_SET_NAME, state="absent", volumes=DEFAULT_VOLUME
-    )
+    results = hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent", volumes=VOLUME_000000)
     for result in results.contacted.values():
         assert result.get("changed") is True
-    hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
+
+    results = hosts.all.zos_data_set(name=DEFAULT_DATA_SET_NAME, state="absent")
+    for result in results.contacted.values():
+        assert result.get("changed") is True
 
 
 @pytest.mark.parametrize("dstype", data_set_types)
@@ -499,7 +506,7 @@ def test_data_member_force_delete(ansible_zos_module):
         for result in results.contacted.values():
             assert result.get("changed") is True
 
-        # add members
+        #add members
         results = hosts.all.zos_data_set(
             batch=[
                 {
@@ -672,7 +679,7 @@ def test_multi_volume_creation_uncatalog_and_catalog_nonvsam(ansible_zos_module)
             space_primary=5,
             space_type="CYL",
             record_length=15,
-            volumes=[DEFAULT_VOLUME, DEFAULT_VOLUME2],
+            volumes=[VOLUME_000000, VOLUME_222222],
         )
         for result in results.contacted.values():
             assert result.get("changed") is True
@@ -686,7 +693,7 @@ def test_multi_volume_creation_uncatalog_and_catalog_nonvsam(ansible_zos_module)
         results = hosts.all.zos_data_set(
             name=DEFAULT_DATA_SET_NAME,
             state="cataloged",
-            volumes=[DEFAULT_VOLUME, DEFAULT_VOLUME2],
+            volumes=[VOLUME_000000, VOLUME_222222],
         )
         for result in results.contacted.values():
             assert result.get("changed") is True
@@ -706,7 +713,7 @@ def test_multi_volume_creation_uncatalog_and_catalog_vsam(ansible_zos_module):
             key_offset=0,
             space_primary=5,
             space_type="CYL",
-            volumes=[DEFAULT_VOLUME, DEFAULT_VOLUME2],
+            volumes=[VOLUME_000000, VOLUME_222222],
         )
         for result in results.contacted.values():
             assert result.get("changed") is True
@@ -720,7 +727,7 @@ def test_multi_volume_creation_uncatalog_and_catalog_vsam(ansible_zos_module):
         results = hosts.all.zos_data_set(
             name=DEFAULT_DATA_SET_NAME,
             state="cataloged",
-            volumes=[DEFAULT_VOLUME, DEFAULT_VOLUME2],
+            volumes=[VOLUME_000000, VOLUME_222222],
         )
         for result in results.contacted.values():
             assert result.get("changed") is True
@@ -738,7 +745,7 @@ def test_data_set_old_aliases(ansible_zos_module):
             state="present",
             format="fb",
             size="5m",
-            volume=DEFAULT_VOLUME,
+            volume=VOLUME_000000,
         )
         for result in results.contacted.values():
             assert result.get("changed") is True

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,35 @@
+plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-spec # We use our own argument parser for advanced conditional and dependent arguments.
+plugins/modules/zos_backup_restore.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_blockinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_copy.py validate-modules:doc-default-does-not-match-spec # We use our own argument parser for advanced conditional and dependent arguments.
+plugins/modules/zos_copy.py validate-modules:doc-type-does-not-match-spec # doc type should be str, while spec type is path to allow user path expansion
+plugins/modules/zos_copy.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_copy.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
+plugins/modules/zos_copy.py validate-modules:undocumented-parameter # Passing args from action plugin
+plugins/modules/zos_data_set.py validate-modules:doc-choices-do-not-match-spec # We use our own argument parser for advanced conditional and dependent arguments.
+plugins/modules/zos_data_set.py validate-modules:doc-type-does-not-match-spec # Have to use raw here for backwards compatibility with old module args, but would confuse current users if exposed.
+plugins/modules/zos_data_set.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_data_set.py validate-modules:undocumented-parameter # Keep aliases to match behavior of old module spec, but some aliases were functionally inaccurate, and detailing in docs would only confuse user.
+plugins/modules/zos_encode.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_fetch.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_fetch.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
+plugins/modules/zos_fetch.py validate-modules:undocumented-parameter # Passing args from action plugin
+plugins/modules/zos_find.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_job_output.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_job_query.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_job_submit.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_job_submit.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
+plugins/modules/zos_job_submit.py validate-modules:undocumented-parameter # Passing args from action plugin
+plugins/modules/zos_job_submit.py pylint:catching-non-exception # False positive, Exception is inherited
+plugins/modules/zos_lineinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_mount.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_mvs_raw.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_operator.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_operator_action_query.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_ping.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_ping.rexx validate-modules:invalid-extension # Opened issue https://github.com/ansible/ansible/issues/79784
+plugins/modules/zos_ping.rexx validate-modules:python-syntax-error # Opened issue https://github.com/ansible/ansible/issues/79784
+plugins/modules/zos_tso_command.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_gather_facts.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
+plugins/modules/zos_volume_init.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0


### PR DESCRIPTION
##### SUMMARY
Given this change will drive over 700 tests it made sense to collapse all the related zos_data_set into one PR to avoid multiple regression pipelines.


1. Documentation: When a MEMBER is created, the format type of the member was not described, it should be clearly defined so that a user does not try to insert an executable into the data formatted member. Issue #631 

2. Bug: A random issue would occur on the pipeline leaving behind VSAM cluster components be it INDEX or DATA, originally this was thought to be a test case issue and a simple test fix but after reviewing I found it much more complex and took a better part of the week to address. To fix this I had to undo most of what was done in  PR [325](https://github.com/ansible-collections/ibm_zos_core/pull/325) for bugfix #140. Although this was a good attempt, the issue was that only one of the cluster components were being deleted here with a `DELETE USER.PRIVATE.TESTDS.DATA FILE(DD1) VVR` while adding the other for INDEX would have been a suitable fix, the issue such a clean up leaves space unclaimed on the volume and not the correct way to back out a data set from z/OS. Thus introduced a flow of tracking state and uncatalog, catalog, delete to achieve this, see image below for most the flow, the flow has since changed with some added exception actions but mostly the flow is correct for reference. Issue #635 

3. The catalog commands were failing because of formatting, I might have been happening for a long time because of all this other related issues it might not have been apparent, thus now the commands are formatted correctly and tested. Issue #802 
 
4. Small .ac command issue where some files are left behind were cleaned up as part of this PR because I was using `./ac --ac-test` and it was inhibiting my ability to work to not fix it. 

Data set deletion flow.
<img width="1060" alt="image" src="https://github.com/ansible-collections/ibm_zos_core/assets/25803172/31ba9295-a3f9-45d6-92cf-35ab795263a2">

##### ISSUE TYPE
- Docs Pull Request
