### PR TITLE
Add test case to validate response come back complete

### DIFF
--- a/changelogs/fragments/918-zos-operator-response-come-back-truncate.yaml
+++ b/changelogs/fragments/918-zos-operator-response-come-back-truncate.yaml
@@ -1,0 +1,4 @@
+bugfix:
+- zos_operator: The last line of the operator was missing in the response of the module.
+    Fix now ensures the presence of the full output of the operator.
+      (https://github.com/ansible-collections/ibm_zos_core/pull/918)

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -118,3 +118,15 @@ def test_zos_operator_positive_verbose_with_quick_delay(ansible_zos_module):
         assert result.get("content") is not None
         # Account for slower network
         assert result.get('elapsed') <= (2 * wait_time_s)
+
+
+def test_response_come_back_complete(ansible_zos_module):
+    hosts = ansible_zos_module
+    results = hosts.all.zos_operator(cmd="\$dspl")
+    res = dict()
+    res["stdout"] = []
+    for result in results.contacted.values():
+        stdout = result.get('content')
+        # HASP646 Only appears in the last line that before did not appears
+        last_line = len(stdout)
+        assert "HASP646" in stdout[last_line - 1]


### PR DESCRIPTION
##### SUMMARY
Add test case to validate the solution on of command response is full in the output.

Validate the fix #782 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Test case test_response_come_back_complete that validates the final line of the response contains HASP646

Required ZOAU 1.2.4
<img width="1453" alt="Captura de pantalla 2023-08-02 a la(s) 9 11 45" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/a221c0cc-b262-4b5a-80c0-d5bc82743638">

<img width="571" alt="Captura de pantalla 2023-08-02 a la(s) 9 12 08" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/05977d27-f7db-4a15-a14f-ad9fff6afdab">

<img width="1216" alt="Captura de pantalla 2023-08-02 a la(s) 9 12 28" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/203ff0df-98d9-45ed-ad66-bbfbb7e55ba6">
