### PR TITLE
Remove tarfile.exctractall and zipfile.extractall in favor of individual member extraction for sanity

### DIFF
--- a/changelogs/fragments/1077-modify-uss-extraction.yml
+++ b/changelogs/fragments/1077-modify-uss-extraction.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_unarchive - Change the USS file extraction method from extractall to a custom function to extract filtered members.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1077).

--- a/plugins/modules/zos_unarchive.py
+++ b/plugins/modules/zos_unarchive.py
@@ -462,6 +462,10 @@ class Unarchive():
             'missing': self.missing,
         }
 
+    def extract_all(self, members):
+        for member in members:
+            self.file.extract(member)
+
 
 class TarUnarchive(Unarchive):
     def __init__(self, module):
@@ -527,7 +531,8 @@ class TarUnarchive(Unarchive):
                     self.file.extract(path)
                     self.targets.append(path)
         else:
-            self.file.extractall(members=sanitize_members(self.file.getmembers(), self.dest, self.format))
+            self.extract_all(members=sanitize_members(self.file.getmembers(), self.dest, self.format))
+            # self.file.extractall(members=sanitize_members(self.file.getmembers(), self.dest, self.format))
             self.targets = files_in_archive
         self.file.close()
         # Returning the current working directory to what it was before to not
@@ -598,7 +603,8 @@ class ZipUnarchive(Unarchive):
                     self.file.extract(path)
                     self.targets.append(path)
         else:
-            self.file.extractall(members=sanitize_members(self.file.infolist(), self.dest, self.format))
+            self.extract_all(members=sanitize_members(self.file.infolist(), self.dest, self.format))
+            # self.file.extractall(members=sanitize_members(self.file.infolist(), self.dest, self.format))
             self.targets = files_in_archive
         self.file.close()
         # Returning the current working directory to what it was before to not

--- a/plugins/modules/zos_unarchive.py
+++ b/plugins/modules/zos_unarchive.py
@@ -532,7 +532,6 @@ class TarUnarchive(Unarchive):
                     self.targets.append(path)
         else:
             self.extract_all(members=sanitize_members(self.file.getmembers(), self.dest, self.format))
-            # self.file.extractall(members=sanitize_members(self.file.getmembers(), self.dest, self.format))
             self.targets = files_in_archive
         self.file.close()
         # Returning the current working directory to what it was before to not
@@ -604,7 +603,6 @@ class ZipUnarchive(Unarchive):
                     self.targets.append(path)
         else:
             self.extract_all(members=sanitize_members(self.file.infolist(), self.dest, self.format))
-            # self.file.extractall(members=sanitize_members(self.file.infolist(), self.dest, self.format))
             self.targets = files_in_archive
         self.file.close()
         # Returning the current working directory to what it was before to not


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replaced extractable call to a custom extract_all to remove bandit warning, members are filtered before using sanitize_members so this doesn't change any behavior.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1075 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_unarchive

