### PR TITLE
Removed run command  use of subprocess from encode defaults infavor of using AnsibleModule run command

### DIFF
--- a/changelogs/fragments/1055-remove-subprocess-encode.yml
+++ b/changelogs/fragments/1055-remove-subprocess-encode.yml
@@ -1,0 +1,4 @@
+trivial:
+  - encode_utils - Removed use of subprocess from system utils, since the only
+    use of it could be replaced for AnsibleModule runcommand method.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1055).

--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -62,7 +62,8 @@ class Defaults:
         """
         system_charset = locale.getdefaultlocale()[1]
         if system_charset is None:
-            rc, out, err = system.run_command("locale -c charmap")
+            module = AnsibleModuleHelper(argument_spec={})
+            rc, out, err = module.run_command("locale -c charmap")
             if rc != 0 or not out or err:
                 if system.is_zos():
                     system_charset = Defaults.DEFAULT_EBCDIC_USS_CHARSET

--- a/plugins/module_utils/system.py
+++ b/plugins/module_utils/system.py
@@ -15,7 +15,7 @@ __metaclass__ = type
 from platform import platform
 from os import name as OS_NAME
 from sys import platform as SYS_PLATFORM
-from subprocess import Popen, PIPE
+# from subprocess import Popen, PIPE
 from ansible.module_utils.six import binary_type, text_type, PY2, PY3
 # from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.common.text.converters import to_bytes, to_text
@@ -76,53 +76,53 @@ def is_zos():
     return is_zos_unix and SYS_PLATFORM == "zos"
 
 
-def run_command(args, stdin=None, **kwargs):
-    """ Execute a shell command on the current system. This function should only
-    be used when AnsibleModule.run_command() is not available. This function
-    essentially serves as a wrapper for Python subprocess.Popen and supports all
-    of the arguments supported by Popen.
+# def run_command(args, stdin=None, **kwargs):
+#     """ Execute a shell command on the current system. This function should only
+#     be used when AnsibleModule.run_command() is not available. This function
+#     essentially serves as a wrapper for Python subprocess.Popen and supports all
+#     of the arguments supported by Popen.
 
-    Required arguments:
-        args: args should be a sequence of program arguments or else a single
-        string or path-like object. By default, the program to execute is the
-        first item in args if args is a sequence. It is recommended to pass
-        args as a sequence.
+#     Required arguments:
+#         args: args should be a sequence of program arguments or else a single
+#         string or path-like object. By default, the program to execute is the
+#         first item in args if args is a sequence. It is recommended to pass
+#         args as a sequence.
 
-        Refer to the following link for a more detailed description of this
-        parameter and other parameters.
-        https://docs.python.org/3/library/subprocess.html#subprocess.Popen
+#         Refer to the following link for a more detailed description of this
+#         parameter and other parameters.
+#         https://docs.python.org/3/library/subprocess.html#subprocess.Popen
 
-    Returns:
-        tuple[int, str, str]: The return code, stdout and stderr produced after
-        executing the command.
-    """
-    rc = out = err = None
-    if not isinstance(args, (list, binary_type, text_type)):
-        rc = -1
-        err = "'args' must be list or string"
-        return rc, out, err
+#     Returns:
+#         tuple[int, str, str]: The return code, stdout and stderr produced after
+#         executing the command.
+#     """
+#     rc = out = err = None
+#     if not isinstance(args, (list, binary_type, text_type)):
+#         rc = -1
+#         err = "'args' must be list or string"
+#         return rc, out, err
 
-    if isinstance(args, (text_type, str)):
-        if PY2:
-            args = to_bytes(args, errors='surrogate_or_strict')
-        elif PY3:
-            args = to_text(args, errors='surrogateescape')
-        args = split(args)
+#     if isinstance(args, (text_type, str)):
+#         if PY2:
+#             args = to_bytes(args, errors='surrogate_or_strict')
+#         elif PY3:
+#             args = to_text(args, errors='surrogateescape')
+#         args = split(args)
 
-    kwargs.update(
-        dict(
-            stdin=PIPE if stdin else None,
-            stderr=PIPE,
-            stdout=PIPE
-        )
-    )
-    try:
-        cmd = Popen(args, **kwargs)
-    except TypeError as proc_err:
-        rc = -1
-        err = str(proc_err)
-        return rc, out, err
+#     kwargs.update(
+#         dict(
+#             stdin=PIPE if stdin else None,
+#             stderr=PIPE,
+#             stdout=PIPE
+#         )
+#     )
+#     try:
+#         cmd = Popen(args, **kwargs)
+#     except TypeError as proc_err:
+#         rc = -1
+#         err = str(proc_err)
+#         return rc, out, err
 
-    out, err = tuple(map(to_text, cmd.communicate()))
-    rc = cmd.returncode
-    return rc, out, err
+#     out, err = tuple(map(to_text, cmd.communicate()))
+#     rc = cmd.returncode
+#     return rc, out, err


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removed use of subprocess from system utils, since the only use of it could be replaced for AnsibleModule run_command method. Removing the use of subprocess from our workflow avoids us having to explain the need to open a subprocess and rather filter the command through ansible own dedicated method (AnsibleModule.run_command). That way we are reverting back from a change done 3 years ago, when it was decided to use our own implementation of subprocess instead of Ansible's, but looking at our modules, we actually use this AnsibleModule wrapper all around and can't think of a reason of why not using it here too.

Also, to avoid future implementations of system.run_command without a solid reason I commented the method's code.

I used a trivial tag as changelog to avoid displaying this to the final user and the change was pretty simple.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


Fixes #873 
Fixes #875 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

module_utils/encode,py (This is used by many modules, all of their test suites were tested.)
