### PR TITLE
[v1.8.0][Backport] Clean temporary data sets created during XMIT unarchive operation

### DIFF
--- a/changelogs/fragments/1049-xmit-temporary-data-sets.yml
+++ b/changelogs/fragments/1049-xmit-temporary-data-sets.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zos_unarchive - When zos_unarchive fails during unpack either with xmit or terse it does not clean the
+    temporary data sets created. Fix now removes the temporary data sets.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1049).

--- a/changelogs/fragments/1049-xmit-temporary-data-sets.yml
+++ b/changelogs/fragments/1049-xmit-temporary-data-sets.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - zos_unarchive - When zos_unarchive fails during unpack either with xmit or terse it does not clean the
     temporary data sets created. Fix now removes the temporary data sets.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1049).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1054).

--- a/plugins/modules/zos_unarchive.py
+++ b/plugins/modules/zos_unarchive.py
@@ -853,7 +853,8 @@ class AMATerseUnarchive(MVSUnarchive):
         dds = {'args': 'UNPACK', 'sysut1': src, 'sysut2': dest}
         rc, out, err = mvs_cmd.amaterse(cmd="", dds=dds)
         if rc != 0:
-            self.clean_environment(data_sets=[dest], uss_files=[], remove_targets=True)
+            ds_remove_list = [dest, src] if not self.remote_src else [dest]
+            self.clean_environment(data_sets=ds_remove_list, uss_files=[], remove_targets=True)
             self.module.fail_json(
                 msg="Failed executing AMATERSE to restore {0} into {1}".format(src, dest),
                 stdout=out,
@@ -881,6 +882,8 @@ class XMITUnarchive(MVSUnarchive):
         """.format(src, dest)
         rc, out, err = mvs_cmd.ikjeft01(cmd=unpack_cmd, authorized=True)
         if rc != 0:
+            ds_remove_list = [dest, src] if not self.remote_src else [dest]
+            self.clean_environment(data_sets=ds_remove_list, uss_files=[], remove_targets=True)
             self.module.fail_json(
                 msg="Failed executing RECEIVE to restore {0} into {1}".format(src, dest),
                 stdout=out,


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is a method that cleans the environment when unpack action fails on remote with mvs commands, currently when remote_src is False temporary data set was not removed, changed that behavior to ensure it happens when mvs formats unpack fails.

Since this is a cleanup of temporary data set I thought about creating test cases, but it can fail in multiple steps, I do have a playbook which you can use to test the behavior but let me know If you think is necessary to create a test case for it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
THIS IS A BACKPORT FOR V1.8.0 AND THIS WAS MERGED TO DEV IN PR #1049. FIXES #1047 FOR V1.8.0

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_unarchive
