### PR TITLE
[v1.9.0] Bugfix/837/missing ZOAU imports

### DIFF
--- a/changelogs/fragments/1042-missing-zoau-imports.yml
+++ b/changelogs/fragments/1042-missing-zoau-imports.yml
@@ -1,0 +1,10 @@
+bugfixes:
+  - zos_job_query - The module handling ZOAU import errors obscured the
+    original traceback when an import error ocurred. Fix now passes correctly
+    the context to the user.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1042).
+
+  - zos_operator - The module handling ZOAU import errors obscured the
+    original traceback when an import error ocurred. Fix now passes correctly
+    the context to the user.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1042).

--- a/plugins/module_utils/import_handler.py
+++ b/plugins/module_utils/import_handler.py
@@ -41,7 +41,7 @@ class ZOAUImportError(object):
     and the moment ANY method gets called, we finally raise an exception.
     """
 
-    def __init__(self, exception_traceback: str):
+    def __init__(self, exception_traceback):
         """When creating a new instance of this class, we save the traceback
         from the original exception so that users have more context when their
         task/code fails. The expected traceback is a string representation of

--- a/plugins/module_utils/import_handler.py
+++ b/plugins/module_utils/import_handler.py
@@ -27,6 +27,48 @@ class MissingZOAUImport(object):
         return method
 
 
+class ZOAUImportError(object):
+    """This class serves as a wrapper for any kind of error when importing
+    ZOAU. Since ZOAU is used by both modules and module_utils, we need a way
+    to alert the user when they're trying to use a function that couldn't be
+    imported properly. If we only had to deal with this in modules, we could
+    just validate that imports worked at the start of their main functions,
+    but on utils, we don't have an entry point where we can validate this.
+    Just raising an exception when trying the import would be better, but that
+    introduces a failure on Ansible sanity tests, so we can't do it.
+
+    Instead, we'll replace what would've been a ZOAU library with this class,
+    and the moment ANY method gets called, we finally raise an exception.
+    """
+
+    def __init__(self, exception_traceback: str):
+        """When creating a new instance of this class, we save the traceback
+        from the original exception so that users have more context when their
+        task/code fails. The expected traceback is a string representation of
+        it, not an actual traceback object. By importing `traceback` from the
+        standard library and calling `traceback.format_exc()` we can
+        get this string.
+        """
+        self.traceback = exception_traceback
+
+    def __getattr__(self, name):
+        """This code is virtually the same from `MissingZOAUImport`. What we
+        do here is hijack all calls to any method from a missing ZOAU library
+        and instead return a method that will alert the user that there was
+        an error while importing ZOAU.
+        """
+        def method(*args, **kwargs):
+            raise ImportError(
+                (
+                    "ZOAU is not properly configured for Ansible. Unable to import zoautil_py. "
+                    "Ensure environment variables are properly configured in Ansible for use with ZOAU. "
+                    "Complete traceback: {0}".format(self.traceback)
+                )
+            )
+
+        return method
+
+
 class MissingImport(object):
     def __init__(self, import_name=""):
         self.import_name = import_name

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -15,21 +15,30 @@ __metaclass__ = type
 
 import fnmatch
 import re
+import traceback
 from time import sleep
 from timeit import default_timer as timer
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
     BetterArgParser,
 )
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
-    MissingZOAUImport,
+    # MissingZOAUImport,
+    ZOAUImportError
 )
 
 try:
-    from zoautil_py.jobs import read_output, list_dds, listing
+    # For files that import individual functions from a ZOAU module,
+    # we'll replace the imports to instead get the module.
+    # This way, we'll always make a call to the module, allowing us
+    # to properly get the exception we need and avoid the issue
+    # described in #837.
+    # from zoautil_py.jobs import read_output, list_dds, listing
+    from zoautil_py import jobs
 except Exception:
-    read_output = MissingZOAUImport()
-    list_dds = MissingZOAUImport()
-    listing = MissingZOAUImport()
+    # read_output = MissingZOAUImport()
+    # list_dds = MissingZOAUImport()
+    # listing = MissingZOAUImport()
+    jobs = ZOAUImportError(traceback.format_exc())
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     zoau_version_checker
@@ -203,7 +212,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
 
     # jls output: owner=job[0], name=job[1], id=job[2], status=job[3], rc=job[4]
     # e.g.: OMVSADM  HELLO    JOB00126 JCLERR   ?
