### PR TITLE
Initial commit to add LIBRARY to choices and docs

### DIFF
--- a/changelogs/fragments/920-bug-add-library-feature-documentation.yml
+++ b/changelogs/fragments/920-bug-add-library-feature-documentation.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zos_copy: Add 'LIBRARY' option as a destination dataset suboption.
+      Update documentation to show this option.
+        (https://github.com/ansible-collections/ibm_zos_core/pull/968)

--- a/changelogs/fragments/920-bug-add-library-feature-documentation.yml
+++ b/changelogs/fragments/920-bug-add-library-feature-documentation.yml
@@ -1,4 +1,0 @@
-bugfixes:
-  - zos_copy: Add 'LIBRARY' option as a destination dataset suboption.
-      Update documentation to show this option.
-        (https://github.com/ansible-collections/ibm_zos_core/pull/968)

--- a/changelogs/fragments/920-zos-copy-add-library-choice.yml
+++ b/changelogs/fragments/920-zos-copy-add-library-choice.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- zos_copy - Update option limit to include LIBRARY as dest_dataset/suboption value.
+    Documentation updated to reflect this change.
+      (https://github.com/ansible-collections/ibm_zos_core/pull/).

--- a/changelogs/fragments/920-zos-copy-add-library-choice.yml
+++ b/changelogs/fragments/920-zos-copy-add-library-choice.yml
@@ -1,4 +1,4 @@
 bugfixes:
 - zos_copy - Update option limit to include LIBRARY as dest_dataset/suboption value.
     Documentation updated to reflect this change.
-      (https://github.com/ansible-collections/ibm_zos_core/pull/).
+      (https://github.com/ansible-collections/ibm_zos_core/pull/968).

--- a/docs/source/modules/zos_copy.rst
+++ b/docs/source/modules/zos_copy.rst
@@ -74,7 +74,7 @@ dest
 
   If ``dest`` is a nonexistent data set, it will be created following the process outlined here and in the ``volume`` option.
 
-  If ``dest`` is a nonexistent data set, the attributes assigned will depend on the type of ``src``. If ``src`` is a USS file, ``dest`` will have a Fixed Block (FB) record format and the remaining attributes will be computed. If ``src`` is binary, ``dest`` will have a Fixed Block (FB) record format with a record length of 80, block size of 32760, and the remaining attributes will be computed.
+  If ``dest`` is a nonexistent data set, the attributes assigned will depend on the type of ``src``. If ``src`` is a USS file, ``dest`` will have a Fixed Block (FB) record format and the remaining attributes will be computed. If *is_binary=true*, ``dest`` will have a Fixed Block (FB) record format with a record length of 80, block size of 32760, and the remaining attributes will be computed. If *executable=true*,``dest`` will have an Undefined (U) record format with a record length of 0, block size of 32760, and the remaining attributes will be computed.
 
   When ``dest`` is a data set, precedence rules apply. If ``dest_data_set`` is set, this will take precedence over an existing data set. If ``dest`` is an empty data set, the empty data set will be written with the expectation its attributes satisfy the copy. Lastly, if no precendent rule has been exercised, ``dest`` will be created with the same attributes of ``src``.
 
@@ -151,6 +151,21 @@ ignore_sftp_stderr
 
 is_binary
   If set to ``true``, indicates that the file or data set to be copied is a binary file/data set.
+
+  | **required**: False
+  | **type**: bool
+
+
+executable
+  If set to ``true``, indicates that the file or library to be copied is an executable.
+
+  If the ``src`` executable has an alias, the alias information is also copied. If the ``dest`` is Unix, the alias is not visible in Unix, even though the information is there and will be visible if copied to a library.
+
+  If *executable=true*, and ``dest`` is a data set, it must be a PDS or PDSE (library).
+
+  If ``dest`` is a nonexistent data set, the library attributes assigned will be Undefined (U) record format with a record length of 0, block size of 32760 and the remaining attributes will be computed.
+
+  If ``dest`` is a file, execute permission for the user will be added to the file (``u+x``).
 
   | **required**: False
   | **type**: bool
@@ -247,7 +262,7 @@ dest_data_set
 
     | **required**: True
     | **type**: str
-    | **choices**: KSDS, ESDS, RRDS, LDS, SEQ, PDS, PDSE, MEMBER, BASIC
+    | **choices**: KSDS, ESDS, RRDS, LDS, SEQ, PDS, PDSE, MEMBER, BASIC, LIBRARY
 
 
   space_primary
@@ -672,6 +687,13 @@ Examples
          record_format: VB
          record_length: 150
 
+   - name: Copy a Program Object on remote system to a new PDSE member MYCOBOL.
+     zos_copy:
+       src: HLQ.COBOLSRC.PDSE(TESTPGM)
+       dest: HLQ.NEW.PDSE(MYCOBOL)
+       remote_src: true
+       executable: true
+
 
 
 
@@ -690,6 +712,8 @@ Notes
    For supported character sets used to encode data, refer to the `documentation <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/resources/character_set.html>`_.
 
    `zos_copy <./zos_copy.html>`_ uses SFTP (Secure File Transfer Protocol) for the underlying transfer protocol; Co:Z SFTP is not supported. In the case of Co:z SFTP, you can exempt the Ansible userid on z/OS from using Co:Z thus falling back to using standard SFTP.
+
+   Beginning in version 1.8.x, zos_copy will no longer attempt to autocorrect a copy of a data type member into a PDSE that contains program objects. You can control this behavior using module option executable that will signify an executable is being copied into a PDSE with other executables. Mixing data type members with program objects will be responded with a (FSUM8976,./zos_copy.html) error.
 
 
 

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -283,6 +283,7 @@ options:
           - PDSE
           - MEMBER
           - BASIC
+          - LIBRARY
       space_primary:
         description:
           - If the destination I(dest) data set does not exist , this sets the
@@ -2741,7 +2742,7 @@ def main():
                     type=dict(
                         type='str',
                         choices=['BASIC', 'KSDS', 'ESDS', 'RRDS',
-                                 'LDS', 'SEQ', 'PDS', 'PDSE', 'MEMBER'],
+                                 'LDS', 'SEQ', 'PDS', 'PDSE', 'MEMBER', 'LIBRARY'],
                         required=True,
                     ),
                     space_primary=dict(


### PR DESCRIPTION
##### SUMMARY
Change to zos_copy:
Added LIBRARY type to dest_dataset/suboptions as a valid choice
Updated in file documentation to reflect the option

Fixes #920 

##### ISSUE TYPE
- Bugfix Pull Request (missing option)
- Docs Pull Request (added option)

##### COMPONENT NAME
zos_copy.py


