### PR TITLE
Update make file doc generation with pre and post scripts for a subset of modules.

### DIFF
--- a/changelogs/fragments/906-update-doc-generation.yml
+++ b/changelogs/fragments/906-update-doc-generation.yml
@@ -1,0 +1,4 @@
+trivial:
+- make - Current doc generation requires manual intervention, this change will
+  allow for doc generation without any manual intervention and removes warnings.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/906)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -172,8 +172,17 @@ module-doc:
 	mv ../plugins/modules/__init__.py ../plugins/modules/__init__.py.skip; \
 	fi
 
+	@echo "Replacing string based carriage returns with literal escaped to produce sphynx consumable RST."
+	scripts/pre-template.sh
+
 	@echo "Generating ReStructuredText for all ansible modules found at '../plugins/modules/' to 'source/modules'."
 	@ansible-doc-extractor --template templates/module.rst.j2 source/modules ../plugins/modules/*.py
+
+	@echo "Updating zos_apf file."
+	scripts/post-zos_apf.sh
+
+	@echo "Reverting edited source file."
+	scripts/post-template.sh
 
 	@if test -e ../plugins/modules/__init__.py.skip; \
     echo "Rename file '../plugins/modules/__init__.py.skip' back to ../plugins/modules/__init__.py.'"; \

--- a/docs/scripts/post-template.sh
+++ b/docs/scripts/post-template.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+################################################################################
+# © Copyright IBM Corporation 2020
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+################################################################################
+# This scripts actions called before after generating RST such that the
+# original template.py is put back in its original state.
+################################################################################
+
+# Obtain the galaxy collection installion up to the template.py located on the host
+template_doc_source=`ansible-config dump|grep DEFAULT_MODULE_PATH| cut -d'=' -f2|sed 's/[][]//g' | tr -d \'\" |sed 's/modules/doc_fragments\/template.py/g'`
+mv $template_doc_source.tmp $template_doc_source

--- a/docs/scripts/post-zos_apf.sh
+++ b/docs/scripts/post-zos_apf.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+################################################################################
+# © Copyright IBM Corporation 2020
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+################################################################################
+# This scripts actions called after generating RST and before generating Html.
+# This script corrects the RST so that correct HTMl can be generated removing the
+# warning:
+# ibm_zos_core/docs/source/modules.rst:23: WARNING: toctree glob pattern 'modules/*' didn't match any documents
+# This script will replace:
+# "    | **default**: /* {mark} ANSIBLE MANAGED BLOCK <timestamp> */"
+# To this:
+# "    | **default**: /* {mark} ANSIBLE MANAGED BLOCK <timestamp> \*/"
+################################################################################
+set -x
+SCRIPT_DIR=`dirname "$0"`
+CURR_PATH=`pwd`
+# Delete any temporary index RST
+if [[ -f $CURR_PATH/source/modules/zos_apf.rst ]]; then
+    sed -i '' "s/\> \\*\//\> \\\*\//g" $CURR_PATH/source/modules/zos_apf.rst
+fi

--- a/docs/scripts/pre-template.sh
+++ b/docs/scripts/pre-template.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+################################################################################
+# © Copyright IBM Corporation 2020
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+################################################################################
+# This scripts actions called before generating RST, this scripts leaves the
+# "\n", "\r", "\r\n" in the template.py doc_fragment so that ansible linting
+# test will pass such that the doc and module are match. Later this script will
+# update the above strings to liters with an esacpe, for example "\n" --> '\\n'.
+# This allows for RST to be generated that is usable by the ansible-doc-extractor
+# and Jinja2 template, and later sphinx html.
+# This requries that the ansible collection be prebuilt so that it can find
+# the template.py within the collection (not within the git project). Thus run
+# './ac --ac-build' before the make file that builds doc. 
+################################################################################
+
+template_doc_source=`ansible-config dump|grep DEFAULT_MODULE_PATH| cut -d'=' -f2|sed 's/[][]//g' | tr -d \'\" |sed 's/modules/doc_fragments\/template.py/g'`
+cp $template_doc_source $template_doc_source.tmp
+sed -i '' "s/\"\\\\n\"/'\\\\\\\\n'/g" $template_doc_source
+sed -i '' "s/\"\\\\r\"/'\\\\\\\\r'/g" $template_doc_source
+sed -i '' "s/\"\\\\r\\\\n\"/'\\\\\\\\r\\\\\\\\n'/g" $template_doc_source

--- a/docs/source/modules/zos_apf.rst
+++ b/docs/source/modules/zos_apf.rst
@@ -128,9 +128,11 @@ persistent
 
     ``{mark}`` length may not exceed 72 characters.
 
