### PR TITLE
Enabler/1024/remote_tmp for zos_script

### DIFF
--- a/changelogs/fragments/1060-remote_tmp_zos_script.yml
+++ b/changelogs/fragments/1060-remote_tmp_zos_script.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - zos_script - add support for remote_tmp from the Ansible
+    configuration to setup where temporary files will be created,
+    replacing the module option tmp_path.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1060).

--- a/docs/source/modules/zos_script.rst
+++ b/docs/source/modules/zos_script.rst
@@ -102,19 +102,6 @@ removes
   | **type**: str
 
 
-tmp_path
-  Directory path in the remote machine where local scripts will be temporarily copied to.
-
-  When not specified, the module will copy local scripts to the default temporary path for the user.
-
-  If ``tmp_path`` does not exist in the remote machine, the module will not create it.
-
-  All scripts copied to ``tmp_path`` will be removed from the managed node before the module finishes executing.
-
-  | **required**: False
-  | **type**: str
-
-
 use_template
   Whether the module should treat ``src`` as a Jinja2 template and render it before continuing with the rest of the module.
 
@@ -264,12 +251,6 @@ Examples
        remote_src: true
        chdir: /u/user/output_dir
 
-   - name: Run a local Python script that uses a custom tmp_path.
-     zos_script:
-       cmd: ./scripts/program.py
-       executable: /usr/bin/python3
-       tmp_path: /usr/tmp/ibm_zos_core
-
    - name: Run a local script made from a template.
      zos_script:
        cmd: ./templates/PROGRAM
@@ -293,6 +274,10 @@ Notes
 
 .. note::
    When executing local scripts, temporary storage will be used on the remote z/OS system. The size of the temporary storage will correspond to the size of the file being copied.
+
+   The location in the z/OS system where local scripts will be copied to can be configured through Ansible's ``remote_tmp`` option. Refer to `Ansible's documentation <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sh_shell.html#parameter-remote_tmp>`_ for more information.
+
+   All local scripts copied to a remote z/OS system  will be removed from the managed node before the module finishes executing.
 
    Execution permissions for the group assigned to the script will be added to remote scripts. The original permissions for remote scripts will be restored by the module before the task ends.
 

--- a/docs/source/modules/zos_script.rst
+++ b/docs/source/modules/zos_script.rst
@@ -251,6 +251,11 @@ Examples
        remote_src: true
        chdir: /u/user/output_dir
 
+   - name: Run a local Python script in the temporary directory specified in the Ansible environment variable 'remote_tmp'.
+     zos_script:
+       cmd: ./scripts/program.py
+       executable: /usr/bin/python3
+
    - name: Run a local script made from a template.
      zos_script:
        cmd: ./templates/PROGRAM

--- a/plugins/action/zos_script.py
+++ b/plugins/action/zos_script.py
@@ -56,7 +56,9 @@ class ActionModule(ActionBase):
         if not remote_src:
             script_path = path.abspath(path.normpath(script_path))
             script_name = path.basename(script_path)
