### PR TITLE
Bugfix/903/remove tmp files

### DIFF
--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -184,18 +184,6 @@ class ActionModule(ActionBase):
             else:
                 result.update(dict(failed=True))
 
-            # dest_file is the only remote path created in this workflow
-            dest_status = self._execute_remote_stat(
-                dest_file, all_vars=task_vars, follow=False
-            )
-            if dest_status.get("dest_file"):
-                self._connection.exec_command("rm -rf {0}".format(dest_path))
-            if rendered_file and os.path.exists(template_dir):
-                try:
-                    os.rmdir(template_dir)
-                except Exception as e:
-                    display.vvv("Unable to remove temporary directory {0}. {1}".format(template_dir, e))
-
         else:
             result.update(
                 self._execute_module(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
zos_job_submit was not properly cleaning up the tmp files reported in #903 , and lines added were essentially doing nothing to clean any files remaining, checked in the local node but tried to remove the same in the remote node.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #903 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_submit

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
