### PR TITLE
Remove conditional unnecessary

### DIFF
--- a/changelogs/fragments/934-Remove-conditional-unnecessary.yml
+++ b/changelogs/fragments/934-Remove-conditional-unnecessary.yml
@@ -1,0 +1,2 @@
+- trivial:
+  - zos_blockinfile - remove test conditional unnecessary (https://github.com/ansible-collections/ibm_zos_core/pull/934).

--- a/tests/functional/modules/test_zos_blockinfile_func.py
+++ b/tests/functional/modules/test_zos_blockinfile_func.py
@@ -1221,9 +1221,6 @@ def test_ds_block_insertafter_eof_with_backup(ansible_zos_module, dstype, backup
             if backup_name:
                 backup_ds_name = result.get("backup_name")
                 assert backup_ds_name is not None
-            else:
-                backup_ds_name = result.get("backup_name")
-                assert backup_ds_name is not None
         results = hosts.all.shell(cmd="cat \"//'{0}'\" ".format(params["path"]))
         for result in results.contacted.values():
             assert result.get("stdout") == EXPECTED_INSERTAFTER_EOF
@@ -1231,8 +1228,6 @@ def test_ds_block_insertafter_eof_with_backup(ansible_zos_module, dstype, backup
         remove_ds_environment(ansible_zos_module, ds_name)
         if backup_name:
             ansible_zos_module.all.zos_data_set(name="BLOCKIF.TEST.BACKUP", state="absent")
-            ansible_zos_module.all.zos_data_set(name=backup_ds_name, state="absent")
-        else:
             ansible_zos_module.all.zos_data_set(name=backup_ds_name, state="absent")
 
 

--- a/tests/functional/modules/test_zos_blockinfile_func.py
+++ b/tests/functional/modules/test_zos_blockinfile_func.py
@@ -1218,9 +1218,8 @@ def test_ds_block_insertafter_eof_with_backup(ansible_zos_module, dstype, backup
         results = hosts.all.zos_blockinfile(**params)
         for result in results.contacted.values():
             assert result.get("changed") == 1
-            if backup_name:
-                backup_ds_name = result.get("backup_name")
-                assert backup_ds_name is not None
+            backup_ds_name = result.get("backup_name")
+            assert backup_ds_name is not None
         results = hosts.all.shell(cmd="cat \"//'{0}'\" ".format(params["path"]))
         for result in results.contacted.values():
             assert result.get("stdout") == EXPECTED_INSERTAFTER_EOF
@@ -1228,6 +1227,8 @@ def test_ds_block_insertafter_eof_with_backup(ansible_zos_module, dstype, backup
         remove_ds_environment(ansible_zos_module, ds_name)
         if backup_name:
             ansible_zos_module.all.zos_data_set(name="BLOCKIF.TEST.BACKUP", state="absent")
+            ansible_zos_module.all.zos_data_set(name=backup_ds_name, state="absent")
+        else:
             ansible_zos_module.all.zos_data_set(name=backup_ds_name, state="absent")
 
 


### PR DESCRIPTION
##### SUMMARY
Fix conditionals for next issues in runs of pipeline

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
The test is the one about backups and to ensure removes the dataset at the end, it was required the assignation of a dataset name with or without a member, one of the options of backup is None, the conditional it was for case None to ensures the delete of dataset but generate and error because variable not assigned of case None.