-            tmp_path = module_args.get('tmp_path')
+            # Accessing the globally-defined temporary directory
+            # that Ansible expects to be used.
+            tmp_path = self._connection._shell._options.get("remote_tmp")
 
             # Getting a temporary path for the script.
             tempfile_args = dict(

--- a/plugins/modules/zos_script.py
+++ b/plugins/modules/zos_script.py
@@ -92,18 +92,6 @@ options:
         script will not be executed.
     type: str
     required: false
-  tmp_path:
-    description:
-      - Directory path in the remote machine where local scripts will be
-        temporarily copied to.
-      - When not specified, the module will copy local scripts to
-        the default temporary path for the user.
-      - If C(tmp_path) does not exist in the remote machine, the
-        module will not create it.
-      - All scripts copied to C(tmp_path) will be removed from the managed
-        node before the module finishes executing.
-    type: str
-    required: false
 
 extends_documentation_fragment:
   - ibm.ibm_zos_core.template
@@ -153,12 +141,6 @@ EXAMPLES = r"""
     cmd: /u/user/scripts/ARGS "1,2"
     remote_src: true
     chdir: /u/user/output_dir
-
-- name: Run a local Python script that uses a custom tmp_path.
-  zos_script:
-    cmd: ./scripts/program.py
-    executable: /usr/bin/python3
-    tmp_path: /usr/tmp/ibm_zos_core
 
 - name: Run a local script made from a template.
   zos_script:
@@ -251,7 +233,6 @@ def run_module():
             executable=dict(type='str', required=False),
             remote_src=dict(type='bool', required=False),
             removes=dict(type='str', required=False),
-            tmp_path=dict(type='str', required=False),
             use_template=dict(type='bool', default=False),
             template_parameters=dict(
                 type='dict',
@@ -287,7 +268,6 @@ def run_module():
         executable=dict(arg_type='path', required=False),
         remote_src=dict(arg_type='bool', required=False),
         removes=dict(arg_type='path', required=False),
-        tmp_path=dict(arg_type='path', required=False),
         use_template=dict(arg_type='bool', required=False),
         template_parameters=dict(
             arg_type='dict',

--- a/plugins/modules/zos_script.py
+++ b/plugins/modules/zos_script.py
@@ -100,6 +100,12 @@ notes:
   - When executing local scripts, temporary storage will be used
     on the remote z/OS system. The size of the temporary storage will
     correspond to the size of the file being copied.
+  - The location in the z/OS system where local scripts will be copied to can be
+    configured through Ansible's C(remote_tmp) option. Refer to
+    L(Ansible's documentation,https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sh_shell.html#parameter-remote_tmp)
+    for more information.
+  - All local scripts copied to a remote z/OS system  will be removed from the
+    managed node before the module finishes executing.
   - Execution permissions for the group assigned to the script will be
     added to remote scripts. The original permissions for remote scripts will
     be restored by the module before the task ends.

--- a/plugins/modules/zos_script.py
+++ b/plugins/modules/zos_script.py
@@ -148,6 +148,11 @@ EXAMPLES = r"""
     remote_src: true
     chdir: /u/user/output_dir
 
+- name: Run a local Python script in the temporary directory specified in the Ansible environment variable 'remote_tmp'.
+  zos_script:
+    cmd: ./scripts/program.py
+    executable: /usr/bin/python3
+
 - name: Run a local script made from a template.
   zos_script:
     cmd: ./templates/PROGRAM

--- a/tests/functional/modules/test_zos_script_func.py
+++ b/tests/functional/modules/test_zos_script_func.py
@@ -237,41 +237,6 @@ def test_rexx_script_chdir(ansible_zos_module):
         hosts.all.file(path=tmp_remote_dir, state='absent')
 
 
-def test_rexx_script_tmp_path(ansible_zos_module):
-    import os
-
-    hosts = ansible_zos_module
-
-    try:
-        rexx_script = create_script_content('tmp_path test', 'rexx')
-        script_path = create_local_file(rexx_script, 'rexx')
-
-        tmp_remote_dir = '/tmp/zos_script_tests'
-        file_result = hosts.all.file(
-            path=tmp_remote_dir,
-            state='directory'
-        )
-
-        for result in file_result.contacted.values():
-            assert result.get('changed') is True
-
-        zos_script_result = hosts.all.zos_script(
-            cmd=script_path,
-            tmp_path=tmp_remote_dir
-        )
-
-        for result in zos_script_result.contacted.values():
-            assert result.get('changed') is True
-            assert result.get('failed', False) is False
-            assert result.get('rc') == 0
-            assert result.get('stderr', '') == ''
-            assert tmp_remote_dir in result.get('remote_cmd', '')
-    finally:
-        if os.path.exists(script_path):
-            os.remove(script_path)
-        hosts.all.file(path=tmp_remote_dir, state='absent')
-
-
 def test_python_script(ansible_zos_module):
     import os
 


### PR DESCRIPTION
Fixes #1024. Instead of implementing its own temp path, the module now takes advantage of Ansible's config.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zos_script

##### ADDITIONAL INFORMATION
Removed the test case for `tmp_path` since now it belongs to the Ansible engine.