+    The timestamp (<timestamp>) used in the default marker follows the '+%Y%m%d-%H%M%S' date format
+
     | **required**: False
     | **type**: str
-    | **default**: /* {mark} ANSIBLE MANAGED BLOCK <timestamp> */
+    | **default**: /* {mark} ANSIBLE MANAGED BLOCK <timestamp> \*/
 
 
   backup

--- a/docs/source/modules/zos_archive.rst
+++ b/docs/source/modules/zos_archive.rst
@@ -26,7 +26,6 @@ Synopsis
 
 
 
-
 Parameters
 ----------
 
@@ -122,7 +121,7 @@ dest
 exclude
   Remote absolute path, glob, or list of paths, globs or data set name patterns for the file, files or data sets to exclude from path list and glob expansion.
 
-  Patterns (wildcards) can contain one of the following: ?, *.
+  Patterns (wildcards) can contain one of the following, `?`, `*`.
 
   * matches everything.
 

--- a/docs/source/modules/zos_data_set.rst
+++ b/docs/source/modules/zos_data_set.rst
@@ -146,7 +146,7 @@ record_format
   | **required**: False
   | **type**: str
   | **default**: FB
-  | **choices**: FB, VB, FBA, VBA, U
+  | **choices**: FB, VB, FBA, VBA, U, F
 
 
 sms_storage_class
@@ -417,7 +417,7 @@ batch
     | **required**: False
     | **type**: str
     | **default**: FB
-    | **choices**: FB, VB, FBA, VBA, U
+    | **choices**: FB, VB, FBA, VBA, U, F
 
 
   sms_storage_class

--- a/docs/source/modules/zos_job_output.rst
+++ b/docs/source/modules/zos_job_output.rst
@@ -217,9 +217,14 @@ jobs
                         "stepname": "STEP0001"
                     }
                 ],
+                "duration": 0,
+                "job_class": "R",
                 "job_id": "JOB00134",
                 "job_name": "HELLO",
                 "owner": "OMVSADM",
+                "priority": "1",
+                "program_name": "IEBGENER",
+                "queue_position": "58",
                 "ret_code": {
                     "code": 0,
                     "msg": "CC 0000",
@@ -264,6 +269,18 @@ jobs
 
     | **type**: str
     | **sample**: JOB
+
+  creation_date
+    Date, local to the target system, when the job was created.
+
+    | **type**: str
+    | **sample**: 2023-05-04
+
+  creation_time
+    Time, local to the target system, when the job was created.
+
+    | **type**: str
+    | **sample**: 14:15:00
 
   ddnames
     Data definition names.
@@ -333,6 +350,41 @@ jobs
                 "         7 //                                                                              "
             ]
 
+
+  job_class
+    Job class for this job.
+
+    | **type**: str
+    | **sample**: A
+
+  svc_class
+    Service class for this job.
+
+    | **type**: str
+    | **sample**: C
+
+  priority
+    A numeric indicator of the job priority assigned through JES.
+
+    | **type**: int
+    | **sample**: 4
+
+  asid
+    The address Space Identifier (ASID) that is a unique descriptor for the job address space. Zero if not active.
+
+    | **type**: int
+
+  queue_position
+    The position within the job queue where the jobs resides.
+
+    | **type**: int
+    | **sample**: 3
+
+  program_name
+    The name of the program found in the job's last completed step found in the PGM parameter.
+
+    | **type**: str
+    | **sample**: IEBGENER
 
   ret_code
     Return code output collected from job log.

