### PR TITLE
[Enabler] [module_utils/dd_statement.py] Changed try except pass to except specific DatasetDeleteError exception

### DIFF
--- a/changelogs/fragments/1052-try-except-pass-dd-statement.yml
+++ b/changelogs/fragments/1052-try-except-pass-dd-statement.yml
@@ -1,0 +1,5 @@
+trivial:
+  - zos_mvs_raw - Removed Try, Except, Pass from the code, instead catching DatasetDeleteError
+    and pass only in that case, any other exception will be raised.
+    This does not change any behavior.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1052).

--- a/changelogs/fragments/1052-try-except-pass-dd-statement.yml
+++ b/changelogs/fragments/1052-try-except-pass-dd-statement.yml
@@ -1,5 +1,4 @@
 trivial:
   - zos_mvs_raw - Removed Try, Except, Pass from the code, instead catching DatasetDeleteError
     and pass only in that case, any other exception will be raised.
-    This does not change any behavior.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1052).

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2020
+# Copyright (c) IBM Corporation 2020, 2023
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -661,7 +661,7 @@ class VIODefinition(DataDefinition):
         """
         try:
             DataSet.delete(self.name)
-        except Exception:
+        except DataSet.DatasetDeleteError:
             pass
 
     def _build_arg_string(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently Bandit marks Try, Except, Pass as a warning, since is not a security issue but rather a behavior that might ignore wrong doings.

This change instead catches any data set deletion error and passes, but raises any other potential issue.

Added details of the code to changelog, since is a trivial change it will not be included in the release notes so no final user will see this.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #876 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enhancement Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/dd_statement.py used also by zos_mvs_raw.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
