### PR TITLE
Enhancement/423/zos copy add data set member alias support

### DIFF
--- a/changelogs/fragments/1014-zos-copy-add-data-set-member-aliases.yml
+++ b/changelogs/fragments/1014-zos-copy-add-data-set-member-aliases.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- zos_copy - introduces a new option 'aliases' to enable preservation of member aliases
+  when copying data to partitioned data sets (PDS) destinations from USS or other PDS sources.
+  Copying aliases of text based members to/from USS is not supported.
+  (https://github.com/ansible-collections/ibm_zos_core/pull/1014)

--- a/docs/source/modules/zos_copy.rst
+++ b/docs/source/modules/zos_copy.rst
@@ -171,6 +171,17 @@ executable
   | **type**: bool
 
 
+aliases
+  If set to ``true``, indicates that any aliases found in the source (USS file, USS dir, PDS/E library or member) are to be preserved during the copy operation.
+
+  Aliases are implicitly preserved when libraries are copied over to USS destinations. That is, when ``executable=True`` and ``dest`` is a USS file or directory, this option will be ignored.
+
+  Copying of aliases for text-based data sets from USS sources or to USS destinations is not currently supported.
+
+  | **required**: False
+  | **type**: bool
+
+
 local_follow
   This flag indicates that any existing filesystem links in the source tree should be followed.
 
@@ -687,12 +698,21 @@ Examples
          record_format: VB
          record_length: 150
 
-   - name: Copy a Program Object on remote system to a new PDSE member MYCOBOL.
+   - name: Copy a Program Object and its aliases on a remote system to a new PDSE member MYCOBOL
      zos_copy:
        src: HLQ.COBOLSRC.PDSE(TESTPGM)
        dest: HLQ.NEW.PDSE(MYCOBOL)
        remote_src: true
        executable: true
+       aliases: true
+
+       - name: Copy a Load Library from a USS directory /home/loadlib to a new PDSE
+     zos_copy:
+       src: '/home/loadlib/'
+       dest: HLQ.LOADLIB.NEW
+       remote_src: true
+       executable: true
+       aliases: true
 
 
 

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -173,6 +173,12 @@ options:
     type: bool
     default: false
     required: false
+  aliases:
+    description:
+      - TODO
+    type: bool
+    default: false
+    required: false
   executable:
     description:
       - If set to C(true), indicates that the file or library to be copied is an executable.
@@ -1397,6 +1403,7 @@ class PDSECopyHandler(CopyHandler):
         self,
         module,
         is_binary=False,
+        aliases=False,
         executable=False,
         backup_name=None
     ):
@@ -1418,6 +1425,7 @@ class PDSECopyHandler(CopyHandler):
             executable=executable,
             backup_name=backup_name
         )
+        self.aliases = aliases # aliases not added to CopyHandler object
 
     def copy_to_pdse(
         self,
@@ -1540,6 +1548,10 @@ class PDSECopyHandler(CopyHandler):
 
         if self.is_binary:
             opts["options"] = "-B"
+
+        if self.aliases:
+            # lower case 'i' for text-based copy
+            opts["options"] = "-i"
 
         if self.executable:
             opts["options"] = "-IX"
@@ -2270,6 +2282,7 @@ def run_module(module, arg_def):
     dest = module.params.get('dest')
     remote_src = module.params.get('remote_src')
     is_binary = module.params.get('is_binary')
+    aliases = module.params.get('aliases')
     executable = module.params.get('executable')
     backup = module.params.get('backup')
     backup_name = module.params.get('backup_name')
@@ -2666,7 +2679,7 @@ def run_module(module, arg_def):
                 temp_path = os.path.join(temp_path, os.path.basename(src))
 
             pdse_copy_handler = PDSECopyHandler(
-                module, is_binary=is_binary, executable=executable, backup_name=backup_name
+                module, is_binary=is_binary, aliases=aliases, executable=executable, backup_name=backup_name
             )
 
             pdse_copy_handler.copy_to_pdse(
@@ -2711,6 +2724,7 @@ def main():
             src=dict(type='path'),
             dest=dict(required=True, type='str'),
             is_binary=dict(type='bool', default=False),
+            aliases=dict(type='bool', default=False, required=False),
             executable=dict(type='bool', default=False),
             encoding=dict(
                 type='dict',
@@ -2812,6 +2826,7 @@ def main():
         src=dict(arg_type='data_set_or_path', required=False),
         dest=dict(arg_type='data_set_or_path', required=True),
         is_binary=dict(arg_type='bool', required=False, default=False),
+        aliases=dict(arg_type='bool', required=False, default=False),
         executable=dict(arg_type='bool', required=False, default=False),
         content=dict(arg_type='str', required=False),
         backup=dict(arg_type='bool', default=False, required=False),

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1489,7 +1489,9 @@ class PDSECopyHandler(CopyHandler):
                 members.append(data_set.extract_member_name(new_src))
             else:
                 # Aliases are included in listing unless alias is set to False.
-                members = datasets.list_members(new_src, **{ 'alias': False })
+                opts = {}
+                opts['options'] = '-H ' # mls option to hide aliases
+                members = datasets.list_members(new_src, **opts)
 
             src_members = ["{0}({1})".format(src_data_set_name, member) for member in members]
             dest_members = [
@@ -1550,12 +1552,14 @@ class PDSECopyHandler(CopyHandler):
         if self.is_binary:
             opts["options"] = "-B"
 
-        if self.aliases:
+        if self.aliases and not self.executable:
             # lower case 'i' for text-based copy (dcp)
             opts["options"] = "-i"
 
         if self.executable:
-            opts["options"] = "-IX"
+            opts["options"] = "-X"
+            if self.aliases:
+                opts["options"] = "-IX"
 
         response = datasets._copy(src, dest, None, **opts)
         rc, out, err = response.rc, response.stdout_response, response.stderr_response

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -173,12 +173,6 @@ options:
     type: bool
     default: false
     required: false
-  aliases:
-    description:
-      - TODO
-    type: bool
-    default: false
-    required: false
   executable:
     description:
       - If set to C(true), indicates that the file or library to be copied is an executable.
@@ -190,6 +184,12 @@ options:
         Undefined (U) record format with a record length of 0, block size of 32760 and the
         remaining attributes will be computed.
       - If C(dest) is a file, execute permission for the user will be added to the file (``u+x``).
+    type: bool
+    default: false
+    required: false
+  aliases:
+    description:
+      - TODO
     type: bool
     default: false
     required: false
@@ -784,8 +784,8 @@ class CopyHandler(object):
         self,
         module,
         is_binary=False,
-        aliases=False,
         executable=False,
+        aliases=False,
         backup_name=None
     ):
         """Utility class to handle copying data between two targets
@@ -804,8 +804,8 @@ class CopyHandler(object):
         """
         self.module = module
         self.is_binary = is_binary
-        self.aliases = aliases
         self.executable = executable
+        self.aliases = aliases
         self.backup_name = backup_name
 
     def run_command(self, cmd, **kwargs):
@@ -1077,8 +1077,8 @@ class USSCopyHandler(CopyHandler):
         self,
         module,
         is_binary=False,
-        aliases=False,
         executable=False,
+        aliases=False,
         common_file_args=None,
         backup_name=None,
     ):
@@ -1096,7 +1096,7 @@ class USSCopyHandler(CopyHandler):
             backup_name {str} -- The USS path or data set name of destination backup
         """
         super().__init__(
-            module, is_binary=is_binary, aliases=aliases, executable=executable, backup_name=backup_name
+            module, is_binary=is_binary, executable=executable, aliases=aliases, backup_name=backup_name
         )
         self.common_file_args = common_file_args
 
@@ -1427,8 +1427,8 @@ class PDSECopyHandler(CopyHandler):
         self,
         module,
         is_binary=False,
-        aliases=False,
         executable=False,
+        aliases=False,
         backup_name=None
     ):
         """ Utility class to handle copying to partitioned data sets or
@@ -1446,8 +1446,8 @@ class PDSECopyHandler(CopyHandler):
         super().__init__(
             module,
             is_binary=is_binary,
-            aliases=aliases,
             executable=executable,
+            aliases=aliases,
             backup_name=backup_name
         )
 
@@ -2322,8 +2322,8 @@ def run_module(module, arg_def):
     dest = module.params.get('dest')
     remote_src = module.params.get('remote_src')
     is_binary = module.params.get('is_binary')
-    aliases = module.params.get('aliases')
     executable = module.params.get('executable')
+    aliases = module.params.get('aliases')
     backup = module.params.get('backup')
     backup_name = module.params.get('backup_name')
     validate = module.params.get('validate')
@@ -2678,8 +2678,8 @@ def run_module(module, arg_def):
             uss_copy_handler = USSCopyHandler(
                 module,
                 is_binary=is_binary,
-                aliases=aliases,
                 executable=executable,
+                aliases=aliases,
                 common_file_args=dict(mode=mode, group=group, owner=owner),
                 backup_name=backup_name,
             )
@@ -2743,7 +2743,7 @@ def run_module(module, arg_def):
                 temp_path = os.path.join(validation.validate_safe_path(temp_path), validation.validate_safe_path(os.path.basename(src)))
 
             pdse_copy_handler = PDSECopyHandler(
-                module, is_binary=is_binary, aliases=aliases, executable=executable, backup_name=backup_name
+                module, is_binary=is_binary, executable=executable, aliases=aliases, backup_name=backup_name
             )
 
             pdse_copy_handler.copy_to_pdse(
@@ -2788,8 +2788,8 @@ def main():
             src=dict(type='path'),
             dest=dict(required=True, type='str'),
             is_binary=dict(type='bool', default=False),
-            aliases=dict(type='bool', default=False, required=False),
             executable=dict(type='bool', default=False),
+            aliases=dict(type='bool', default=False, required=False),
             encoding=dict(
                 type='dict',
                 required=False,
@@ -2890,8 +2890,8 @@ def main():
         src=dict(arg_type='data_set_or_path', required=False),
         dest=dict(arg_type='data_set_or_path', required=True),
         is_binary=dict(arg_type='bool', required=False, default=False),
-        aliases=dict(arg_type='bool', required=False, default=False),
         executable=dict(arg_type='bool', required=False, default=False),
+        aliases=dict(arg_type='bool', required=False, default=False),
         content=dict(arg_type='str', required=False),
         backup=dict(arg_type='bool', default=False, required=False),
         backup_name=dict(arg_type='data_set_or_path', required=False),

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -189,7 +189,10 @@ options:
     required: false
   aliases:
     description:
-      - TODO
+      - If set to C(true), indicates that any aliases found in the src file or library are to be preserved.
+      - Aliases are implicitly preserved when libraries are copied over to USS.
+        That is, when C(executable=True) and C(dest) is a USS file or directory, this option will be ignored.
+      - Copying of aliases for text-based data sets to USS destinations or from USS sources is not currently supported.
     type: bool
     default: false
     required: false
@@ -581,12 +584,21 @@ EXAMPLES = r"""
       record_format: VB
       record_length: 150
 
-- name: Copy a Program Object on remote system to a new PDSE member MYCOBOL.
+- name: Copy a Program Object and its aliases on a remote system to a new PDSE member MYCOBOL
   zos_copy:
     src: HLQ.COBOLSRC.PDSE(TESTPGM)
     dest: HLQ.NEW.PDSE(MYCOBOL)
     remote_src: true
     executable: true
+    aliases: true
+
+    - name: Copy a Load Library from a USS directory /home/loadlib to a new PDSE.
+  zos_copy:
+    src: '/home/loadlib/'
+    dest: HLQ.LOADLIB.NEW
+    remote_src: true
+    executable: true
+    aliases: true
 """
 
 RETURN = r"""

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1095,7 +1095,7 @@ class USSCopyHandler(CopyHandler):
             backup_name {str} -- The USS path or data set name of destination backup
         """
         super().__init__(
-            module, is_binary=is_binary, executable=executable, backup_name=backup_name
+            module, is_binary=is_binary, aliases=aliases, executable=executable, backup_name=backup_name
         )
         self.common_file_args = common_file_args
 
@@ -1439,10 +1439,10 @@ class PDSECopyHandler(CopyHandler):
         super().__init__(
             module,
             is_binary=is_binary,
+            aliases=aliases,
             executable=executable,
             backup_name=backup_name
         )
-        self.aliases = aliases # aliases not added to CopyHandler object
 
     def copy_to_pdse(
         self,
@@ -2523,7 +2523,9 @@ def run_module(module, arg_def):
     if aliases:
         if (src_ds_type=='USS' or dest_ds_type=='USS' ) and not executable:
             module.fail_json(
-                msg="Alias support for text-based data sets is not available for USS sources (src) or targets (dest). Try setting executable=True or aliases=False."
+                msg="Alias support for text-based data sets is not available "
+                    + "for USS sources (src) or targets (dest). "
+                    + "Try setting executable=True or aliases=False."
             )
 
     # ********************************************************************

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -814,13 +814,9 @@ class CopyHandler(object):
         module,
         is_binary=False,
         executable=False,
-<<<<<<< HEAD
         aliases=False,
-        backup_name=None
-=======
         backup_name=None,
         force_lock=False,
->>>>>>> dev
     ):
         """Utility class to handle copying data between two targets
 
@@ -1472,13 +1468,9 @@ class PDSECopyHandler(CopyHandler):
         module,
         is_binary=False,
         executable=False,
-<<<<<<< HEAD
         aliases=False,
-        backup_name=None
-=======
         backup_name=None,
         force_lock=False,
->>>>>>> dev
     ):
         """ Utility class to handle copying to partitioned data sets or
         partitioned data set members.
@@ -1496,13 +1488,9 @@ class PDSECopyHandler(CopyHandler):
             module,
             is_binary=is_binary,
             executable=executable,
-<<<<<<< HEAD
             aliases=aliases,
-            backup_name=backup_name
-=======
             backup_name=backup_name,
             force_lock=force_lock,
->>>>>>> dev
         )
 
     def copy_to_pdse(
@@ -2805,15 +2793,12 @@ def run_module(module, arg_def):
                 temp_path = os.path.join(validation.validate_safe_path(temp_path), validation.validate_safe_path(os.path.basename(src)))
 
             pdse_copy_handler = PDSECopyHandler(
-<<<<<<< HEAD
-                module, is_binary=is_binary, executable=executable, aliases=aliases, backup_name=backup_name
-=======
                 module,
                 is_binary=is_binary,
                 executable=executable,
+                aliases=aliases,
                 backup_name=backup_name,
                 force_lock=force_lock,
->>>>>>> dev
             )
 
             pdse_copy_handler.copy_to_pdse(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1488,7 +1488,8 @@ class PDSECopyHandler(CopyHandler):
             if src_member:
                 members.append(data_set.extract_member_name(new_src))
             else:
-                members = datasets.list_members(new_src)
+                # Aliases are included in listing unless alias is set to False.
+                members = datasets.list_members(new_src, **{ 'alias': False })
 
             src_members = ["{0}({1})".format(src_data_set_name, member) for member in members]
             dest_members = [
@@ -1497,7 +1498,7 @@ class PDSECopyHandler(CopyHandler):
                 for member in members
             ]
 
-        existing_members = datasets.list_members(dest)
+        existing_members = datasets.list_members(dest) # include aliases in list
         overwritten_members = []
         new_members = []
 
@@ -1550,7 +1551,7 @@ class PDSECopyHandler(CopyHandler):
             opts["options"] = "-B"
 
         if self.aliases:
-            # lower case 'i' for text-based copy
+            # lower case 'i' for text-based copy (dcp)
             opts["options"] = "-i"
 
         if self.executable:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -189,10 +189,11 @@ options:
     required: false
   aliases:
     description:
-      - If set to C(true), indicates that any aliases found in the src file or library are to be preserved.
-      - Aliases are implicitly preserved when libraries are copied over to USS.
+      - If set to C(true), indicates that any aliases found in the source
+        (USS file, USS dir, PDS/E library or member) are to be preserved during the copy operation.
+      - Aliases are implicitly preserved when libraries are copied over to USS destinations.
         That is, when C(executable=True) and C(dest) is a USS file or directory, this option will be ignored.
-      - Copying of aliases for text-based data sets to USS destinations or from USS sources is not currently supported.
+      - Copying of aliases for text-based data sets from USS sources or to USS destinations is not currently supported.
     type: bool
     default: false
     required: false

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -609,7 +609,7 @@ EXAMPLES = r"""
     executable: true
     aliases: true
 
-    - name: Copy a Load Library from a USS directory /home/loadlib to a new PDSE
+- name: Copy a Load Library from a USS directory /home/loadlib to a new PDSE
   zos_copy:
     src: '/home/loadlib/'
     dest: HLQ.LOADLIB.NEW

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -289,6 +289,7 @@ options:
           - PDSE
           - MEMBER
           - BASIC
+          - LIBRARY
       space_primary:
         description:
           - If the destination I(dest) data set does not exist , this sets the
@@ -2818,7 +2819,7 @@ def main():
                     type=dict(
                         type='str',
                         choices=['BASIC', 'KSDS', 'ESDS', 'RRDS',
-                                 'LDS', 'SEQ', 'PDS', 'PDSE', 'MEMBER'],
+                                 'LDS', 'SEQ', 'PDS', 'PDSE', 'MEMBER', 'LIBRARY'],
                         required=True,
                     ),
                     space_primary=dict(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -593,7 +593,7 @@ EXAMPLES = r"""
     executable: true
     aliases: true
 
-    - name: Copy a Load Library from a USS directory /home/loadlib to a new PDSE.
+    - name: Copy a Load Library from a USS directory /home/loadlib to a new PDSE
   zos_copy:
     src: '/home/loadlib/'
     dest: HLQ.LOADLIB.NEW

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2556,7 +2556,7 @@ def run_module(module, arg_def):
         and dest_ds_type=='USS' and not os.path.isdir(dest)
     ):
         module.fail_json(
-            msg="Cannot write a partitioned data set (PDS) to a USS file.".format(src_ds_type)
+            msg="Cannot write a partitioned data set (PDS) to a USS file."
         )
 
     # ********************************************************************

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1553,7 +1553,10 @@ class PDSECopyHandler(CopyHandler):
             if src_member:
                 members.append(data_set.extract_member_name(new_src))
             else:
-                # Aliases are included in listing unless alias is set to False.
+                # The 'members' variable below is used to store a list of members in the src PDS/E.
+                # Items in the list are passed to the copy_to_member function.
+                # Aliases are included in the output by list_members unless the alias option is disabled.
+                # The logic for preserving/copying aliases is contained in the copy_to_member function.
                 opts = {}
                 opts['options'] = '-H '  # mls option to hide aliases
                 members = datasets.list_members(new_src, **opts)
@@ -1565,7 +1568,7 @@ class PDSECopyHandler(CopyHandler):
                 for member in members
             ]
 
-        existing_members = datasets.list_members(dest)  # include aliases in list
+        existing_members = datasets.list_members(dest)  # fyi - this list includes aliases
         overwritten_members = []
         new_members = []
 

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1417,7 +1417,6 @@ class USSCopyHandler(CopyHandler):
             member_name {str} -- The name of the source data set member
         """
 
-
         if os.path.isdir(dest):
             # If source is a data set member, destination file should have
             # the same name as the member.
@@ -1556,7 +1555,7 @@ class PDSECopyHandler(CopyHandler):
             else:
                 # Aliases are included in listing unless alias is set to False.
                 opts = {}
-                opts['options'] = '-H ' # mls option to hide aliases
+                opts['options'] = '-H '  # mls option to hide aliases
                 members = datasets.list_members(new_src, **opts)
 
             src_members = ["{0}({1})".format(src_data_set_name, member) for member in members]
@@ -1566,7 +1565,7 @@ class PDSECopyHandler(CopyHandler):
                 for member in members
             ]
 
-        existing_members = datasets.list_members(dest) # include aliases in list
+        existing_members = datasets.list_members(dest)  # include aliases in list
         overwritten_members = []
         new_members = []
 
@@ -2576,7 +2575,7 @@ def run_module(module, arg_def):
     # Alias support is not avaiable to and from USS for text-based data sets.
     # ********************************************************************
     if aliases:
-        if (src_ds_type=='USS' or dest_ds_type=='USS' ) and not executable:
+        if (src_ds_type == 'USS' or dest_ds_type == 'USS') and not executable:
             module.fail_json(
                 msg="Alias support for text-based data sets is not available "
                     + "for USS sources (src) or targets (dest). "
@@ -2588,7 +2587,7 @@ def run_module(module, arg_def):
     # ********************************************************************
     if (
         src_ds_type in data_set.DataSet.MVS_PARTITIONED and not src_member
-        and dest_ds_type=='USS' and not os.path.isdir(dest)
+        and dest_ds_type == 'USS' and not os.path.isdir(dest)
     ):
         module.fail_json(
             msg="Cannot write a partitioned data set (PDS) to a USS file."

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3241,6 +3241,14 @@ def test_copy_member_to_uss_dir(ansible_zos_module, src_type):
             executable=SHELL_EXECUTABLE
         )
 
+        # ensure aliases:True errors out for non-text member copy
+        copy_aliases_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True, aliases=True)
+        for result in copy_aliases_res.contacted.values():
+            error_msg = "Alias support for text-based data sets is not available"
+            assert result.get("failed") is True
+            assert result.get("changed") is False
+            assert error_msg in result.get("msg")
+
         copy_res = hosts.all.zos_copy(src=src, dest=dest, remote_src=True)
         stat_res = hosts.all.stat(path=dest_path)
         verify_copy = hosts.all.shell(

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2782,14 +2782,14 @@ def test_copy_pds_loadlib_member_to_uss_to_loadlib(ansible_zos_module):
 
         # generate loadlib into src_pds
         generate_executable_ds(hosts, cobol_src_pds, cobol_src_mem, src_lib, pgm_mem, pgm_mem_alias)
+
+        # zos_copy an executable to USS file:
         copy_uss_res = hosts.all.zos_copy(
             src="{0}({1})".format(src_lib, pgm_mem),
             dest=uss_dest,
             remote_src=True,
             executable=True,
             force=True)
-
-        # zos_copy an executable to USS file:
         for result in copy_uss_res.contacted.values():
             assert result.get("msg") is None
             assert result.get("changed") is True
@@ -3200,6 +3200,14 @@ def test_copy_pdse_to_uss_dir(ansible_zos_module, src_type):
             )
 
         hosts.all.file(path=dest_path, state="directory")
+
+        # ensure aliases:True errors out for non-text member copy
+        copy_aliases_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True, aliases=True)
+        for result in copy_aliases_res.contacted.values():
+            error_msg = "Alias support for text-based data sets is not available"
+            assert result.get("failed") is True
+            assert result.get("changed") is False
+            assert error_msg in result.get("msg")
 
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
         stat_res = hosts.all.stat(path=dest_path)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2582,6 +2582,8 @@ def test_copy_pds_to_existing_pds(ansible_zos_module, args):
 
 
 @pytest.mark.pdse
+@pytest.mark.loadlib
+@pytest.mark.aliases
 @pytest.mark.parametrize("is_created", ["true", "false"])
 def test_copy_pds_loadlib_member_to_pds_loadlib_member(ansible_zos_module, is_created):
     hosts = ansible_zos_module
@@ -2715,6 +2717,8 @@ def test_copy_pds_loadlib_member_to_pds_loadlib_member(ansible_zos_module, is_cr
         hosts.all.zos_data_set(name=dest_lib_aliases, state="absent")
 
 @pytest.mark.pdse
+@pytest.mark.loadlib
+@pytest.mark.aliases
 @pytest.mark.uss
 def test_copy_pds_loadlib_member_to_uss_to_loadlib(ansible_zos_module):
     hosts = ansible_zos_module
@@ -2862,6 +2866,8 @@ def test_copy_pds_loadlib_member_to_uss_to_loadlib(ansible_zos_module):
 
 
 @pytest.mark.pdse
+@pytest.mark.loadlib
+@pytest.mark.aliases
 def test_copy_pds_loadlib_to_pds_loadlib(ansible_zos_module):
 
     hosts = ansible_zos_module
@@ -3012,6 +3018,8 @@ def test_copy_pds_loadlib_to_pds_loadlib(ansible_zos_module):
         hosts.all.zos_data_set(name=dest_lib_aliases, state="absent")
 
 @pytest.mark.pdse
+@pytest.mark.loadlib
+@pytest.mark.aliases
 @pytest.mark.uss
 def test_copy_pds_loadlib_to_uss_to_pds_loadlib(ansible_zos_module):
 
@@ -3202,7 +3210,7 @@ def test_copy_pds_loadlib_to_uss_to_pds_loadlib(ansible_zos_module):
         hosts.all.zos_data_set(name=src_lib, state="absent")
         hosts.all.zos_data_set(name=dest_lib, state="absent")
         hosts.all.zos_data_set(name=dest_lib_aliases, state="absent")
-        hosts.all.file(path=uss_dir_path, state="directory")
+        hosts.all.file(path=uss_dir_path, state="absent")
 
 
 @pytest.mark.uss
@@ -3498,6 +3506,7 @@ def test_copy_member_to_existing_uss_file(ansible_zos_module, args):
 
 @pytest.mark.uss
 @pytest.mark.pdse
+@pytest.mark.aliases
 @pytest.mark.parametrize("src_type", ["pds", "pdse"])
 def test_copy_pdse_to_uss_dir(ansible_zos_module, src_type):
     hosts = ansible_zos_module
@@ -3542,6 +3551,7 @@ def test_copy_pdse_to_uss_dir(ansible_zos_module, src_type):
 
 @pytest.mark.uss
 @pytest.mark.pdse
+@pytest.mark.aliases
 @pytest.mark.parametrize("src_type", ["pds", "pdse"])
 def test_copy_member_to_uss_dir(ansible_zos_module, src_type):
     hosts = ansible_zos_module

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -9,3 +9,5 @@ markers =
     pdse: partitioned data sets test cases.
     vsam: VSAM data sets test cases.
     template: Jinja2 templating test cases.
+    aliases: aliases option test cases.
+    loadlib: executable copy test cases.


### PR DESCRIPTION
##### SUMMARY
Introduces a new option `aliases` in the zos_copy module to preserve aliases when copying executable libraries (MVS or USS) to partitioned data sets.

<!--- Describe the change below, including rationale and design decisions -->

Fixes #423 
see supporting issue #1015 

This also addresses - #621 
##### ISSUE TYPE
- Feature Pull Request
