### PR TITLE
Release tasks v1.6.0

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -25,9 +25,7 @@ exclude_paths:
   - tests/helpers
   - tests/requirements.txt
   - tests/unit
-  - tests/sanity/ignore-2.9.txt
   - tests/sanity/ignore-2.10.txt
-  - tests/sanity/ignore-2.11.txt
   - venv*
 parseable: true
 quiet: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,13 +5,13 @@ ibm.ibm_zos_core Release Notes
 .. contents:: Topics
 
 
-v1.6.0-beta.1
-=============
+v1.6.0
+======
 
 Release Summary
 ---------------
 
-Release Date: '2023-04-26'
+Release Date: '2023-06-23'
 This changelog describes all changes made to the modules and plugins included
 in this collection. The release date is the date the changelog is created.
 For additional details such as required dependencies and availability review
@@ -29,8 +29,8 @@ Minor Changes
 - module_utils - job.py utility did not support positional wiled card placement, this enhancement uses `fnmatch` logic to support wild cards.
 - zos_copy - Fixed a bug where the module would change the mode for a directory when copying into it the contents of another. (https://github.com/ansible-collections/ibm_zos_core/pull/723)
 - zos_copy - was enhanced to keep track of modified members in a destination dataset, restoring them to their previous state in case of a failure. (https://github.com/ansible-collections/ibm_zos_core/pull/551)
-- zos_data_set - add force parameter to enable member delete while pdse is in use (https://github.com/ansible-collections/ibm_zos_core/pull/718).
-- zos_job_query - ansible module does not support positional wild card placement for `job_name1 or `job_id`. This enhancement allows embedded wildcards throughout the `job_name` and `job_id`. (https://github.com/ansible-collections/ibm_zos_core/pull/721)
+- zos_data_set - add force parameter to enable member delete while PDS/e is in use (https://github.com/ansible-collections/ibm_zos_core/pull/718).
+- zos_job_query - ansible module does not support positional wild card placement for `job_name` or `job_id`. This enhancement allows embedded wildcards throughout the `job_name` and `job_id`. (https://github.com/ansible-collections/ibm_zos_core/pull/721)
 - zos_lineinfile - would access data sets with exclusive access so no other task can read the data, this enhancement allows for a data set to be opened with a disposition set to share so that other tasks can access the data when option `force` is set to `true`. (https://github.com/ansible-collections/ibm_zos_core/pull/731)
 - zos_tso_command - was enhanced to accept `max_rc` as an option. This option allows a non-zero return code to succeed as a valid return code. (https://github.com/ansible-collections/ibm_zos_core/pull/666)
 
@@ -38,11 +38,18 @@ Bugfixes
 --------
 
 - Fixed wrong error message when a USS source is not found, aligning with a similar error message from zos_blockinfile "{src} does not exist".
-- zos_blockinfile - was unable to use double quotes which prevented some use cases and did not display an approriate message. The fix now allows for double quotes to be used with the module. (https://github.com/ansible-collections/ibm_zos_core/pull/680)
+- module_utils - data_set.py - Reported a failure caused when cataloging a VSAM data set. Fix now corrects how VSAM data sets are cataloged. (https://github.com/ansible-collections/ibm_zos_core/pull/816).
+- zos_blockinfile - was unable to use double quotes which prevented some use cases and did not display an appropriate message. The fix now allows for double quotes to be used with the module. (https://github.com/ansible-collections/ibm_zos_core/pull/680)
+- zos_copy - Encoding normalization used to handle newlines in text files was applied to binary files too. Fix makes sure that binary files bypass this normalization. (https://github.com/ansible-collections/ibm_zos_core/pull/810)
 - zos_copy - Fixes a bug where files not encoded in IBM-1047 would trigger an error while computing the record length for a new destination dataset. Issue 664. (https://github.com/ansible-collections/ibm_zos_core/pull/743)
 - zos_copy - Fixes a bug where the code for fixing an issue with newlines in files (issue 599) would use the wrong encoding for normalization. Issue 678. (https://github.com/ansible-collections/ibm_zos_core/pull/743)
+- zos_copy - Reported a warning about the use of _play_context.verbosity.This change corrects the module action to prevent the warning message. (https://github.com/ansible-collections/ibm_zos_core/pull/814).
+- zos_copy - kept permissions on target directory when copy overwrote files. The fix now set permissions when mode is given. (https://github.com/ansible-collections/ibm_zos_core/pull/790)
+- zos_data_set - Reported a failure caused when `present=absent` for a VSAM data set leaving behind cluster components. Fix introduces a new logical flow that will evaluate the volumes, compare it to the provided value and if necessary catalog and delete. (https://github.com/ansible-collections/ibm_zos_core/pull/816).
 - zos_encode - fixes a bug where converted files were not tagged afterwards with the new code set. (https://github.com/ansible-collections/ibm_zos_core/pull/534)
+- zos_fetch - Reported a warning about the use of _play_context.verbosity.This change corrects the module action to prevent the warning message. (https://github.com/ansible-collections/ibm_zos_core/pull/814).
 - zos_find - fixes a bug where find result values stopped being returned after first value in a list was 'not found'. (https://github.com/ansible-collections/ibm_zos_core/pull/668)
+- zos_gather_facts - Fixes an issue in the zoau version checker which prevented the zos_gather_facts module from running with newer versions of ZOAU. (https://github.com/ansible-collections/ibm_zos_core/pull/797)
 - zos_lineinfile - Fixed a bug where a Python f-string was used and thus removed to ensure support for Python 2.7 on the controller. (https://github.com/ansible-collections/ibm_zos_core/pull/659)
 
 New Modules

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,7 @@ Minor Changes
 -------------
 
 - Updated the text converter import from "from ansible.module_utils._text" to "from ansible.module_utils.common.text.converters" to remove warning".. warn Use ansible.module_utils.common.text.converters instead.". (https://github.com/ansible-collections/ibm_zos_core/pull/602)
-- module_utils - job.py utility did not support positional wiled card placement, this enhancement uses `fnmatch` logic to support wild cards.
+- module_utils - job.py utility did not support positional wild card placement, this enhancement uses `fnmatch` logic to support wild cards.
 - zos_copy - Fixed a bug where the module would change the mode for a directory when copying into it the contents of another. (https://github.com/ansible-collections/ibm_zos_core/pull/723)
 - zos_copy - was enhanced to keep track of modified members in a destination dataset, restoring them to their previous state in case of a failure. (https://github.com/ansible-collections/ibm_zos_core/pull/551)
 - zos_data_set - add force parameter to enable member delete while PDS/e is in use (https://github.com/ansible-collections/ibm_zos_core/pull/718).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ executing operator commands, executing TSO commands, ping,
 querying operator actions, APF authorizing libraries,
 editing textual data in data sets or Unix System Services files,
 finding data sets, backing up and restoring data sets and
-volumes, mounting file systems and running z/OS programs without JCL.
+volumes, mounting file systems, running z/OS programs without JCL and
+initializing volumes.
 
 
 Red Hat Ansible Certified Content for IBM Z
@@ -49,7 +50,7 @@ and ansible-doc to automate tasks on z/OS.
 
 Ansible version compatibility
 =============================
-This collection has been tested against the following Ansible versions: >=2.9,<2.15.
+This collection has been tested against the following Ansible versions: >=2.9,<2.16.
 
 Copyright
 =========

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -116,4 +116,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 1.6.0-beta.1
+version: 1.6.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -760,6 +760,44 @@ releases:
       name: zos_gather_facts
       namespace: ''
     release_date: '2022-11-02'
+  1.6.0:
+    changes:
+      bugfixes:
+      - module_utils - data_set.py - Reported a failure caused when cataloging a VSAM
+        data set. Fix now corrects how VSAM data sets are cataloged. (https://github.com/ansible-collections/ibm_zos_core/pull/816).
+      - zos_copy - Encoding normalization used to handle newlines in text files was
+        applied to binary files too. Fix makes sure that binary files bypass this
+        normalization. (https://github.com/ansible-collections/ibm_zos_core/pull/810)
+      - zos_copy - Reported a warning about the use of _play_context.verbosity.This
+        change corrects the module action to prevent the warning message. (https://github.com/ansible-collections/ibm_zos_core/pull/814).
+      - zos_copy - kept permissions on target directory when copy overwrote files.
+        The fix now set permissions when mode is given. (https://github.com/ansible-collections/ibm_zos_core/pull/790)
+      - zos_data_set - Reported a failure caused when `present=absent` for a VSAM
+        data set leaving behind cluster components. Fix introduces a new logical flow
+        that will evaluate the volumes, compare it to the provided value and if necessary
+        catalog and delete. (https://github.com/ansible-collections/ibm_zos_core/pull/816).
+      - zos_fetch - Reported a warning about the use of _play_context.verbosity.This
+        change corrects the module action to prevent the warning message. (https://github.com/ansible-collections/ibm_zos_core/pull/814).
+      - zos_gather_facts - Fixes an issue in the zoau version checker which prevented
+        the zos_gather_facts module from running with newer versions of ZOAU. (https://github.com/ansible-collections/ibm_zos_core/pull/797)
+      release_summary: 'Release Date: ''2023-06-23''
+
+        This changelog describes all changes made to the modules and plugins included
+
+        in this collection. The release date is the date the changelog is created.
+
+        For additional details such as required dependencies and availability review
+
+        the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__'
+    fragments:
+    - 783_fix_zoau_version_checker.yml
+    - 790_overwrite_permissions_on_copy.yml
+    - 810_fix_binary_file_bypass.yml
+    - 813-ansible-lint.yml
+    - 814-zos_data_set-update-vsam-copy.yml
+    - 816-zos_data_set-update-vsam.yml
+    - v1.6.0_summary.yml
+    release_date: '2023-06-23'
   1.6.0-beta.1:
     changes:
       bugfixes:

--- a/changelogs/fragments/v1.6.0_summary.yml
+++ b/changelogs/fragments/v1.6.0_summary.yml
@@ -1,0 +1,6 @@
+release_summary: |
+  Release Date: '2023-06-23'
+  This changelog describes all changes made to the modules and plugins included
+  in this collection. The release date is the date the changelog is created.
+  For additional details such as required dependencies and availability review
+  the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,8 +6,8 @@
 Releases
 ========
 
-Version 1.6.0-beta.1
-====================
+Version 1.6.0
+=============
 
 New Modules
 -----------
@@ -18,23 +18,41 @@ Minor Changes
 -------------
 
 - ``zos_blockinfile`` - Adds an enhancement to allow double quotes within a block.
+- ``zos_copy``
+
+      - Updates the behavior of the `mode` option so that permissions are applied to existing directories and contents.
+      - Adds an enhancement to option `restore_backup` to track modified members in a data set in the event of an error, restoring them to their previous state without reallocating the data set.
 - ``zos_data_set`` - Adds a new option named *force* to enable deletion of a data member in a PDSE that is simultaneously in use by others.
 - ``zos_job_query`` - Enables embedded positional wild card placement throughout *job_name* and *job_id* parameters.
 - ``zos_lineinfile`` - Adds a new option named *force* to enable modification of a data member in a data set that is simultaneously in use by others.
 - ``zos_tso_command`` - Adds a new option named *max_rc* to enable non-zero return codes lower than the specified maximum return as succeeded.
+- ``module_utils``
+
+      - job - Adds support for positional wild card placement for `job_name`` and `job_id`.
+      - Adds support for import *common.text.converters* over the deprecated *_text* import.
 
 Bugfixes
 --------
 
 - ``zos_copy``
+
       - Fixes a bug where files not encoded in IBM-1047 would trigger an error while computing the record length for a new destination dataset.
       - Fixes a bug where the module would change the mode for a directory when copying in the contents of another directory.
       - Fixes a bug where the incorrect encoding would be used during normalization, particularly when processing newlines in files.
+      - Fixes a bug where binary files were not excluded when normalizing data to remove newlines.
+      - Fixes a bug where a *_play_context.verbosity* deprecation warning would appear.
+- ``zos_fetch`` - Fixes a bug where a *_play_context.verbosity* deprecation warning would appear.
 - ``zos_encode`` - Fixes a bug where converted files were not tagged with the new code set afterwards.
 - ``zos_find`` - Fixes a bug where the module would stop searching and exit after the first value in a list was not found.
 - ``zos_lineinfile``
+
       - Removes use of Python f-string to ensure support for Python 2.7 on the controller.
-      - Fixes a bug where an incorect error message would be raised when a USS source was not found.
+      - Fixes a bug where an incorrect error message would be raised when a USS source was not found.
+- ``module_utils``
+
+      - data_set - Fixes an failure caused by cataloging a VSAM data set when the data set is not cataloged.
+- ``zos_data_set`` - Fixes a bug that will leave VSAM data set cluster components behind when instructed to delete the data set (`present=absent`).
+- ``zos_gather_facts`` - Fixes a bug that prevented the module from executing with newer versions of ZOAU.
 
 Availability
 ------------

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: ibm
 name: ibm_zos_core
 
 # The collection version
-version: 1.6.0-beta.1
+version: 1.6.0
 
 # Collection README file
 readme: README.md
@@ -90,7 +90,5 @@ build_ignore:
   - tests/helpers
   - tests/requirements.txt
   - tests/unit
-  - tests/sanity/ignore-2.9.txt
   - tests/sanity/ignore-2.10.txt
-  - tests/sanity/ignore-2.11.txt
   - venv*

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -92,3 +92,4 @@ build_ignore:
   - tests/unit
   - tests/sanity/ignore-2.10.txt
   - venv*
+  

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -81,6 +81,7 @@ build_ignore:
   - collections
   - docs
   - importer_result.json
+  - make.env.encrypt
   - scripts
   - test_config.yml
   - tests/*.ini

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -82,6 +82,7 @@ build_ignore:
   - docs
   - importer_result.json
   - make.env.encrypt
+  - Makefile
   - scripts
   - test_config.yml
   - tests/*.ini

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -80,6 +80,7 @@ build_ignore:
   - changelogs
   - collections
   - docs
+  - importer_result.json
   - scripts
   - test_config.yml
   - tests/*.ini
@@ -92,4 +93,3 @@ build_ignore:
   - tests/unit
   - tests/sanity/ignore-2.10.txt
   - venv*
-  

--- a/meta/ibm_zos_core_meta.yml
+++ b/meta/ibm_zos_core_meta.yml
@@ -1,5 +1,5 @@
 name: ibm_zos_core
-version: "1.6.0-beta.1"
+version: "1.6.0"
 managed_requirements:
     -
         name: "IBM Open Enterprise SDK for Python"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.12.00'
+requires_ansible: '>=2.9.0'


### PR DESCRIPTION
##### SUMMARY
This PR does not resolve issue #733 but this PR helps bring #733 closer to completion. 

##### ISSUE TYPE
- Feature Pull Request

Version 1.6.0
=============

New Modules
-----------

- ``zos_volume_init`` - Can initialize volumes or minidisks on target z/OS systems which includes creating a volume label and an entry into the volume table of contents (VTOC).

Minor Changes
-------------

- ``zos_blockinfile`` - Adds an enhancement to allow double quotes within a block.
- ``zos_copy``

      - Updates the behavior of the `mode` option so that permissions are applied to existing directories and contents.
      - Adds an enhancement to option `restore_backup` to track modified members in a data set in the event of an error, restoring them to their previous state without reallocating the data set.
- ``zos_data_set`` - Adds a new option named *force* to enable deletion of a data member in a PDSE that is simultaneously in use by others.
- ``zos_job_query`` - Enables embedded positional wild card placement throughout *job_name* and *job_id* parameters.
- ``zos_lineinfile`` - Adds a new option named *force* to enable modification of a data member in a data set that is simultaneously in use by others.
- ``zos_tso_command`` - Adds a new option named *max_rc* to enable non-zero return codes lower than the specified maximum return as succeeded.
- ``module_utils``

      - job - Adds support for positional wild card placement for `job_name`` and `job_id`.
      - Adds support for import *common.text.converters* over the deprecated *_text* import.

Bugfixes
--------

- ``zos_copy``

      - Fixes a bug where files not encoded in IBM-1047 would trigger an error while computing the record length for a new destination dataset.
      - Fixes a bug where the module would change the mode for a directory when copying in the contents of another directory.
      - Fixes a bug where the incorrect encoding would be used during normalization, particularly when processing newlines in files.
      - Fixes a bug where binary files were not excluded when normalizing data to remove newlines.
      - Fixes a bug where a *_play_context.verbosity* deprecation warning would appear.
- ``zos_fetch`` - Fixes a bug where a *_play_context.verbosity* deprecation warning would appear.
- ``zos_encode`` - Fixes a bug where converted files were not tagged with the new code set afterwards.
- ``zos_find`` - Fixes a bug where the module would stop searching and exit after the first value in a list was not found.
- ``zos_lineinfile``

      - Removes use of Python f-string to ensure support for Python 2.7 on the controller.
      - Fixes a bug where an incorrect error message would be raised when a USS source was not found.
- ``module_utils``

      - data_set - Fixes an failure caused by cataloging a VSAM data set when the data set is not cataloged.
- ``zos_data_set`` - Fixes a bug that will leave VSAM data set cluster components behind when instructed to delete the data set (`present=absent`).
- ``zos_gather_facts`` - Fixes a bug that prevented the module from executing with newer versions of ZOAU.

Availability
------------

* `Automation Hub`_
* `Galaxy`_
* `GitHub`_

Reference
---------

* Supported by `z/OS V2R3`_ or later
* Supported by the `z/OS® shell`_
* Supported by `IBM Open Enterprise SDK for Python`_ `3.9`_ - `3.11`_
* Supported by IBM `Z Open Automation Utilities 1.2.2`_ (or later) but prior to version 1.3.
