### PR TITLE
[Enabler] [zos_mvs_raw] Remove Try, Except, Pass from code

### DIFF
--- a/changelogs/fragments/1051-try-except-pass-zos_mvs_raw.yml
+++ b/changelogs/fragments/1051-try-except-pass-zos_mvs_raw.yml
@@ -1,0 +1,4 @@
+trivial:
+  - zos_mvs_raw - Removed Try, Except, Pass from the code, try block is in place to ignore any errors,
+    pass statement was changed to a variable assignment. This does not change any behavior.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1051).

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2766,7 +2766,8 @@ def data_set_exists(name, volumes=None):
         present, changed = DataSet.attempt_catalog_if_necessary(name, volumes)
         exists = present
     except Exception:
-        pass
+        # Failure locating or cataloging the data set. Go ahead assumming it does not exist.
+        exists = False
     return exists
 
 

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2767,6 +2767,7 @@ def data_set_exists(name, volumes=None):
         exists = present
     except Exception:
         # Failure locating or cataloging the data set. Go ahead assumming it does not exist.
+        # exists = False to avoid using pass clause which results in bandit warning.
         exists = False
     return exists
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently Bandit marks Try, Except, Pass as a warning, since is not a security issue but rather a behavior that might ignore wrong doings.
In this case, we know the code is only used to find a data set and catalog, this action can throw an exception if a data set name is not valid (not really bc we validate it) and if there is an error cataloging that data set. If there is an error cataloging we just forget about that data set assuming it doesn't exist and create a new cataloged one.

This PR does not change any behavior.

Added details of the code to changelog, since is a trivial change it will not be included in the release notes so no final user will see this.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #877 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enhancement Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_mvs_raw

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
