### PR TITLE
Added latest to allow member copy when disp=shr

### DIFF
--- a/changelogs/fragments/969-Simplify_loadlib_test_cases.yml
+++ b/changelogs/fragments/969-Simplify_loadlib_test_cases.yml
@@ -1,0 +1,3 @@
+trivial:
+- zos_copy - Divide large test case for loadlibs and simplify functions.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/969)

--- a/changelogs/fragments/980-zos-copy-disp-shr.yml
+++ b/changelogs/fragments/980-zos-copy-disp-shr.yml
@@ -1,6 +1,6 @@
 minor_changes:
 - zos_copy - Add new option `force_lock` that can copy into data sets that are
-   already in use by other processes (DSP=SHR). User
+   already in use by other processes (DISP=SHR). User
    needs to use with caution because this is subject to race conditions and
    can lead to data loss.
   (https://github.com/ansible-collections/ibm_zos_core/pull/980).

--- a/changelogs/fragments/980-zos-copy-disp-shr.yml
+++ b/changelogs/fragments/980-zos-copy-disp-shr.yml
@@ -1,5 +1,6 @@
 minor_changes:
-- zos_copy - module can now copy into data sets that are already in use by
-   other processes (DSP=SHR) using option `force`. User needs to bare in mind
-   that using this when DIS=SHR can lead to data loss.
-  (https://github.com/ansible-collections/ibm_zos_core/pull/804).
+- zos_copy - Add new option `force_lock` that can copy into data sets that are
+   already in use by other processes (DSP=SHR). User
+   needs to use with caution because this is subject to race conditions and
+   can lead to data loss.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/980).

--- a/changelogs/fragments/980-zos-copy-disp-shr.yml
+++ b/changelogs/fragments/980-zos-copy-disp-shr.yml
@@ -1,6 +1,5 @@
 minor_changes:
 - zos_copy - Add new option `force_lock` that can copy into data sets that are
-   already in use by other processes (DISP=SHR). User
-   needs to use with caution because this is subject to race conditions and
-   can lead to data loss.
+   already in use by other processes (DISP=SHR). User needs to use with caution
+   because this is subject to race conditions and can lead to data loss.
   (https://github.com/ansible-collections/ibm_zos_core/pull/980).

--- a/changelogs/fragments/980-zos-copy-disp-shr.yml
+++ b/changelogs/fragments/980-zos-copy-disp-shr.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- zos_copy - module can now copy into data sets that are already in use by
+   other processes (DSP=SHR) using option `force`. User needs to bare in mind
+   that using this when DIS=SHR can lead to data loss.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/804).

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -59,6 +59,7 @@ class ActionModule(ActionBase):
         local_follow = _process_boolean(task_args.get('local_follow'), default=False)
         remote_src = _process_boolean(task_args.get('remote_src'), default=False)
         is_binary = _process_boolean(task_args.get('is_binary'), default=False)
+        force_lock = _process_boolean(task_args.get('force_lock'), default=False)
         executable = _process_boolean(task_args.get('executable'), default=False)
         ignore_sftp_stderr = _process_boolean(task_args.get("ignore_sftp_stderr"), default=False)
         backup_name = task_args.get("backup_name", None)
@@ -126,6 +127,9 @@ class ActionModule(ActionBase):
                 msg = "Cannot specify 'mode', 'owner' or 'group' for MVS destination"
                 return self._exit_action(result, msg, failed=True)
 
+        if force_lock:
+            display.warning(
+                msg="Using force_lock uses operations that are subject to race conditions and can lead to data loss, use with caution.")
         template_dir = None
 
         if not remote_src:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -152,9 +152,9 @@ options:
         process with DISP=SHR then zos_copy will copy using DISP=SHR.
         Use with caution, this can lead to data loss.
       - If a dataset member has aliases, and is not a program
-	    object, copying that member to a dataset that is in use will result in
-	    the aliases not being preserved in the target dataset. When this scenario
-	    occurs an error message will be produced along with a non-zero return code.
+        object, copying that member to a dataset that is in use will result in
+        the aliases not being preserved in the target dataset. When this scenario
+        occurs an error message will be produced along with a non-zero return code.
     type: bool
     default: false
     required: false

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -861,7 +861,7 @@ class CopyHandler(object):
             dest {str} -- The name of the destination VSAM
         """
         out_dsp = "shr" if self.force else "old"
-        dds = {"OUT" : "{0},{1}".format(dest.upper(), out_dsp)}
+        dds = {"OUT": "{0},{1}".format(dest.upper(), out_dsp)}
         repro_cmd = """  REPRO -
         INDATASET('{0}') -
         OUTFILE(OUT)""".format(src.upper())

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -810,6 +810,9 @@ class CopyHandler(object):
                                 is executable
             backup_name {str} -- The USS path or data set name of destination
                                  backup
+            force_lock {str} -- Whether the dest data set should be copied into
+                                using disp=shr when is opened by another
+                                process.
         """
         self.module = module
         self.is_binary = is_binary

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -148,23 +148,16 @@ options:
         destination does not exist.
       - If set to C(false) and destination exists, the module exits with a note to
         the user.
-      - If set to C(true) and destination is an MVS data set opened by another
-        process with DISP=SHR then zos_copy will copy using DISP=SHR.
-        Use with caution, this can lead to data loss.
-      - If a dataset member has aliases, and is not a program
-        object, copying that member to a dataset that is in use will result in
-        the aliases not being preserved in the target dataset. When this scenario
-        occurs an error message will be produced along with a non-zero return code.
     type: bool
     default: false
     required: false
   force_lock:
     description:
       - By default, when c(dest) is a MVS data set and is being used by another
-        process with DISP=SHR or DISP=OLD the module will fail; use C(force_lock)
+        process with DISP=SHR or DISP=OLD the module will fail. Use C(force_lock)
         to bypass this check and continue with copy.
       - If set to C(true) and destination is a MVS data set opened by another
-        process with DISP=SHR then zos_copy will copy using DISP=SHR.
+        process then zos_copy will try to copy using DISP=SHR.
       - Using C(force_lock) uses operations that are subject to race conditions
         and can lead to data loss, use with caution.
       - If a dataset member has aliases, and is not a program

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -160,7 +160,7 @@ options:
         process then zos_copy will try to copy using DISP=SHR.
       - Using C(force_lock) uses operations that are subject to race conditions
         and can lead to data loss, use with caution.
-      - If a dataset member has aliases, and is not a program
+      - If a data set member has aliases, and is not a program
         object, copying that member to a dataset that is in use will result in
         the aliases not being preserved in the target dataset. When this scenario
         occurs the module will fail.

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -874,9 +874,6 @@ class CopyHandler(object):
         repro_cmd = """  REPRO -
         INDATASET('{0}') -
         OUTFILE(OUT)""".format(src.upper())
-        # repro_cmd = """  REPRO -
-        # INDATASET('{0}') -
-        # OUDATASET('{1}')""".format(dest.upper())
         rc, out, err = idcams(repro_cmd, dds=dds, authorized=True)
         if rc != 0:
             raise CopyOperationError(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2619,7 +2619,8 @@ def run_module(module, arg_def):
         module,
         is_binary=is_binary,
         executable=executable,
-        backup_name=backup_name
+        backup_name=backup_name,
+        force_lock=force_lock,
     )
 
     try:

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1584,7 +1584,7 @@ def test_copy_dest_lock(ansible_zos_module, ds_type):
             hosts.all.zos_data_set(name=src_data_set, state="present", type="member", replace=True)
             hosts.all.zos_data_set(name=dest_data_set, state="present", type="member", replace=True)
         # copy text_in source
-        hosts.all.shell(cmd="decho \"{0}\" \"{1}\"".format(DUMMY_DATA, DATASET_2+"({0})".format(MEMBER_1)))
+        hosts.all.shell(cmd="decho \"{0}\" \"{1}\"".format(DUMMY_DATA, src_data_set))
         # copy/compile c program and copy jcl to hold data set lock for n seconds in background(&)
         hosts.all.zos_copy(content=c_pgm, dest='/tmp/disp_shr/pdse-lock.c', force=True)
         hosts.all.zos_copy(

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1601,7 +1601,7 @@ def test_copy_dest_lock(ansible_zos_module, ds_type):
             src = src_data_set,
             dest = dest_data_set,
             remote_src = True,
-            force=True,
+            force_lock=True,
         )
         for result in results.contacted.values():
             print(result)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -328,6 +328,32 @@ def link_loadlib_from_cobol(hosts, ds_name, cobol_pds):
         hosts.all.file(path=temp_jcl, state="absent")
     return rc
 
+def generate_executable_ds(hosts, src, dest, cobol):
+    member = "HELLOSRC"
+    hosts.all.zos_copy(content=COBOL_SRC, dest=cobol)
+    dest_name = "{0}({1})".format(dest, member)
+    src_name = "{0}({1})".format(src, member)
+    rc = link_loadlib_from_cobol(hosts, dest_name, cobol)
+    assert rc == 0
+    cmd = "mvscmd --pgm={0}  --steplib={1} --sysprint=* --stderr=* --stdout=*"
+    hosts.all.shell(cmd=cmd.format(member, dest))
+    rc = link_loadlib_from_cobol(hosts, src_name, cobol)
+    hosts.all.shell(cmd=cmd.format(member, src))
+    assert rc == 0
+    exec_res = hosts.all.shell(cmd=cmd.format(member, src))
+    for result in exec_res.contacted.values():
+        assert result.get("rc") == 0
+
+def generate_executable_uss(hosts, src, src_jcl_call):
+    hosts.all.zos_copy(content=hello_world, dest=src, force=True)
+    hosts.all.zos_copy(content=call_c_hello_jcl, dest=src_jcl_call, force=True)
+    hosts.all.shell(cmd="xlc -o hello_world hello_world.c", chdir="/tmp/c/")
+    hosts.all.shell(cmd="submit {0}".format(src_jcl_call))
+    verify_exe_src = hosts.all.shell(cmd="/tmp/c/hello_world")
+    for res in verify_exe_src.contacted.values():
+        assert res.get("rc") == 0
+        stdout = res.get("stdout")
+        assert  "Hello World" in str(stdout)
 
 @pytest.mark.uss
 @pytest.mark.parametrize("src", [
@@ -2515,6 +2541,87 @@ def test_copy_pds_loadlib_member_to_pds_loadlib_member(ansible_zos_module, is_cr
     src = "USER.LOAD.SRC"
     dest = "USER.LOAD.DEST"
     cobol_pds = "USER.COBOL.SRC"
+    dest_exe = "USER.LOAD.EXE"
+    try:
+        hosts.all.zos_data_set(
+            name=src,
+            state="present",
+            type="pdse",
+            record_format="U",
+            record_length=0,
+            block_size=32760,
+            space_primary=2,
+            space_type="M",
+            replace=True
+        )
+        hosts.all.zos_data_set(
+            name=dest,
+            state="present",
+            type="pdse",
+            record_format="U",
+            record_length=0,
+            block_size=32760,
+            space_primary=2,
+            space_type="M",
+            replace=True
+        )
+        hosts.all.zos_data_set(
+            name=cobol_pds,
+            state="present",
+            type="pds",
+            space_primary=2,
+            record_format="FB",
+            record_length=80,
+            block_size=3120,
+            replace=True,
+        )
+        member = "HELLOSRC"
+        cobol_pds = "{0}({1})".format(cobol_pds, member)
+        generate_executable_ds(hosts, src, dest, cobol_pds)
+        if is_created:
+            hosts.all.zos_data_set(
+                name=dest_exe,
+                state="present",
+                type="pdse",
+                record_format="U",
+                record_length=0,
+                block_size=32760,
+                space_primary=2,
+                space_type="M",
+                replace=True
+            )
+        copy_res = hosts.all.zos_copy(
+            src="{0}({1})".format(src, member),
+            dest="{0}({1})".format(dest_exe, "MEM1"),
+            remote_src=True,
+            executable=True)
+
+        verify_copy = hosts.all.shell(
+            cmd="mls {0}".format(dest_exe),
+            executable=SHELL_EXECUTABLE
+        )
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == "{0}({1})".format(dest_exe, "MEM1")
+
+        for v_cp in verify_copy.contacted.values():
+            assert v_cp.get("rc") == 0
+            stdout = v_cp.get("stdout")
+            assert stdout is not None
+    finally:
+        hosts.all.zos_data_set(name=dest, state="absent")
+        hosts.all.zos_data_set(name=src, state="absent")
+        hosts.all.zos_data_set(name=cobol_pds, state="absent")
+
+@pytest.mark.pdse
+@pytest.mark.uss
+def test_copy_pds_loadlib_member_to_uss(ansible_zos_module):
+    hosts = ansible_zos_module
+    src = "USER.LOAD.SRC"
+    dest = "USER.LOAD.DEST"
+    cobol_pds = "USER.COBOL.SRC"
     uss_dest = "/tmp/HELLO"
     try:
         hosts.all.zos_data_set(
@@ -2528,19 +2635,17 @@ def test_copy_pds_loadlib_member_to_pds_loadlib_member(ansible_zos_module, is_cr
             space_type="M",
             replace=True
         )
-        if is_created:
-            hosts.all.zos_data_set(
-                name=dest,
-                state="present",
-                type="pdse",
-                record_format="U",
-                record_length=0,
-                block_size=32760,
-                space_primary=2,
-                space_type="M",
-                replace=True
-            )
-
+        hosts.all.zos_data_set(
+            name=dest,
+            state="present",
+            type="pdse",
+            record_format="U",
+            record_length=0,
+            block_size=32760,
+            space_primary=2,
+            space_type="M",
+            replace=True
+        )
         hosts.all.zos_data_set(
             name=cobol_pds,
             state="present",
@@ -2553,61 +2658,13 @@ def test_copy_pds_loadlib_member_to_pds_loadlib_member(ansible_zos_module, is_cr
         )
         member = "HELLOSRC"
         cobol_pds = "{0}({1})".format(cobol_pds, member)
-        rc = hosts.all.zos_copy(
-            content=COBOL_SRC,
-            dest=cobol_pds
-        )
-        dest_name = "{0}({1})".format(dest, member)
-        src_name = "{0}({1})".format(src, member)
-        # both src and dest need to be a loadlib
-        rc = link_loadlib_from_cobol(hosts, dest_name, cobol_pds)
-        assert rc == 0
-        # make sure is executable
-        cmd = "mvscmd --pgm={0}  --steplib={1} --sysprint=* --stderr=* --stdout=*"
-        exec_res = hosts.all.shell(
-            cmd=cmd.format(member, dest)
-        )
-        for result in exec_res.contacted.values():
-            assert result.get("rc") == 0
-        rc = link_loadlib_from_cobol(hosts, src_name, cobol_pds)
-        assert rc == 0
-
-        exec_res = hosts.all.shell(
-            cmd=cmd.format(member, src)
-        )
-        for result in exec_res.contacted.values():
-            assert result.get("rc") == 0
-        # Execute the copy from pdse to another with executable and validate it
-        copy_res = hosts.all.zos_copy(
-            src="{0}({1})".format(src, member),
-            dest="{0}({1})".format(dest, "MEM1"),
-            remote_src=True,
-            executable=True)
-
-        verify_copy = hosts.all.shell(
-            cmd="mls {0}".format(dest),
-            executable=SHELL_EXECUTABLE
-        )
-
-        for result in copy_res.contacted.values():
-            assert result.get("msg") is None
-            assert result.get("changed") is True
-            assert result.get("dest") == "{0}({1})".format(dest, "MEM1")
-
-        for v_cp in verify_copy.contacted.values():
-            assert v_cp.get("rc") == 0
-            stdout = v_cp.get("stdout")
-            assert stdout is not None
-            # number of members
-            assert len(stdout.splitlines()) == 2
-        # Copy to a uss file executable from the library execute and validate
+        generate_executable_ds(hosts, src, dest, cobol_pds)
         copy_uss_res = hosts.all.zos_copy(
-            src="{0}({1})".format(dest, "MEM1"),
+            src="{0}({1})".format(src, member),
             dest=uss_dest,
             remote_src=True,
             executable=True,
             force=True)
-
         for result in copy_uss_res.contacted.values():
             assert result.get("msg") is None
             assert result.get("changed") is True
@@ -2615,12 +2672,10 @@ def test_copy_pds_loadlib_member_to_pds_loadlib_member(ansible_zos_module, is_cr
         verify_exe_uss = hosts.all.shell(
             cmd="{0}".format(uss_dest)
         )
-
         for v_cp_u in verify_exe_uss.contacted.values():
             assert v_cp_u.get("rc") == 0
             stdout = v_cp_u.get("stdout")
             assert  "SIMPLE HELLO WORLD" in str(stdout)
-
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
         hosts.all.zos_data_set(name=src, state="absent")
@@ -2628,26 +2683,14 @@ def test_copy_pds_loadlib_member_to_pds_loadlib_member(ansible_zos_module, is_cr
         hosts.all.file(name=uss_dest, state="absent")
 
 
-@pytest.mark.pdse
 @pytest.mark.uss
-@pytest.mark.parametrize("is_created", ["true", "false"])
-def test_copy_executables_uss_to_member(ansible_zos_module, is_created):
+def test_copy_executables_uss_to_uss(ansible_zos_module):
     hosts= ansible_zos_module
     src= "/tmp/c/hello_world.c"
     src_jcl_call= "/tmp/c/call_hw_pgm.jcl"
     dest_uss="/tmp/c/hello_world_2"
-    dest = "USER.LOAD.DEST"
-    member = "HELLOSRC"
     try:
-        hosts.all.zos_copy(content=hello_world, dest=src, force=True)
-        hosts.all.zos_copy(content=call_c_hello_jcl, dest=src_jcl_call, force=True)
-        hosts.all.shell(cmd="xlc -o hello_world hello_world.c", chdir="/tmp/c/")
-        hosts.all.shell(cmd="submit {0}".format(src_jcl_call))
-        verify_exe_src = hosts.all.shell(cmd="/tmp/c/hello_world")
-        for res in verify_exe_src.contacted.values():
-            assert res.get("rc") == 0
-            stdout = res.get("stdout")
-            assert  "Hello World" in str(stdout)
+        generate_executable_uss(hosts, src, src_jcl_call)
         copy_uss_res = hosts.all.zos_copy(
             src="/tmp/c/hello_world",
             dest=dest_uss,
@@ -2663,6 +2706,21 @@ def test_copy_executables_uss_to_member(ansible_zos_module, is_created):
             assert res.get("rc") == 0
             stdout = res.get("stdout")
             assert  "Hello World" in str(stdout)
+    finally:
+        hosts.all.shell(cmd='rm -r /tmp/c')
+
+
+@pytest.mark.pdse
+@pytest.mark.uss
+@pytest.mark.parametrize("is_created", ["true", "false"])
+def test_copy_executables_uss_to_member(ansible_zos_module, is_created):
+    hosts= ansible_zos_module
+    src= "/tmp/c/hello_world.c"
+    src_jcl_call= "/tmp/c/call_hw_pgm.jcl"
+    dest = "USER.LOAD.DEST"
+    member = "HELLOSRC"
+    try:
+        generate_executable_uss(hosts, src, src_jcl_call)
         if is_created:
             hosts.all.zos_data_set(
                 name=dest,

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -185,7 +185,7 @@ int main(int argc, char** argv)
 call_c_jcl="""//PDSELOCK JOB MSGCLASS=A,MSGLEVEL=(1,1),NOTIFY=&SYSUID,REGION=0M
 //LOCKMEM  EXEC PGM=BPXBATCH
 //STDPARM DD *
-SH /tmp/disp_shr/pdse-lock '{0}({1})'
+SH /tmp/disp_shr/pdse-lock '{0}'
 //STDIN  DD DUMMY
 //STDOUT DD SYSOUT=*
 //STDERR DD SYSOUT=*
@@ -1565,22 +1565,30 @@ def test_ensure_copy_file_does_not_change_permission_on_dest(ansible_zos_module,
 
 
 @pytest.mark.seq
-def test_copy_dest_lock(ansible_zos_module):
+@pytest.mark.parametrize("ds_type", ["PDS", "PDSE", "SEQ"])
+def test_copy_dest_lock(ansible_zos_module, ds_type):
     DATASET_1 = "USER.PRIVATE.TESTDS"
     DATASET_2 = "ADMI.PRIVATE.TESTDS"
     MEMBER_1 = "MEM1"
+    if ds_type == "PDS" or ds_type == "PDSE":
+        src_data_set = DATASET_1 + "({0})".format(MEMBER_1)
+        dest_data_set = DATASET_2 + "({0})".format(MEMBER_1)
+    else:
+        src_data_set = DATASET_1
+        dest_data_set = DATASET_2
     try:
         hosts = ansible_zos_module
         hosts.all.zos_data_set(name=DATASET_1, state="present", type="pdse", replace=True)
         hosts.all.zos_data_set(name=DATASET_2, state="present", type="pdse", replace=True)
-        hosts.all.zos_data_set(name=DATASET_1 + "({0})".format(MEMBER_1), state="present", type="member", replace=True)
-        hosts.all.zos_data_set(name=DATASET_2 + "({0})".format(MEMBER_1), state="present", type="member", replace=True)
+        if ds_type == "PDS" or ds_type == "PDSE":
+            hosts.all.zos_data_set(name=src_data_set, state="present", type="member", replace=True)
+            hosts.all.zos_data_set(name=dest_data_set, state="present", type="member", replace=True)
         # copy text_in source
         hosts.all.shell(cmd="decho \"{0}\" \"{1}\"".format(DUMMY_DATA, DATASET_2+"({0})".format(MEMBER_1)))
         # copy/compile c program and copy jcl to hold data set lock for n seconds in background(&)
         hosts.all.zos_copy(content=c_pgm, dest='/tmp/disp_shr/pdse-lock.c', force=True)
         hosts.all.zos_copy(
-            content=call_c_jcl.format(DATASET_1, MEMBER_1),
+            content=call_c_jcl.format(dest_data_set),
             dest='/tmp/disp_shr/call_c_pgm.jcl',
             force=True
         )
@@ -1590,8 +1598,8 @@ def test_copy_dest_lock(ansible_zos_module):
         # pause to ensure c code acquires lock
         time.sleep(5)
         results = hosts.all.zos_copy(
-            src = DATASET_2 + "({0})".format(MEMBER_1),
-            dest = DATASET_1 + "({0})".format(MEMBER_1),
+            src = src_data_set,
+            dest = dest_data_set,
             remote_src = True,
             force=True,
         )
@@ -1601,13 +1609,13 @@ def test_copy_dest_lock(ansible_zos_module):
             assert result.get("msg") is None
             # verify that the content is the same
             verify_copy = hosts.all.shell(
-                cmd="dcat \"{0}\"".format(DATASET_2 + "({0})".format(MEMBER_1)),
+                cmd="dcat \"{0}\"".format(dest_data_set),
                 executable=SHELL_EXECUTABLE,
             )
             for vp_result in verify_copy.contacted.values():
                 print(vp_result)
                 verify_copy_2 = hosts.all.shell(
-                    cmd="dcat \"{0}\"".format(DATASET_1 + "({0})".format(MEMBER_1)),
+                    cmd="dcat \"{0}\"".format(src_data_set),
                     executable=SHELL_EXECUTABLE,
                 )
                 for vp_result_2 in verify_copy_2.contacted.values():

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1601,6 +1601,7 @@ def test_copy_dest_lock(ansible_zos_module, ds_type):
             src = src_data_set,
             dest = dest_data_set,
             remote_src = True,
+            force=True,
             force_lock=True,
         )
         for result in results.contacted.values():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
zos_copy does not support interactions with data sets that are already in use by other processes (DSP=SHR). With these changes using force flag now user can issue copies for these data sets.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #735 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy
