### PR TITLE
Staging v1.7.0 merge to main (#1019)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -25,7 +25,11 @@ exclude_paths:
   - tests/helpers
   - tests/requirements.txt
   - tests/unit
+  - tests/sanity/ignore-2.9.txt
   - tests/sanity/ignore-2.10.txt
+  - tests/sanity/ignore-2.11.txt
+  - tests/sanity/ignore-2.12.txt
+  - tests/sanity/ignore-2.13.txt
   - venv*
 parseable: true
 quiet: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,38 +5,13 @@ ibm.ibm_zos_core Release Notes
 .. contents:: Topics
 
 
-v1.7.0-beta.2
-=============
+v1.7.0
+======
 
 Release Summary
 ---------------
 
-Release Date: '2023-08-21'
-This changelog describes all changes made to the modules and plugins included
-in this collection. The release date is the date the changelog is created.
-For additional details such as required dependencies and availability review
-the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__
-
-Minor Changes
--------------
-
-- zos_archive - If destination data set space is not provided then the module computes it based on the src list and/or expanded src list based on pattern provided. (https://github.com/ansible-collections/ibm_zos_core/pull/930).
-- zos_archive - When xmit faces a space error in xmit operation because of dest or log data set are filled raises an appropriate error hint. (https://github.com/ansible-collections/ibm_zos_core/pull/930).
-- zos_unarchive - When copying to remote fails now a proper error message is displayed. (https://github.com/ansible-collections/ibm_zos_core/pull/930).
-- zos_unarchive - When copying to remote if space_primary is not defined, then is defaulted to 5M. (https://github.com/ansible-collections/ibm_zos_core/pull/930).
-
-Bugfixes
---------
-
-- zos_archive - Module did not return the proper src state after archiving. Fix now displays the status of the src after the operation. (https://github.com/ansible-collections/ibm_zos_core/pull/930).
-
-v1.7.0-beta.1
-=============
-
-Release Summary
----------------
-
-Release Date: '2023-07-26'
+Release Date: '2023-10-09'
 This changelog describes all changes made to the modules and plugins included
 in this collection. The release date is the date the changelog is created.
 For additional details such as required dependencies and availability review
@@ -51,6 +26,8 @@ Minor Changes
 -------------
 
 - Add support for Jinja2 templates in zos_copy and zos_job_submit when using local source files. (https://github.com/ansible-collections/ibm_zos_core/pull/667)
+- zos_archive - If destination data set space is not provided then the module computes it based on the src list and/or expanded src list based on pattern provided. (https://github.com/ansible-collections/ibm_zos_core/pull/930).
+- zos_archive - When xmit faces a space error in xmit operation because of dest or log data set are filled raises an appropriate error hint. (https://github.com/ansible-collections/ibm_zos_core/pull/930).
 - zos_copy - Adds block_size, record_format, record_length, space_primary, space_secondary, space_type and type in the return output when the destination data set does not exist and has to be created by the module. (https://github.com/ansible-collections/ibm_zos_core/pull/773)
 - zos_data_set - record format = 'F' has been added to support 'fixed' block records. This allows records that can use the entire block. (https://github.com/ansible-collections/ibm_zos_core/pull/821)
 - zos_job_output - zoau added 'program_name' to their field output starting with v1.2.4.  This enhancement checks for that version and passes the extra column through. (https://github.com/ansible-collections/ibm_zos_core/pull/841)
@@ -58,11 +35,14 @@ Minor Changes
 - zos_job_query - unnecessary calls were made to find a jobs DDs that incurred unnecessary overhead. This change removes those resulting in a performance increase in job related queries. (https://github.com/ansible-collections/ibm_zos_core/pull/911)
 - zos_job_query - zoau added 'program_name' to their field output starting with v1.2.4.  This enhancement checks for that version and passes the extra column through. (https://github.com/ansible-collections/ibm_zos_core/pull/841)
 - zos_job_submit - zoau added 'program_name' to their field output starting with v1.2.4.  This enhancement checks for that version and passes the extra column through. (https://github.com/ansible-collections/ibm_zos_core/pull/841)
+- zos_unarchive - When copying to remote fails now a proper error message is displayed. (https://github.com/ansible-collections/ibm_zos_core/pull/930).
+- zos_unarchive - When copying to remote if space_primary is not defined, then is defaulted to 5M. (https://github.com/ansible-collections/ibm_zos_core/pull/930).
 
 Bugfixes
 --------
 
 - module_utils - data_set.py - Reported a failure caused when cataloging a VSAM data set. Fix now corrects how VSAM data sets are cataloged. (https://github.com/ansible-collections/ibm_zos_core/pull/791).
+- zos_archive - Module did not return the proper src state after archiving. Fix now displays the status of the src after the operation. (https://github.com/ansible-collections/ibm_zos_core/pull/930).
 - zos_blockinfile - Test case generate a data set that was not correctly removed. Changes delete the correct data set not only member. (https://github.com/ansible-collections/ibm_zos_core/pull/840)
 - zos_copy - Module returned the dynamic values created with the same dataset type and record format. Fix validate the correct dataset type and record format of target created. (https://github.com/ansible-collections/ibm_zos_core/pull/824)
 - zos_copy - Reported a false positive such that the response would have `changed=true` when copying from a source (src) or destination (dest) data set that was in use (DISP=SHR). This change now displays an appropriate error message and returns `changed=false`. (https://github.com/ansible-collections/ibm_zos_core/pull/794).

--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ and ansible-doc to automate tasks on z/OS.
 
 Ansible version compatibility
 =============================
-This collection has been tested against **Ansible** and **Ansible Core** versions >=2.9,<2.16.
-The Ansible and Ansible Core versions supported for this collection align to the
+This collection has been tested against **Ansible Core** versions >=2.14.
+The Ansible Core versions supported for this collection align to the
 [ansible-core support matrix](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix). Review the
 [Ansible community changelogs](https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-community-changelogs) for corresponding **Ansible community packages**
 and **ansible-core**.
 
 For **Ansible Automation Platform** (AAP) users, review the
-[Ansible Automation Platform Certified Content](https://access.redhat.com/articles/3642632)
+[Ansible Automation Platform Certified Content](https://access.redhat.com/support/articles/ansible-automation-platform-certified-content)
 and [AAP Life Cycle](https://access.redhat.com/support/policy/updates/ansible-automation-platform)
 for more more information on supported versions of Ansible.
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -126,4 +126,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 1.7.0-beta.2
+version: 1.7.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -875,6 +875,20 @@ releases:
       name: zos_volume_init
       namespace: ''
     release_date: '2023-04-26'
+  1.7.0:
+    changes:
+      release_summary: 'Release Date: ''2023-10-09''
+
+        This changelog describes all changes made to the modules and plugins included
+
+        in this collection. The release date is the date the changelog is created.
+
+        For additional details such as required dependencies and availability review
+
+        the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__'
+    fragments:
+    - v1.7.0_summary.yml
+    release_date: '2023-10-09'
   1.7.0-beta.1:
     changes:
       bugfixes:

--- a/docs/source/modules/zos_gather_facts.rst
+++ b/docs/source/modules/zos_gather_facts.rst
@@ -22,11 +22,6 @@ Synopsis
 - Note, the module will fail fast if any unsupported options are provided. This is done to raise awareness of a failure in an automation setting.
 
 
-Requirements
-------------
-
-- ZOAU 1.2.1 or later.
-
 
 
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,47 +6,14 @@
 Releases
 ========
 
-Version 1.7.0-beta.2
-====================
-
-Minor Changes
--------------
-- ``zos_archive``
-
-      - When xmit faces a space error in xmit operation because of dest or log data set being filled raises an appropriate error hint.
-      - If destination data set space is not provided then the module computes it based on the src list and/or expanded src list based on pattern provided.
-
-- ``zos_unarchive``
-
-      - When copying to remote fails now a proper error message is displayed.
-      - When copying to remote if space_primary is not defined, then is defaulted to 5M.
-
-Bugfixes
---------
-- ``zos_archive`` - Module did not return the proper src state after archiving. Fix now displays the status of the src after the operation.
-
-Availability
-------------
-
-* `Galaxy`_
-* `GitHub`_
-
-Reference
----------
-
-* Supported by `z/OS V2R3`_ or later
-* Supported by the `z/OS® shell`_
-* Supported by `IBM Open Enterprise SDK for Python`_ `3.9`_ - `3.11`_
-* Supported by IBM `Z Open Automation Utilities 1.2.3`_ (or later) but prior to version 1.3.
-
-Version 1.7.0-beta.1
-====================
+Version 1.7.0
+=============
 
 New Modules
 -----------
 
-- ``zos_archive`` -  archive files, data sets and extend archives on z/OS. Formats include, *bz2*, *gz*, *tar*, *zip*, *terse*, *xmit* and *pax*.
-- ``zos_unarchive`` - unarchive files and data sets in z/OS. Formats include, *bz2*, *gz*, *tar*, *zip*, *terse*, *xmit* and *pax*.
+- ``zos_archive`` - archive files, data sets and extend archives on z/OS. Formats include, *bz2*, *gz*, *tar*, *zip*, *terse*, *xmit* and *pax*.
+- ``zos_unarchive`` - unarchive files and data sets on z/OS. Formats include, *bz2*, *gz*, *tar*, *zip*, *terse*, *xmit* and *pax*.
 
 Major Changes
 -------------
@@ -60,36 +27,48 @@ Minor Changes
       - displays the data set attributes when the destination does not exist and was created by the module.
       - reverts the logic that would automatically create backups in the event of a module failure leaving it up to the user to decide if a backup is needed.
 - ``zos_data_set`` - supports record format *F* (fixed) where one physical block on disk is one logical record and all the blocks and records are the same size.
-- ``zos_job_output`` - displays job information *asid*, *creation date*, *creation time*, *job class*, *priority*, *queue position*, *service class* and conditionally *program name* (when ZOAU is v 1.2.4 or later).
+- ``zos_job_output`` - displays job information *asid*, *creation date*, *creation time*, *job class*, *priority*, *queue position*, *service class* and conditionally *program name* (when ZOAU is v1.2.4 or later).
 - ``zos_job_query``
+
       - displays job information *asid*, *creation date*, *creation time*, *job class*, *priority*, *queue position*, *service class* and conditionally *program name* (when ZOAU is v 1.2.4 or later).
       - removes unnecessary queries to find DDs improving the modules performance.
-- ``zos_job_submit`` - displays job information *asid*, *creation date*, *creation time*, *job class*, *priority*, *queue position*, *service class* and conditionally *program name* (when ZOAU is v 1.2.4 or later).
+- ``zos_job_submit`` - displays job information *asid*, *creation date*, *creation time*, *job class*, *priority*, *queue position*, *service class* and conditionally *program name* (when ZOAU is v1.2.4 or later).
+- ``zos_archive``
+
+      - When XMIT encounters a space error because of the destination (dest) or log data set has reached capacity, the module raises an appropriate error message.
+      - When the destination (dest) data set space is not provided, then the module computes it using the source (src) given the pattern provided.
+
+- ``zos_unarchive``
+
+      - When copying to the z/OS managed node (remote_src) results in a failure, a proper error message is displayed
+      - When copying to the z/OS managed node (remote_src), if the option *primary_space* is not defined, then it is defaulted to 5M.
 
 Bugfixes
 --------
-- ``zos_data_set`` - fixes occasionally occurring orphaned VSAM cluster components such as INDEX when `present=absent`.
-- ``zos_fetch`` - fixes the warning that appeared about the use of _play_context.verbosity.
+- ``zos_data_set`` - fixes occasionally occurring orphaned VSAM cluster components such as INDEX when *present=absent*.
+- ``zos_fetch`` - fixes the warning that appeared about the use of *_play_context.verbosity*.
 - ``zos_copy``
 
-      - fixes the warning that appeared about the use of _play_context.verbosity.
+      - fixes the warning that appeared about the use of *_play_context.verbosity*.
       - fixes an issue where subdirectories would not be encoded.
       - fixes an issue where when mode was set, the mode was not applied to existing directories and files.
-      - displays a error message when copying into a data set that is being accessed by another process and no longer returns with `changed=true`.
+      - displays a error message when copying into a data set that is being accessed by another process and no longer returns with *changed=true*.
 
-``zos_job_output`` - displays an appropriate error message for a job is not found in the spool.
-``zos_operator`` - fixes the false reports that a command failed when keywords such as *error* were seen, the module now acts as a passthrough.
+- ``zos_job_output`` - displays an appropriate error message for a job is not found in the spool.
+- ``zos_operator`` - fixes the false reports that a command failed when keywords such as *error* were seen, the module now acts as a passthrough.
+- ``zos_archive`` - Module did not return the proper src state after archiving. Fix now displays the status of the src after the operation.
 
 Availability
 ------------
 
+* `Automation Hub`_
 * `Galaxy`_
 * `GitHub`_
 
 Reference
 ---------
 
-* Supported by `z/OS V2R3`_ or later
+* Supported by `z/OS®`_ V2R4 or later
 * Supported by the `z/OS® shell`_
 * Supported by `IBM Open Enterprise SDK for Python`_ `3.9`_ - `3.11`_
 * Supported by IBM `Z Open Automation Utilities 1.2.3`_ (or later) but prior to version 1.3.
@@ -152,7 +131,7 @@ Availability
 Reference
 ---------
 
-* Supported by `z/OS V2R3`_ or later
+* Supported by `z/OS®`_ V2R4 or later
 * Supported by the `z/OS® shell`_
 * Supported by `IBM Open Enterprise SDK for Python`_ `3.9`_ - `3.11`_
 * Supported by IBM `Z Open Automation Utilities 1.2.2`_ (or later) but prior to version 1.3.
@@ -268,7 +247,7 @@ Availability
 Reference
 ---------
 
-* Supported by `z/OS Version`_ V2R4 or later
+* Supported by `z/OS®`_ V2R4 or later
 * Supported by the `z/OS® shell`_
 * Supported by `IBM Open Enterprise SDK for Python`_ `3.9`_ - `3.11`_
 * Supported by IBM `Z Open Automation Utilities 1.2.2`_ (or later) but prior to version 1.3.
@@ -307,7 +286,7 @@ Availability
 Reference
 ---------
 
-* Supported by `z/OS V2R3`_ or later
+* Supported by `z/OS®`_ V2R4 or later
 * Supported by the `z/OS® shell`_
 * Supported by `IBM Open Enterprise SDK for Python`_ `3.9`_
 * Supported by IBM `Z Open Automation Utilities 1.1.0`_ and
@@ -457,7 +436,7 @@ Availability
 Reference
 ---------
 
-* Supported by `z/OS V2R3`_ or later
+* Supported by `z/OS®`_ V2R4 or later
 * Supported by the `z/OS® shell`_
 * Supported by `IBM Open Enterprise SDK for Python`_ `3.8`_` - `3.9`_
 * Supported by IBM `Z Open Automation Utilities 1.1.0`_ and
@@ -558,7 +537,7 @@ Availability
 Reference
 ---------
 
-* Supported by `z/OS V2R3`_ or later
+* Supported by `z/OS®`_ V2R4 or later
 * Supported by the `z/OS® shell`_
 * Supported by `IBM Open Enterprise SDK for Python`_ v3.8.2 -
   `IBM Open Enterprise SDK for Python`_ v3.9.5
@@ -599,7 +578,7 @@ Availability
 Reference
 ---------
 
-* Supported by `z/OS V2R3`_ or later
+* Supported by `z/OS®`_ V2R4 or later
 * Supported by the `z/OS® shell`_
 * Supported by `IBM Open Enterprise SDK for Python`_ 3.8.2 or later
 * Supported by IBM `Z Open Automation Utilities 1.1.0`_ and
@@ -645,7 +624,7 @@ Availability
 Reference
 ---------
 
-* Supported by `z/OS V2R3`_ or later
+* Supported by `z/OS®`_ V2R4 or later
 * Supported by the `z/OS® shell`_
 * Supported by `IBM Open Enterprise SDK for Python`_ 3.8.2 or later
 * Supported by IBM `Z Open Automation Utilities 1.1.0`_ and
@@ -677,7 +656,7 @@ Availability
 Reference
 ---------
 
-* Supported by `z/OS V2R3`_ or later
+* Supported by `z/OS®`_ V2R4 or later
 * Supported by the `z/OS® shell`_
 * Supported by `IBM Open Enterprise SDK for Python`_ 3.8.2 or later
 * Supported by IBM `Z Open Automation Utilities 1.1.0`_ and
@@ -800,7 +779,7 @@ Availability
 Reference
 ---------
 
-* Supported by `z/OS V2R3`_ or later
+* Supported by `z/OS®`_ V2R4 or later
 * Supported by the `z/OS® shell`_
 * Supported by `IBM Open Enterprise SDK for Python`_ 3.8.2 or later
 * Supported by IBM `Z Open Automation Utilities 1.1.0`_ and
@@ -821,115 +800,6 @@ Known issues
     #. ``zos_mvs_raw`` module execution fails when invoking DFSRRC00 with parm
        "UPB,PRECOMP", "UPB, POSTCOMP" or "UPB,PRECOMP,POSTCOMP". This issue is
        addressed by APAR PH28089.
-
-Version 1.2.1
-=============
-
-Notes
------
-
-* Update required
-* Module changes
-
-  * Noteworthy Python 2.x support
-
-    * encode - removed TemporaryDirectory usage.
-    * zos_copy - fixed regex support, dictionary merge operation fix
-    * zos_fetch - fix quote import
-
-* Collection changes
-
-  * Beginning this release, all sample playbooks previously included with the
-    collection will be made available on the `samples repository`_. The
-    `samples repository`_ explains the playbook concepts,
-    discusses z/OS administration, provides links to the samples support site,
-    blogs and other community resources.
-
-* Documentation changes
-
-  * In this release, documentation related to playbook configuration has been
-    migrated to the `samples repository`_. Each sample contains a README that
-    explains what configurations must be made to run the sample playbook.
-
-.. _samples repository:
-   https://github.com/IBM/z_ansible_collections_samples/blob/main/README.md
-
-Availability
-------------
-
-* `Automation Hub`_
-* `Galaxy`_
-* `GitHub`_
-
-Reference
----------
-
-* Supported by IBM Open Enterprise Python for z/OS: 3.8.2 or later
-* Supported by IBM Z Open Automation Utilities 1.0.3 PTF UI70435
-* Supported by z/OS V2R3 or later
-* The z/OS® shell
-
-Version 1.1.0
-=============
-
-Notes
------
-* Update recommended
-* New modules
-
-  * zos_fetch
-  * zos_encode
-  * zos_operator_action_query
-  * zos_operator
-  * zos_tso_command
-  * zos_ping
-
-* New filter
-* Improved error handling and messages
-* Bug fixes
-* Documentation updates
-* New samples
-
-Availability
-------------
-
-* `Automation Hub`_
-* `Galaxy`_
-* `GitHub`_
-
-Reference
----------
-
-* Supported by IBM Open Enterprise Python for z/OS: 3.8.2 or later
-* Supported by IBM Z Open Automation Utilities: 1.0.3 PTF UI70435
-* Supported by z/OS V2R3
-* The z/OS® shell
-
-
-Version 1.0.0
-=============
-
-Notes
------
-
-* Update recommended
-* Security vulnerabilities fixed
-* Improved test, security and injection coverage
-* Module zos_data_set catalog support added
-* Documentation updates
-
-Availability
-------------
-
-* `Automation Hub`_
-* `Galaxy`_
-* `GitHub`_
-
-Reference
----------
-
-* Supported by IBM Z Open Automation Utilities: 1.0.1 PTF UI66957 through
-  1.0.3 PTF UI70435
 
 .. .............................................................................
 .. Global Links
@@ -960,8 +830,12 @@ Reference
    https://www.ibm.com/docs/en/zoau/1.2.x
 .. _z/OS® shell:
    https://www.ibm.com/support/knowledgecenter/en/SSLTBW_2.4.0/com.ibm.zos.v2r4.bpxa400/part1.htm
+.. _z/OS®:
+   https://www.ibm.com/docs/en/zos
 .. _z/OS V2R3:
    https://www.ibm.com/support/knowledgecenter/SSLTBW_2.3.0/com.ibm.zos.v2r3/en/homepage.html
+.. _z/OS V2R4:
+   https://www.ibm.com/docs/en/zos/2.4.0
 .. _z/OS Version:
    https://www.ibm.com/docs/en/zos
 .. _FAQs:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: ibm
 name: ibm_zos_core
 
 # The collection version
-version: 1.7.0-beta.2
+version: 1.7.0
 
 # Collection README file
 readme: README.md
@@ -91,5 +91,9 @@ build_ignore:
   - tests/helpers
   - tests/requirements.txt
   - tests/unit
+  - tests/sanity/ignore-2.9.txt
   - tests/sanity/ignore-2.10.txt
+  - tests/sanity/ignore-2.11.txt
+  - tests/sanity/ignore-2.12.txt
+  - tests/sanity/ignore-2.13.txt
   - venv*

--- a/meta/ibm_zos_core_meta.yml
+++ b/meta/ibm_zos_core_meta.yml
@@ -1,5 +1,5 @@
 name: ibm_zos_core
-version: "1.7.0-beta.2"
+version: "1.7.0"
 managed_requirements:
     -
         name: "IBM Open Enterprise SDK for Python"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.9.0'
+requires_ansible: '>=2.14.0'

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2019, 2020, 2021, 2022
+# Copyright (c) IBM Corporation 2019-2023
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020, 2022
+# Copyright (c) IBM Corporation 2020, 2022, 2023
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_encode.py
+++ b/plugins/modules/zos_encode.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020, 2022
+# Copyright (c) IBM Corporation 2019, 2020, 2022, 2023
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/modules/zos_gather_facts.py
+++ b/plugins/modules/zos_gather_facts.py
@@ -23,8 +23,6 @@ DOCUMENTATION = r"""
 module: zos_gather_facts
 short_description: Gather z/OS system facts.
 version_added: '1.5.0'
-requirements:
-    - ZOAU 1.2.1 or later.
 author:
     - "Ketan Kelkar (@ketankelkar)"
 description:


### PR DESCRIPTION
This merges the meta data changes made in version 1.7.0 (`git cherry-pick  4726116`) for issue #888 
From this PR [here](https://github.com/ansible-collections/ibm_zos_core/commit/4726116eac771a3db633400b2a3fd932a5d652f3) 
We need to have these changes in our `dev` branch will be Q4 1.9.0-beta.1, the metadata changes and doc changes must travel be pushed upstream to `dev`.


* Galaxy 1.7 updates
* Update meta runtime to support ansible-core 2.14 or later
* Update ibm_zos_core_meta.yml with updated version
* Update readme to align to supported ansible versions and new urls
* Added additional sanity ignore files to the exclude list
* Added additional sanity ignore files to the exclude list for ansible-lint.
* Update copyright yrs for source files that were overlooked
* Remove requirements from module doc, rely on offerings minimum requirements, also zoau 1.2.1 never was supported
* Add changelog summary for 1.7
* Adding generated antsibull-changelog release changelog and artifacts
* Remove v1.7.0_summary, its no longer needed
* Update release notes for ac 1.7.0
* Remove unsupported collection versions requiring a version of zoau that is EOS