-    # listing(job_id, owner) in 1.2.0 has owner param, 1.1 does not
+    # jobs.listing(job_id, owner) in 1.2.0 has owner param, 1.1 does not
     # jls output has expanded in zoau 1.2.3 and later: jls -l -v shows headers
     # jobclass=job[5] serviceclass=job[6] priority=job[7] asid=job[8]
     # creationdatetime=job[9] queueposition=job[10]
@@ -216,13 +225,13 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
     kwargs = {
         "job_id": job_id_temp,
     }
-    entries = listing(**kwargs)
+    entries = jobs.listing(**kwargs)
 
     while ((entries is None or len(entries) == 0) and duration <= timeout):
         current_time = timer()
         duration = round(current_time - start_time)
         sleep(1)
-        entries = listing(**kwargs)
+        entries = jobs.listing(**kwargs)
 
     if entries:
         for entry in entries:
@@ -274,12 +283,12 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
             job["duration"] = duration
 
             if dd_scan:
-                list_of_dds = list_dds(entry.id)
+                list_of_dds = jobs.list_dds(entry.id)
                 while ((list_of_dds is None or len(list_of_dds) == 0) and duration <= timeout):
                     current_time = timer()
                     duration = round(current_time - start_time)
                     sleep(1)
-                    list_of_dds = list_dds(entry.id)
+                    list_of_dds = jobs.list_dds(entry.id)
 
                 job["duration"] = duration
 
@@ -324,7 +333,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
                     tmpcont = None
                     if "stepname" in single_dd:
                         if "dataset" in single_dd:
-                            tmpcont = read_output(
+                            tmpcont = jobs.read_output(
                                 entry.id, single_dd["stepname"], single_dd["dataset"])
 
                     dd["content"] = tmpcont.split("\n")

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -260,6 +260,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import (
 )
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
 import re
 
 
@@ -287,7 +288,7 @@ def run_module():
             jobs = None
 
     except Exception as e:
-        module.fail_json(msg=e, **result)
+        module.fail_json(msg=to_text(e), **result)
     result["jobs"] = jobs
     module.exit_json(**result)
 

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -144,14 +144,17 @@ changed:
     sample: true
 """
 
+import traceback
 from timeit import default_timer as timer
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
     AnsibleModuleHelper,
 )
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
-    MissingZOAUImport,
+    # MissingZOAUImport,
+    ZOAUImportError
 )
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser import (
@@ -161,7 +164,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser
 try:
     from zoautil_py import opercmd
 except Exception:
-    opercmd = MissingZOAUImport()
+    opercmd = ZOAUImportError(traceback.format_exc())
 
 try:
     from zoautil_py import ZOAU_API_VERSION
@@ -241,10 +244,10 @@ def run_module():
                              stderr_lines=str(error).splitlines() if error is not None else result["content"],
                              changed=result["changed"],)
     except Error as e:
-        module.fail_json(msg=repr(e), **result)
+        module.fail_json(msg=to_text(e), **result)
     except Exception as e:
         module.fail_json(
-            msg="An unexpected error occurred: {0}".format(repr(e)), **result
+            msg="An unexpected error occurred: {0}".format(to_text(e)), **result
         )
 
     module.exit_json(**result)

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -194,7 +194,7 @@ def run_module():
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
 
     # Checking that we can actually use ZOAU.
-    if type(opercmd) == ZOAUImportError:
+    if isinstance(opercmd, ZOAUImportError):
         module.fail_json(msg="An error ocurred while importing ZOAU: {0}".format(opercmd.traceback))
 
     try:

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -193,6 +193,10 @@ def run_module():
     result = dict(changed=False)
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
 
+    # Checking that we can actually use ZOAU.
+    if type(opercmd) == ZOAUImportError:
+        module.fail_json(msg="An error ocurred while importing ZOAU: {0}".format(opercmd.traceback))
+
     try:
         new_params = parse_params(module.params)
         rc_message = run_operator_command(new_params)


### PR DESCRIPTION
##### SUMMARY
Proposal for a solution for #837.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
- zos_operator
- zos_job_query
- module_utils/job.py

##### ADDITIONAL INFORMATION
To bubble up import errors from ZOAU, we'll still use the idea behind `MissingZOAUImport` but change around a few things to avoid losing important context when an import fails. For now it's just for zos_operator and zos_job_query/job.py, to showcase the two types of changes we'll need to do:
- Changes in module_utils where we always import at a module level instead of individual functions, and making sure modules use `to_text` to properly render the exception in the return JSON.
- Changes in modules where we do a check early on to catch import failures.