### PR TITLE
Added DBRM doc to zos_copy module

### DIFF
--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -192,7 +192,7 @@ options:
       - When I(is_binary=true), no encoding conversion is applied to the content,
         all content transferred retains the original state.
       - Use I(is_binary=true) when copying a Database Request Module (DBRM) to
-        retain the original state of the  serialized SQL statements of a program.
+        retain the original state of the serialized SQL statements of a program.
     type: bool
     default: false
     required: false

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -188,7 +188,11 @@ options:
   is_binary:
     description:
       - If set to C(true), indicates that the file or data set to be copied is a
-        binary file/data set.
+        binary file or data set.
+      - When I(is_binary=true), no encoding conversion is applied to the content,
+        all content transferred retains the original state.
+      - Use I(is_binary=true) when copying a Database Request Module (DBRM) to
+        retain the original state of the  serialized SQL statements of a program.
     type: bool
     default: false
     required: false


### PR DESCRIPTION
This fixes issue #836 which is only a doc change to describe how DBRMs can be supporting with `zos_copy`