### PR TITLE
Bugfix/1030/uss local unarchive

### DIFF
--- a/plugins/action/zos_unarchive.py
+++ b/plugins/action/zos_unarchive.py
@@ -61,8 +61,6 @@ class ActionModule(ActionBase):
             format_name = format.get("name")
             copy_module_args = dict()
             dest_data_set = format.get("dest_data_set")
-            if dest_data_set is None:
-                dest_data_set = dict()
             dest = ""
             if source.startswith('~'):
                 source = os.path.expanduser(source)
@@ -73,6 +71,8 @@ class ActionModule(ActionBase):
                     module_name="tempfile", module_args={}, task_vars=task_vars,
                 ).get("path")
             elif format_name in MVS_SUPPORTED_FORMATS:
+                if dest_data_set is None:
+                    dest_data_set = dict()
                 tmp_hlq = module_args.get("tmp_hlq") if module_args.get("tmp_hlq") is not None else ""
                 cmd_res = self._execute_module(
                     module_name="command",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sending a tar, gz, zip bz2 or pax into the remote without specifying dest_data_set attributes fails. Fix now sets dest_data_set to None after 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1030 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_unarchive 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