--- a/docs/source/modules/zos_job_query.rst
+++ b/docs/source/modules/zos_job_query.rst
@@ -134,7 +134,8 @@ jobs
         [
             {
                 "asid": 0,
-                "creation_datetime": "20230503T121300",
+                "creation_date": "2023-05-03",
+                "creation_time": "12:13:00",
                 "job_class": "K",
                 "job_id": "JOB01427",
                 "job_name": "LINKJOB",
@@ -146,7 +147,8 @@ jobs
             },
             {
                 "asid": 4,
-                "creation_datetime": "20230503T121400",
+                "creation_date": "2023-05-03",
+                "creation_time": "12:14:00",
                 "job_class": "A",
                 "job_id": "JOB16577",
                 "job_name": "LINKCBL",
@@ -245,13 +247,13 @@ jobs
 
 
   job_class
-    Letter indicating job class for this job.
+    Job class for this job.
 
     | **type**: str
     | **sample**: A
 
   svc_class
-    Character indicating service class for this job.
+    Service class for this job.
 
     | **type**: str
     | **sample**: C
@@ -263,21 +265,33 @@ jobs
     | **sample**: 4
 
   asid
-    An identifier created by JES.
+    The address Space Identifier (ASID) that is a unique descriptor for the job address space. Zero if not active.
 
     | **type**: int
 
-  creation_datetime
-    Date and time, local to the target system, when the job was created.
+  creation_date
+    Date, local to the target system, when the job was created.
 
     | **type**: str
-    | **sample**: 20230504T141500
+    | **sample**: 2023-05-04
+
+  creation_time
+    Time, local to the target system, when the job was created.
+
+    | **type**: str
+    | **sample**: 14:15:00
 
   queue_position
-    Integer of the position within the job queue where this jobs resided.
+    The position within the job queue where the jobs resides.
 
     | **type**: int
     | **sample**: 3
+
+  program_name
+    The name of the program found in the job's last completed step found in the PGM parameter.
+
+    | **type**: str
+    | **sample**: IEBGENER
 
 
 message

--- a/docs/source/modules/zos_job_submit.rst
+++ b/docs/source/modules/zos_job_submit.rst
@@ -353,7 +353,8 @@ jobs
                 "asid": 0,
                 "class": "K",
                 "content_type": "JOB",
-                "creation_datetime": "20230503T121300",
+                "creation_date": "2023-05-03",
+                "creation_time": "12:13:00",
                 "ddnames": [
                     {
                         "byte_count": "677",
@@ -553,6 +554,7 @@ jobs
                 "job_name": "DBDGEN00",
                 "owner": "OMVSADM",
                 "priority": 1,
+                "program_name": "IEBGENER",
                 "queue_position": 3,
                 "ret_code": {
                     "code": 0,
@@ -567,7 +569,8 @@ jobs
                     ]
                 },
                 "subsystem": "STL1",
-                "svc_class": "?"
+                "svc_class": "?",
+                "system": "STL1"
             }
         ]
 
@@ -722,13 +725,13 @@ jobs
 
 
   job_class
-    Letter indicating job class for this job.
+    Job class for this job.
 
     | **type**: str
     | **sample**: A
 
   svc_class
-    Character indicating service class for this job.
+    Service class for this job.
 
     | **type**: str
     | **sample**: C
@@ -740,21 +743,33 @@ jobs
     | **sample**: 4
 
   asid
-    An identifier created by JES.
+    The address Space Identifier (ASID) that is a unique descriptor for the job address space. Zero if not active.
 
     | **type**: int
 
-  creation_datetime
-    Date and time, local to the target system, when the job was created.
+  creation_date
+    Date, local to the target system, when the job was created.
 
     | **type**: str
-    | **sample**: 20230504T141500
+    | **sample**: 2023-05-04
+
+  creation_time
+    Time, local to the target system, when the job was created.
+
+    | **type**: str
+    | **sample**: 14:15:00
 
   queue_position
-    Integer of the position within the job queue where this jobs resided.
+    The position within the job queue where the jobs resides.
 
     | **type**: int
     | **sample**: 3
+
+  program_name
+    The name of the program found in the job's last completed step found in the PGM parameter.
+
+    | **type**: str
+    | **sample**: IEBGENER
 
 
 message

--- a/docs/source/modules/zos_unarchive.rst
+++ b/docs/source/modules/zos_unarchive.rst
@@ -26,7 +26,6 @@ Synopsis
 
 
 
-
 Parameters
 ----------
 

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -118,6 +118,8 @@ options:
           - Using a custom marker without the C({mark}) variable may result
             in the block being repeatedly inserted on subsequent playbook runs.
           - C({mark}) length may not exceed 72 characters.
+          - The timestamp (<timestamp>) used in the default marker
+            follows the '+%Y%m%d-%H%M%S' date format
         required: False
         type: str
         default: "/* {mark} ANSIBLE MANAGED BLOCK <timestamp> */"

--- a/plugins/modules/zos_archive.py
+++ b/plugins/modules/zos_archive.py
@@ -117,7 +117,7 @@ options:
       - Remote absolute path, glob, or list of paths, globs or data set name
         patterns for the file, files or data sets to exclude from path list
         and glob expansion.
-      - "Patterns (wildcards) can contain one of the following: ?, *."
+      - "Patterns (wildcards) can contain one of the following, `?`, `*`."
       - "* matches everything."
       - "? matches any single character."
     type: list


### PR DESCRIPTION
This improves the make file such that pre and post scripts are invoked to process some of the RST known to need additional editing. 

This issue will:
- update the make file
- new scripts
- correct `zos_copy`, `zos_job_submit`, `zos_archive` and` zos_apf` module doc
- generate new doc using the updated make file
- generate doc for modules that had updates that would normally be caught in the release process but doing so now. 

Addresses issue #905 

