### PR TITLE
modify get_data_set_attributes function

### DIFF
--- a/changelogs/fragments/964-modify-get_data_set_attributes-function.yml
+++ b/changelogs/fragments/964-modify-get_data_set_attributes-function.yml
@@ -1,0 +1,3 @@
+trivial:
+- zos_copy - modify get_data_set_attributes helper function to no longer overwrite caller-defined attributes.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/964)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1613,8 +1613,8 @@ def get_data_set_attributes(
     name,
     size,
     is_binary,
-    record_format="VB",
-    record_length=1028,
+    record_format=None,
+    record_length=None,
     type="SEQ",
     volume=None
 ):
@@ -1649,11 +1649,21 @@ def get_data_set_attributes(
     space_primary = space_primary + int(math.ceil(space_primary * 0.05))
     space_secondary = int(math.ceil(space_primary * 0.10))
 
-    # Overwriting record_format and record_length when the data set has binary data.
-    if is_binary:
-        record_format = "FB"
-        record_length = 80
+    # set default value - record_format
+    if record_format is None:
+        if is_binary:
+            record_format = "FB"
+        else:
+            record_format = "VB"
 
+    # set default value - record_length
+    if record_length is None:
+        if is_binary:
+            record_length = 80
+        else:
+            record_length = 1028
+
+    # compute block size
     max_block_size = 32760
     if record_format == "FB":
         # Computing the biggest possible block size that doesn't exceed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Honor incoming param values instead of overwriting in the case of is_binary=True
Functionally, there should be no changes (other than the case where `executable=True` and `is_binary=True` and the helper function was overwriting record format and record length set up for executable (recf=U, recl=0) with overriding behavior (recf=FB, recl=80). 

This fix does not modify any incoming values. 

Fixes #924 


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

