### PR TITLE
Enhance zos_archive and zos_unarchive test cases

### DIFF
--- a/changelogs/fragments/965-enhance-archive-tests.yml
+++ b/changelogs/fragments/965-enhance-archive-tests.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - zos_archive: Enhanced test cases to use test lines the same length of the record length.
+      (https://github.com/ansible-collections/ibm_zos_core/pull/965)
+  - zos_unarchive: Enhanced test cases to use test lines the same length of the record length.
+      (https://github.com/ansible-collections/ibm_zos_core/pull/965)

--- a/tests/functional/modules/test_zos_archive_func.py
+++ b/tests/functional/modules/test_zos_archive_func.py
@@ -347,7 +347,7 @@ List of tests:
     "record_length", [80, 120]
 )
 @pytest.mark.parametrize(
-    "record_format", ["FB", "VB",],
+    "record_format", ["FB", "VB"],
 )
 def test_mvs_archive_single_dataset(ansible_zos_module, format, data_set, record_length, record_format):
     try:
@@ -423,7 +423,7 @@ def test_mvs_archive_single_dataset(ansible_zos_module, format, data_set, record
     "record_length", [80, 120]
 )
 @pytest.mark.parametrize(
-    "record_format", ["FB", "VB",],
+    "record_format", ["FB", "VB"],
 )
 def test_mvs_archive_single_dataset_use_adrdssu(ansible_zos_module, format, data_set, record_length, record_format):
     try:

--- a/tests/functional/modules/test_zos_archive_func.py
+++ b/tests/functional/modules/test_zos_archive_func.py
@@ -372,8 +372,12 @@ def test_mvs_archive_single_dataset(ansible_zos_module, format, data_set, record
                     type="member",
                     state="present"
                 )
-        # Write some content into src
-        test_line = "this is a test line"
+        # Write some content into src the same size of the record,
+        # need to reduce 4 from V and VB due to RDW
+        if record_format in ["V", "VB"]:
+            test_line = "a" * (record_length - 4)
+        else:
+            test_line = "a" * record_length
         for member in data_set.get("members"):
             if member == "":
                 ds_to_write = f"{data_set.get('name')}"
@@ -444,8 +448,12 @@ def test_mvs_archive_single_dataset_use_adrdssu(ansible_zos_module, format, data
                     type="member",
                     state="present"
                 )
-        # Write some content into src
-        test_line = "this is a test line"
+        # Write some content into src the same size of the record,
+        # need to reduce 4 from V and VB due to RDW
+        if record_format in ["V", "VB"]:
+            test_line = "a" * (record_length - 4)
+        else:
+            test_line = "a" * record_length
         for member in data_set.get("members"):
             if member == "":
                 ds_to_write = f"{data_set.get('name')}"
@@ -487,10 +495,7 @@ def test_mvs_archive_single_dataset_use_adrdssu(ansible_zos_module, format, data
         dict(name=TEST_PDS, dstype="PDSE", members=["MEM1", "MEM2", "MEM3"]),
         ]
 )
-@pytest.mark.parametrize(
-    "record_length", [80],
-)
-def test_mvs_archive_single_data_set_remove_target(ansible_zos_module, format, data_set, record_length):
+def test_mvs_archive_single_data_set_remove_target(ansible_zos_module, format, data_set):
     try:
         hosts = ansible_zos_module
         # Clean env
@@ -501,7 +506,6 @@ def test_mvs_archive_single_data_set_remove_target(ansible_zos_module, format, d
             name=data_set.get("name"),
             type=data_set.get("dstype"),
             state="present",
-            record_length=record_length,
             record_format="FB",
             replace=True,
         )

--- a/tests/functional/modules/test_zos_unarchive_func.py
+++ b/tests/functional/modules/test_zos_unarchive_func.py
@@ -401,6 +401,11 @@ def test_mvs_unarchive_single_data_set(ansible_zos_module, format, data_set, rec
             cmd_result = hosts.all.shell(cmd = "dls {0}.*".format(HLQ))
             for c_result in cmd_result.contacted.values():
                 assert data_set.get("name") in c_result.get("stdout")
+
+        # Check data integrity after unarchive
+        cat_result = hosts.all.shell(cmd=f"dcat \"{ds_to_write}\"")
+        for result in cat_result.contacted.values():
+            assert result.get("stdout") == test_line
     finally:
         hosts.all.zos_data_set(name=data_set.get("name"), state="absent")
         hosts.all.zos_data_set(name=MVS_DEST_ARCHIVE, state="absent")
@@ -993,6 +998,13 @@ def test_mvs_unarchive_single_data_set_remote_src(ansible_zos_module, format, da
             cmd_result = hosts.all.shell(cmd = "dls {0}.*".format(HLQ))
             for c_result in cmd_result.contacted.values():
                 assert data_set.get("name") in c_result.get("stdout")
+
+        # Check data integrity after unarchive
+        cat_result = hosts.all.shell(cmd=f"dcat \"{ds_to_write}\"")
+        for result in cat_result.contacted.values():
+            assert result.get("stdout") == test_line
+
+
     finally:
         hosts.all.shell(cmd="drm {0}*".format(data_set.get("name")))
         hosts.all.zos_data_set(name=MVS_DEST_ARCHIVE, state="absent")

--- a/tests/functional/modules/test_zos_unarchive_func.py
+++ b/tests/functional/modules/test_zos_unarchive_func.py
@@ -344,8 +344,12 @@ def test_mvs_unarchive_single_data_set(ansible_zos_module, format, data_set, rec
                     type="member",
                     state="present"
                 )
-        # Write some content into src
-        test_line = "this is a test line"
+        # Write some content into src the same size of the record,
+        # need to reduce 4 from V and VB due to RDW
+        if record_format in ["V", "VB"]:
+            test_line = "a" * (record_length - 4)
+        else:
+            test_line = "a" * record_length
         for member in data_set.get("members"):
             if member == "":
                 ds_to_write = f"{data_set.get('name')}"
@@ -442,8 +446,12 @@ def test_mvs_unarchive_single_data_set_use_adrdssu(ansible_zos_module, format, d
                     type="member",
                     state="present"
                 )
-        # Write some content into src
-        test_line = "this is a test line"
+        # Write some content into src the same size of the record,
+        # need to reduce 4 from V and VB due to RDW
+        if record_format in ["V", "VB"]:
+            test_line = "a" * (record_length - 4)
+        else:
+            test_line = "a" * record_length
         for member in data_set.get("members"):
             if member == "":
                 ds_to_write = f"{data_set.get('name')}"
@@ -930,8 +938,12 @@ def test_mvs_unarchive_single_data_set_remote_src(ansible_zos_module, format, da
                     type="member",
                     state="present"
                 )
-        # Write some content into src
-        test_line = "this is a test line"
+        # Write some content into src the same size of the record,
+        # need to reduce 4 from V and VB due to RDW
+        if record_format in ["V", "VB"]:
+            test_line = "a" * (record_length - 4)
+        else:
+            test_line = "a" * record_length
         for member in data_set.get("members"):
             if member == "":
                 ds_to_write = f"{data_set.get('name')}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enhance the zos_archive and zos_unarchive, original idea was to simplify test cases but added test_lines with the actual record length of the dataset and take into account RDW.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #897 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enhancement Pull Request
