### PR TITLE
Functional tso command test cases currently can not be run concurrently#880

### DIFF
--- a/changelogs/fragments/880-Functional_tso_command_test_cases_currently_can_not_be_run_concurrently.yml
+++ b/changelogs/fragments/880-Functional_tso_command_test_cases_currently_can_not_be_run_concurrently.yml
@@ -1,4 +1,6 @@
 trivial:
-- zos_tso_command - Test cases were running in a specific sequence to validated.
-  Change summary the sequence into one test case.
+- zos_tso_command - Test suite was set up to run sequentially such that
+  certain tests relied on prior test cases. The new changes combine those
+  inter-dependent test cases into a single test case so that each individual
+  test case can now be run stand-alone.
   (https://github.com/ansible-collections/ibm_zos_core/pull/895)

--- a/changelogs/fragments/880-Functional_tso_command_test_cases_currently_can_not_be_run_concurrently.yml
+++ b/changelogs/fragments/880-Functional_tso_command_test_cases_currently_can_not_be_run_concurrently.yml
@@ -1,4 +1,4 @@
-bugfix:
+trivial:
 - zos_tso_command - Test cases were running in a specific sequence to validated.
   Change summary the sequence into one test case.
   (https://github.com/ansible-collections/ibm_zos_core/pull/895)

--- a/changelogs/fragments/880-Functional_tso_command_test_cases_currently_can_not_be_run_concurrently.yml
+++ b/changelogs/fragments/880-Functional_tso_command_test_cases_currently_can_not_be_run_concurrently.yml
@@ -1,0 +1,4 @@
+bugfix:
+- zos_tso_command - Test cases were running in a specific sequence to validated.
+  Change summary the sequence into one test case.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/895)

--- a/tests/functional/modules/test_zos_tso_command_func.py
+++ b/tests/functional/modules/test_zos_tso_command_func.py
@@ -15,14 +15,9 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import os
-import sys
-import warnings
-
 import ansible.constants
 import ansible.errors
 import ansible.utils
-import pytest
 
 DEFAULT_TEMP_DATASET="imstestl.ims1.temp.ps"
 

--- a/tests/functional/modules/test_zos_tso_command_func.py
+++ b/tests/functional/modules/test_zos_tso_command_func.py
@@ -58,7 +58,7 @@ def test_zos_tso_command_allocate_listing_delete(ansible_zos_module):
         for item in result.get("output"):
             assert item.get("rc") == 0
         assert result.get("changed") is True
-    # Validate listds of datasets and validate LISTDS using alias param 'command'
+    # Validate listds of datasets and validate LISTDS using alias param 'command' of auth command
     results = hosts.all.zos_tso_command(commands=["LISTDS '{0}'".format(DEFAULT_TEMP_DATASET)])
     for result in results.contacted.values():
         for item in result.get("output"):
@@ -70,7 +70,7 @@ def test_zos_tso_command_allocate_listing_delete(ansible_zos_module):
         for item in result.get("output"):
             assert item.get("rc") == 0
         assert result.get("changed") is True
-    # Validate LISTCAT comand
+    # Validate LISTCAT comand and an unauth command
     results = hosts.all.zos_tso_command(
         commands=["LISTCAT ENT('{0}')".format(DEFAULT_TEMP_DATASET)]
     )

--- a/tests/functional/modules/test_zos_tso_command_func.py
+++ b/tests/functional/modules/test_zos_tso_command_func.py
@@ -63,13 +63,13 @@ def test_zos_tso_command_allocate_listing_delete(ansible_zos_module):
         for item in result.get("output"):
             assert item.get("rc") == 0
         assert result.get("changed") is True
-    # Validate listds auth of a dataset with commands
+    # Validate listds of datasets and validate LISTDS using alias param 'command'
     results = hosts.all.zos_tso_command(commands=["LISTDS '{0}'".format(DEFAULT_TEMP_DATASET)])
     for result in results.contacted.values():
         for item in result.get("output"):
             assert item.get("rc") == 0
         assert result.get("changed") is True
-    # Validate listds auth single command
+    # Validate LISTDS using alias param 'command'
     results = hosts.all.zos_tso_command(command="LISTDS '{0}'".format(DEFAULT_TEMP_DATASET))
     for result in results.contacted.values():
         for item in result.get("output"):
@@ -89,7 +89,8 @@ def test_zos_tso_command_allocate_listing_delete(ansible_zos_module):
         for item in result.get("output"):
             assert item.get("rc") == 0
         assert result.get("changed") is True
-    # Validate already was remove
+    # Expect the tso_command to fail here because the previous command will have already deleted the data set
+    # Validate data set was removed by previous call
     results = hosts.all.zos_tso_command(commands=["delete '{0}'".format(DEFAULT_TEMP_DATASET)])
     for result in results.contacted.values():
         for item in result.get("output"):
@@ -127,7 +128,10 @@ def test_zos_tso_command_multiple_commands(ansible_zos_module):
     results = hosts.all.zos_tso_command(commands=commands_list)
     for result in results.contacted.values():
         for item in result.get("output"):
-            assert item.get("rc") == 0
+            if result.get("command") == "LU omvsadm":
+                assert item.get("rc") == 0
+            if result.get("command") == "LISTGRP":
+                assert item.get("rc") == 0
         assert result.get("changed") is True
 
 

--- a/tests/functional/modules/test_zos_tso_command_func.py
+++ b/tests/functional/modules/test_zos_tso_command_func.py
@@ -128,9 +128,9 @@ def test_zos_tso_command_multiple_commands(ansible_zos_module):
     results = hosts.all.zos_tso_command(commands=commands_list)
     for result in results.contacted.values():
         for item in result.get("output"):
-            if result.get("command") == "LU omvsadm":
+            if item.get("command") == "LU omvsadm":
                 assert item.get("rc") == 0
-            if result.get("command") == "LISTGRP":
+            if item.get("command") == "LISTGRP":
                 assert item.get("rc") == 0
         assert result.get("changed") is True
 

--- a/tests/functional/modules/test_zos_tso_command_func.py
+++ b/tests/functional/modules/test_zos_tso_command_func.py
@@ -70,7 +70,7 @@ def test_zos_tso_command_allocate_listing_delete(ansible_zos_module):
         for item in result.get("output"):
             assert item.get("rc") == 0
         assert result.get("changed") is True
-    # Validate LISTCAT comand and an unauth command
+    # Validate LISTCAT command and an unauth command
     results = hosts.all.zos_tso_command(
         commands=["LISTCAT ENT('{0}')".format(DEFAULT_TEMP_DATASET)]
     )


### PR DESCRIPTION
##### SUMMARY
The change substitute a set of test that depends of a sequential run and summarized in one large test with some of the options tested before and remove hardcoded verifications.

Fixes #880 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME


##### ADDITIONAL INFORMATION
Take logic of 8 tests and validation of each one, that required a sequential run  to just one test in the right sequence.
<img width="1464" alt="Captura de pantalla 2023-07-17 a la(s) 12 50 07" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/84335286-8fd8-4058-a3ea-1c199914173b">

`test_zos_tso_command_allocate_listing_delete`
<img width="579" alt="Captura de pantalla 2023-07-17 a la(s) 12 50 17" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/187d06aa-6ad7-4233-949d-f389feffc260">
