### PR TITLE
Cherry picked v1.8.0

### DIFF
--- a/changelogs/fragments/1041-bug-zos-submit-job-honor-return-output-literally.yml
+++ b/changelogs/fragments/1041-bug-zos-submit-job-honor-return-output-literally.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - zos_submit_job - Previous code did not return output, but still requested job data from the target system.
+    This changes to honor return_output=false by not querying the job dd segments at all.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1058).

--- a/changelogs/fragments/1041-bug-zos-submit-job-honor-return-output-literally.yml
+++ b/changelogs/fragments/1041-bug-zos-submit-job-honor-return-output-literally.yml
@@ -1,4 +1,4 @@
 minor_changes:
   - zos_submit_job - Previous code did not return output, but still requested job data from the target system.
     This changes to honor return_output=false by not querying the job dd segments at all.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1058).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1063).

--- a/changelogs/fragments/1043-bug-title-zos_operator-is-passing-wrong-value-to-zoauopercmd.yml
+++ b/changelogs/fragments/1043-bug-title-zos_operator-is-passing-wrong-value-to-zoauopercmd.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - zos_operator - The module was ignoring the wait time argument.
+    The module now passes the wait time argument to ZOAU.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1044).
+
+  - zos_operator_action_query - The module was ignoring the wait time argument.
+    The module now passes the wait time argument to ZOAU.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1044).

--- a/changelogs/fragments/1043-bug-title-zos_operator-is-passing-wrong-value-to-zoauopercmd.yml
+++ b/changelogs/fragments/1043-bug-title-zos_operator-is-passing-wrong-value-to-zoauopercmd.yml
@@ -1,8 +1,8 @@
 bugfixes:
   - zos_operator - The module was ignoring the wait time argument.
     The module now passes the wait time argument to ZOAU.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1044).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1063).
 
   - zos_operator_action_query - The module was ignoring the wait time argument.
     The module now passes the wait time argument to ZOAU.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1044).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1063).

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -36,7 +36,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
 )
 
 
-def job_output(job_id=None, owner=None, job_name=None, dd_name=None, duration=0, timeout=0, start_time=timer()):
+def job_output(job_id=None, owner=None, job_name=None, dd_name=None, dd_scan=True, duration=0, timeout=0, start_time=timer()):
     """Get the output from a z/OS job based on various search criteria.
 
     Keyword Arguments:
@@ -44,6 +44,7 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None, duration=0,
         owner (str) -- The owner of the job (default: {None})
         job_name (str) -- The job name search for (default: {None})
         dd_name (str) -- The data definition to retrieve (default: {None})
+        dd_scan (bool) - Whether or not to pull information from the dd's for this job {default: {True}}
         duration (int) -- The time the submitted job ran for
         timeout (int) - how long to wait in seconds for a job to complete
         start_time (int) - time the JCL started its submission
@@ -70,7 +71,7 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None, duration=0,
     dd_name = parsed_args.get("dd_name") or ""
 
     job_detail = _get_job_status(job_id=job_id, owner=owner, job_name=job_name,
-                                 dd_name=dd_name, duration=duration, timeout=timeout, start_time=start_time)
+                                 dd_name=dd_name, duration=duration, dd_scan=dd_scan, timeout=timeout, start_time=start_time)
 
     # while ((job_detail is None or len(job_detail) == 0) and duration <= timeout):
     #     current_time = timer()
@@ -83,7 +84,7 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None, duration=0,
         owner = "" if owner == "*" else owner
         job_name = "" if job_name == "*" else job_name
         job_detail = _get_job_status(job_id=job_id, owner=owner, job_name=job_name,
-                                     dd_name=dd_name, duration=duration, timeout=timeout, start_time=start_time)
+                                     dd_name=dd_name, dd_scan=dd_scan, duration=duration, timeout=timeout, start_time=start_time)
     return job_detail
 
 

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -959,7 +959,7 @@ def run_module():
 
         job_output_txt = job_output(
             job_id=job_submitted_id, owner=None, job_name=None, dd_name=None,
-            duration=duration, timeout=wait_time_s, start_time=start_time)
+            dd_scan=return_output, duration=duration, timeout=wait_time_s, start_time=start_time)
 
         result["duration"] = duration
 

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -283,7 +283,7 @@ def run_operator_command(params):
         use_wait_arg = True
 
     if use_wait_arg:
-        kwargs.update({"wait_arg": True})
+        kwargs.update({"wait": True})
 
     args = []
     rc, stdout, stderr, elapsed = execute_command(cmdtxt, timeout=wait_s, *args, **kwargs)

--- a/plugins/modules/zos_operator_action_query.py
+++ b/plugins/modules/zos_operator_action_query.py
@@ -272,7 +272,7 @@ def run_module():
             use_wait_arg = True
 
         if use_wait_arg:
-            kwargs.update({"wait_arg": False})
+            kwargs.update({"wait": True})
 
         args = []
 


### PR DESCRIPTION
##### SUMMARY
backport of 1041 and 1044 for 1.8.0 ga
Fixes 
#1041  : Option return_output when set to false continues to access job output in zos_submit_job
#1044 : zos operator is passing wrong value to zoauopercmd for delays

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zos_submit_job
zos_data_set <= zos_operator and zos_operator_action_query

