### PR TITLE
Add fix for change copy built-in for zos_copy and remove remain files…

### DIFF
--- a/changelogs/fragments/951-Change-copy-for-zos-copy-and-remove-temporary-files.yml
+++ b/changelogs/fragments/951-Change-copy-for-zos-copy-and-remove-temporary-files.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - zos_job_submit: Temporary files were created in tmp directory.
+      Fix now ensure the deletion of files every time the module run.
+        (https://github.com/ansible-collections/ibm_zos_core/pull/951)
+minor_changes:
+  - zos_job_submit: Change action plugin call from copy to zos_copy.
+      (https://github.com/ansible-collections/ibm_zos_core/pull/951)

--- a/changelogs/fragments/951-Change-copy-for-zos-copy-and-remove-temporary-files.yml
+++ b/changelogs/fragments/951-Change-copy-for-zos-copy-and-remove-temporary-files.yml
@@ -1,6 +1,6 @@
 bugfixes:
   - zos_job_submit: Temporary files were created in tmp directory.
-      Fix now ensure the deletion of files every time the module run.
+      Fix now ensures the deletion of files every time the module run.
         (https://github.com/ansible-collections/ibm_zos_core/pull/951)
 minor_changes:
   - zos_job_submit: Change action plugin call from copy to zos_copy.

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -28,6 +28,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.action.zos_copy import ActionM
 
 display = Display()
 
+
 class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         """ handler for file transfer operations """

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -178,12 +178,6 @@ class ActionModule(ActionBase):
 
             if rendered_file:
                 os.remove(rendered_file)
-            if os.path.isfile(tmp_src):
-                self._connection.exec_command("rm -rf {0}".format(tmp_src))
-            if os.path.isfile(dest_file):
-                self._connection.exec_command("rm -rf {0}".format(dest_file))
-            if os.path.isfile(source_full):
-                self._connection.exec_command("rm -rf {0}".format(source_full))
 
         else:
             result.update(

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -167,15 +167,17 @@ class ActionModule(ActionBase):
                                                          templar=self._templar,
                                                          shared_loader_obj=self._shared_loader_obj)
             result.update(zos_copy_action_module.run(task_vars=task_vars))
-            module_args["src"] = dest_path
-            result.update(
-                self._execute_module(
-                    module_name="ibm.ibm_zos_core.zos_job_submit",
-                    module_args=module_args,
-                    task_vars=task_vars,
+            if result.get("msg") is None:
+                module_args["src"] = dest_path
+                result.update(
+                    self._execute_module(
+                        module_name="ibm.ibm_zos_core.zos_job_submit",
+                        module_args=module_args,
+                        task_vars=task_vars,
+                    )
                 )
-            )
-
+            else:
+                result.update(dict(failed=True))
             if rendered_file:
                 os.remove(rendered_file)
             if os.path.isfile(tmp_src):

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -178,6 +178,12 @@ class ActionModule(ActionBase):
 
             if rendered_file:
                 os.remove(rendered_file)
+            if os.path.isfile(tmp_src):
+                self._connection.exec_command("rm -rf {0}".format(tmp_src))
+            if os.path.isfile(dest_file):
+                self._connection.exec_command("rm -rf {0}".format(dest_file))
+            if os.path.isfile(source_full):
+                self._connection.exec_command("rm -rf {0}".format(source_full))
 
         else:
             result.update(


### PR DESCRIPTION
##### SUMMARY
Change the action plugin of zos_job_submit module that was calling Ansible build int copy now uses zos_copy. Change the remove function to ensure Ansible/temp folder goes empty by files created by action plugin.

Fixes #926 and #903 

##### ISSUE TYPE
- Bugfix Pull Request
- Enabler Pull Request

##### COMPONENT NAME
Change the call of plugin of Ansible build in copy to zos_copy module, adjust the code to ensure works properly and add validation to remove temporal files that module use.

##### ADDITIONAL INFORMATION
Import action module of zos_copy an prepare the change on the environment to works properly and get the right files with the jcl, lastly add validations to ensure clean temporary files creates to works with local files.

<img width="1078" alt="Captura de pantalla 2023-08-29 a la(s) 14 09 21" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/38c748d3-618b-42d3-ae0f-4d0e7a9b8a3c">
<img width="1102" alt="Captura de pantalla 2023-08-29 a la(s) 14 09 54" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/051f9e91-77c7-413c-9cb6-4f5f54279afa">

