### PR TITLE
Switched job.py to use the version_checker module for zoau versioning

### DIFF
--- a/changelogs/fragments/949-enhance-job-to-use-zoau-version-module.yml
+++ b/changelogs/fragments/949-enhance-job-to-use-zoau-version-module.yml
@@ -1,0 +1,3 @@
+enhancements:
+  - job.py: Now using a common zoau version library, instead of a custom importer.
+      (https://github.com/ansible-collections/ibm_zos_core/pull/970)

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -31,11 +31,23 @@ except Exception:
     list_dds = MissingZOAUImport()
     listing = MissingZOAUImport()
 
-try:
-    from zoautil_py import ZOAU_API_VERSION
-except Exception:
-    ZOAU_API_VERSION = "1.2.0"
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
+    zoau_version_checker
+)
 
+
+# try:
+#     from zoautil_py import ZOAU_API_VERSION
+# except Exception:
+#    ZOAU_API_VERSION = "1.2.0"
+
+
+def get_z_version():
+    """Get value and return it"""
+    vl = get_zoau_version_str()
+    ret = vl.merge('.')
+    return( ret )
 
 def job_output(job_id=None, owner=None, job_name=None, dd_name=None, duration=0, timeout=0, start_time=timer()):
     """Get the output from a z/OS job based on various search criteria.
@@ -255,7 +267,9 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
 
             # this section only works on zoau 1.2.3/+ vvv
 
-            if ZOAU_API_VERSION > "1.2.2":
+            zoau_version = get_z_version()
+
+            if zoau_version > "1.2.2":
                 job["job_class"] = entry.job_class
                 job["svc_class"] = entry.svc_class
                 job["priority"] = entry.priority
@@ -263,7 +277,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
                 job["creation_date"] = str(entry.creation_datetime)[0:10]
                 job["creation_time"] = str(entry.creation_datetime)[12:]
                 job["queue_position"] = entry.queue_position
-            if ZOAU_API_VERSION >= "1.2.4":
+            if zoau_version >= "1.2.4":
                 job["program_name"] = entry.program_name
 
             # this section only works on zoau 1.2.3/+ ^^^


### PR DESCRIPTION
##### SUMMARY
Modified job.py routine to use zoau_version_checker to check version of zoau

should resolve 949

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
job.py needs to know the zoau version so it can determine which variables to check for in the return object.


##### ADDITIONAL INFORMATION
It appears (still checking) that the __init__.py file is not maintained, as 1.2.5 is showing version=1.2.4.  

