### PR TITLE
Bugfix for #807 - zos_copy ignores encoding for binary files

### DIFF
--- a/changelogs/fragments/810_fix_binary_file_bypass.yml
+++ b/changelogs/fragments/810_fix_binary_file_bypass.yml
@@ -1,5 +1,5 @@
 bugfixes:
 - zos_copy - Encoding normalization used to handle newlines in
-  text files was applied to binary files too. Fix now makes sure
+  text files was applied to binary files too. Fix makes sure
   that binary files bypass this normalization.
   (https://github.com/ansible-collections/ibm_zos_core/pull/810)

--- a/changelogs/fragments/810_fix_binary_file_bypass.yml
+++ b/changelogs/fragments/810_fix_binary_file_bypass.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- zos_copy - Encoding normalization used to handle newlines in
+  text files was applied to binary files too. Fix now makes sure
+  that binary files bypass this normalization.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/810)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2234,7 +2234,7 @@ def run_module(module, arg_def):
             # When the destination is a dataset, we'll normalize the source
             # file to UTF-8 for the record length computation as Python
             # generally uses UTF-8 as the default encoding.
-            if not is_uss:
+            if not is_binary and not is_uss:
                 new_src = temp_path or src
                 new_src = os.path.normpath(new_src)
                 # Normalizing encoding when src is a USS file (only).

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -43,6 +43,11 @@ DUMMY DATA ---- LINE 007 ------
 
 DUMMY_DATA_CRLF = b"00000001 DUMMY DATA\r\n00000002 DUMMY DATA\r\n"
 
+# FD is outside of the range of UTF-8, so it should be useful when testing
+# that binary data is not getting converted.
+DUMMY_DATA_BINARY = b"\xFD\xFD\xFD\xFD"
+DUMMY_DATA_BINARY_ESCAPED = "\\xFD\\xFD\\xFD\\xFD"
+
 VSAM_RECORDS = """00000001A record
 00000002A record
 00000003A record
@@ -1163,6 +1168,79 @@ def test_copy_file_crlf_endings_to_sequential_data_set(ansible_zos_module):
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
         os.remove(src)
+
+
+# The following two tests are to address the bugfix for issue #807.
+@pytest.mark.uss
+@pytest.mark.seq
+def test_copy_local_binary_file_without_encoding_conversion(ansible_zos_module):
+    hosts = ansible_zos_module
+    dest = "USER.TEST.SEQ.FUNCTEST"
+
+    fd, src = tempfile.mkstemp()
+    os.close(fd)
+    with open(src, "wb") as infile:
+        infile.write(DUMMY_DATA_BINARY)
+
+    try:
+        hosts.all.zos_data_set(name=dest, state="absent")
+
+        copy_result = hosts.all.zos_copy(
+            src=src,
+            dest=dest,
+            remote_src=False,
+            is_binary=True
+        )
+
+        for cp_res in copy_result.contacted.values():
+            assert cp_res.get("msg") is None
+            assert cp_res.get("changed") is True
+            assert cp_res.get("dest") == dest
+    finally:
+        hosts.all.zos_data_set(name=dest, state="absent")
+        os.remove(src)
+
+
+@pytest.mark.uss
+@pytest.mark.seq
+def test_copy_remote_binary_file_without_encoding_conversion(ansible_zos_module):
+    hosts = ansible_zos_module
+    src = "/tmp/zos_copy_binary_file"
+    dest = "USER.TEST.SEQ.FUNCTEST"
+
+    try:
+        hosts.all.zos_data_set(name=dest, state="absent")
+
+        # Creating a binary file on the remote system through Python
+        # to avoid encoding issues if we were to copy a local file
+        # or use the shell directly.
+        python_cmd = """python3 -c 'with open("{0}", "wb") as f: f.write(b"{1}")'""".format(
+            src,
+            DUMMY_DATA_BINARY_ESCAPED
+        )
+        python_result = hosts.all.shell(python_cmd)
+        for result in python_result.contacted.values():
+            assert result.get("msg") is None or result.get("msg") == ""
+            assert result.get("stderr") is None or result.get("stderr") == ""
+
+        # Because the original bug report used a file tagged as 'binary'
+        # on z/OS, we'll recreate that use case here.
+        hosts.all.shell("chtag -b {0}".format(src))
+
+        copy_result = hosts.all.zos_copy(
+            src=src,
+            dest=dest,
+            remote_src=True,
+            is_binary=True
+        )
+
+        for cp_res in copy_result.contacted.values():
+            assert cp_res.get("msg") is None
+            assert cp_res.get("changed") is True
+            assert cp_res.get("dest") == dest
+    finally:
+        hosts.all.zos_data_set(name=dest, state="absent")
+        hosts.all.file(path=src, state="absent")
 
 
 @pytest.mark.uss


### PR DESCRIPTION
##### SUMMARY
Fixes #807. Code introduced in 1.5.0 in `zos_copy` tried to convert the encoding of binary files, resulting in an error when the file was tagged as `binary` on z/OS or invalid bytes for UTF-8 were read.

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
zos_copy

##### ADDITIONAL INFORMATION
Added a couple of test cases to validate the handling of binary files.
