### PR TITLE
[v1.8.0] [Backport] [zos_copy] mvs to non existent mvs copy verify destination attrs match

### DIFF
--- a/changelogs/fragments/1067-mvs_to_non_existent_mvs_copy_verify_destination_attrs_match.yml
+++ b/changelogs/fragments/1067-mvs_to_non_existent_mvs_copy_verify_destination_attrs_match.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_copy - Module calculated incorrectly the values of the source dataset
+    when making a copy with executables and aliases and the target did not exist.
+    Fix now and create the target dataset with the same attributes as the source.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1067).

--- a/changelogs/fragments/1067-mvs_to_non_existent_mvs_copy_verify_destination_attrs_match.yml
+++ b/changelogs/fragments/1067-mvs_to_non_existent_mvs_copy_verify_destination_attrs_match.yml
@@ -1,5 +1,5 @@
 bugfixes:
-  - zos_copy - Module calculated incorrectly the values of the source dataset
-    when making a copy with executables and aliases and the target did not exist.
-    Fix now and create the target dataset with the same attributes as the source.
+  - zos_copy - When copying an executable data set with aliases and destination did not exist,
+    destination data set was created with wrong attributes. Fix now creates destination data set
+    with the same attributes as the source.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1067).

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -278,7 +278,7 @@ class DataSet(object):
         return False
 
     @staticmethod
-    def allocate_model_data_set(ds_name, model, asa_text=False, vol=None):
+    def allocate_model_data_set(ds_name, model, executable=False, asa_text=False, vol=None):
         """Allocates a data set based on the attributes of a 'model' data set.
         Useful when a data set needs to be created identical to another. Supported
         model(s) are Physical Sequential (PS), Partitioned Data Sets (PDS/PDSE),
@@ -291,6 +291,7 @@ class DataSet(object):
             must be used. See extract_dsname(ds_name) in data_set.py
             model {str} -- The name of the data set whose allocation parameters
             should be used to allocate the new data set 'ds_name'
+            executable {bool} -- Whether the new data set should support executables
             asa_text {bool} -- Whether the new data set should support ASA control
             characters (have record format FBA)
             vol {str} -- The volume where data set should be allocated
@@ -326,6 +327,11 @@ class DataSet(object):
         if asa_text:
             alloc_cmd = """{0} -
             RECFM(F,B,A)""".format(alloc_cmd)
+
+        if executable:
+            alloc_cmd = """{0} -
+            RECFM(U) -
+            DSNTYPE(LIBRARY)""".format(alloc_cmd)
 
         rc, out, err = mvs_cmd.ikjeft01(alloc_cmd, authorized=True)
         if rc != 0:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2334,25 +2334,7 @@ def allocate_destination_data_set(
     elif dest_ds_type in data_set.DataSet.MVS_PARTITIONED and not dest_exists:
         # Taking the src as model if it's also a PDSE.
         if src_ds_type in data_set.DataSet.MVS_PARTITIONED:
-            if executable:
-                src_attributes = datasets.listing(src_name)[0]
-                size = int(src_attributes.total_space)
-                record_format = "U"
-                record_length = 0
-
-                dest_params = get_data_set_attributes(
-                    dest,
-                    size,
-                    is_binary,
-                    asa_text,
-                    record_format=record_format,
-                    record_length=record_length,
-                    type="LIBRARY",
-                    volume=volume
-                )
-                data_set.DataSet.ensure_present(replace=force, **dest_params)
-            else:
-                data_set.DataSet.allocate_model_data_set(ds_name=dest, model=src_name, asa_text=asa_text, vol=volume)
+            data_set.DataSet.allocate_model_data_set(ds_name=dest, model=src_name, executable=executable, asa_text=asa_text, vol=volume)
         elif src_ds_type in data_set.DataSet.MVS_SEQ:
             src_attributes = datasets.listing(src_name)[0]
             # The size returned by listing is in bytes.


### PR DESCRIPTION
##### SUMMARY
The copy of an executable and aliases in a dataset to a creation to another dataset not in existence modify size.

Fixes #1022 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Remove the function of ensure_present and modify the function of allocate model data set to include the correct one for executables.

##### ADDITIONAL INFORMATION
Remove the ensure_present function by calculating the size and now using function of allocate_model_data_set to include a case about executable using:
`if executable:
            alloc_cmd = """{0} -
            RECFM(U) -
            DSNTYPE(LIBRARY)""".format(alloc_cmd)`
[Pipeline](https://ibm.box.com/s/lyudfq6vwdm2i822bm7fva90sf6xxcnc)

