### PR TITLE
[Bugfix][v1.9.0]short job name sends back a value error with a full stack trace as the msg

### DIFF
--- a/changelogs/fragments/1078-short_job_name_sends_back_a_value_error.yaml
+++ b/changelogs/fragments/1078-short_job_name_sends_back_a_value_error.yaml
@@ -1,7 +1,7 @@
 bugfixes:
-  - zos_job_output - When passing a job id or name less than 8 characters the module send full stack trace as the msg.
-    Change now allows user to use job id or name with less than 8 characters and wildcards.
+  - zos_job_output - When passing a job ID or name less than 8 characters long, the module sent the full stack trace as the module's message.
+    Change now allows the use of a shorter job ID or name, as well as wildcards.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1078).
-  - zos_job_query - When passing a job id or name less than 8 characters the module send full stack trace as the msg.
-    Change now allows user to use job id or name with less than 8 characters and wildcards.
+  - zos_job_query - When passing a job ID or name less than 8 characters long, the module sent the full stack trace as the module's message.
+    Change now allows the use of a shorter job ID or name, as well as wildcards.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1078).

--- a/changelogs/fragments/1078-short_job_name_sends_back_a_value_error.yaml
+++ b/changelogs/fragments/1078-short_job_name_sends_back_a_value_error.yaml
@@ -5,3 +5,7 @@ bugfixes:
   - zos_job_query - When passing a job ID or name less than 8 characters long, the module sent the full stack trace as the module's message.
     Change now allows the use of a shorter job ID or name, as well as wildcards.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1078).
+
+minor_change:
+  - zos_job_output - When passing a job ID and owner the module take as mutually exclusive. Change now allows the use of a job ID and owner at the same time.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1078).

--- a/changelogs/fragments/1078-short_job_name_sends_back_a_value_error.yaml
+++ b/changelogs/fragments/1078-short_job_name_sends_back_a_value_error.yaml
@@ -1,0 +1,7 @@
+bugfixes:
+  - zos_job_output - When passing a job id or name less than 8 characters the module send full stack trace as the msg.
+    Change now allows user to use job id or name with less than 8 characters and wildcards.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1078).
+  - zos_job_query - When passing a job id or name less than 8 characters the module send full stack trace as the msg.
+    Change now allows user to use job id or name with less than 8 characters and wildcards.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1078).

--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -756,7 +756,7 @@ class BetterArgHandler(object):
         """Resolver for data_set type arguments.
 
         Arguments:
-            contents {bool} -- The contents of the argument.
+            contents {str} -- The contents of the argument.
 
         Raises:
             ValueError: When contents is invalid argument type

--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -764,7 +764,7 @@ class BetterArgHandler(object):
             str -- The arguments contents after any necessary operations.
         """
         if not fullmatch(
-            r"(^[a-zA-Z$#@%}]{1}[0-9a-zA-Z$#@%*]{2,7})|(^['\*']{1})",
+            r"(^[a-zA-Z$#@%}]{1}[0-9a-zA-Z$#@%*]{1,7})|(^['\*']{1})",
             str(contents),
             IGNORECASE,
         ):

--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -747,13 +747,13 @@ class BetterArgHandler(object):
     # ---------------------------------------------------------------------------- #
     #                    JOB ID AND JOB NAME NAMING RULES                          #
     # ---------------------------------------------------------------------------- #
-    # A text string of up to 8 characters.
-    # The first character must be a letter or a national (#, $, @) character.
-    # Other characters can be letters, numbers, or national (#, $, @) characters.
-    # If the text string contains #, $, or @, enclose the text string in single or double quotation marks.
 
     def _job_identifier(self, contents, resolve_dependencies):
         """Resolver for data_set type arguments.
+        A text string of up to 8 characters.
+        The first character must be a letter or a national (#, $, @) character.
+        Other characters can be letters, numbers, or national (#, $, @) characters.
+        If the text string contains #, $, or @, enclose the text string in single or double quotation marks.
 
         Arguments:
             contents {str} -- The contents of the argument.

--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -764,7 +764,7 @@ class BetterArgHandler(object):
             str -- The arguments contents after any necessary operations.
         """
         if not fullmatch(
-            r"[a-zA-Z$#@%]{1}[0-9a-zA-Z$#@%]{2,7}",
+            r"(^[a-zA-Z$#@%}]{1}[0-9a-zA-Z$#@%]{2,7})|(^['\*']{1})",
             str(contents),
             IGNORECASE,
         ):

--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -148,6 +148,7 @@ class BetterArgHandler(object):
             "data_set_or_path": self._data_set_or_path_type,
             "encoding": self._encoding_type,
             "dd": self._dd_type,
+            "job_identifier": self._job_identifier,
         }
 
     def handle_arg(self):
@@ -742,6 +743,35 @@ class BetterArgHandler(object):
                     arg_function, self.arg_name
                 )
             )
+
+    # ---------------------------------------------------------------------------- #
+    #                    JOB ID AND JOB NAME NAMING RULES                          #
+    # ---------------------------------------------------------------------------- #
+    # A text string of up to 8 characters.
+    # The first character must be a letter or a national (#, $, @) character.
+    # Other characters can be letters, numbers, or national (#, $, @) characters.
+    # If the text string contains #, $, or @, enclose the text string in single or double quotation marks.
+
+    def _job_identifier(self, contents, resolve_dependencies):
+        """Resolver for data_set type arguments.
+
+        Arguments:
+            contents {bool} -- The contents of the argument.
+
+        Raises:
+            ValueError: When contents is invalid argument type
+        Returns:
+            str -- The arguments contents after any necessary operations.
+        """
+        if not fullmatch(
+            r"[a-zA-Z$#@%]{1}[0-9a-zA-Z$#@%]{2,7}",
+            str(contents),
+            IGNORECASE,
+        ):
+            raise ValueError(
+                'Invalid argument "{0}" for type "job_id or job_name".'.format(contents)
+            )
+        return str(contents)
 
 
 class BetterArgParser(object):

--- a/plugins/module_utils/better_arg_parser.py
+++ b/plugins/module_utils/better_arg_parser.py
@@ -764,7 +764,7 @@ class BetterArgHandler(object):
             str -- The arguments contents after any necessary operations.
         """
         if not fullmatch(
-            r"(^[a-zA-Z$#@%}]{1}[0-9a-zA-Z$#@%]{2,7})|(^['\*']{1})",
+            r"(^[a-zA-Z$#@%}]{1}[0-9a-zA-Z$#@%*]{2,7})|(^['\*']{1})",
             str(contents),
             IGNORECASE,
         ):

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -417,6 +417,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import (
     job_output,
 )
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
+    better_arg_parser
+)
 
 
 def run_module():
@@ -428,6 +431,23 @@ def run_module():
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    args_def = dict(
+        job_id=dict(type="job_identifier", required=False),
+        job_name=dict(type="job_identifier", required=False),
+        owner=dict(type="str", required=False),
+        ddname=dict(type="str", required=False),
+    )
+
+    try:
+        parser = better_arg_parser.BetterArgParser(args_def)
+        parsed_args = parser.parse_args(module.params)
+        module.params = parsed_args
+    except ValueError as err:
+        module.fail_json(
+            msg='Parameter verification failed.',
+            stderr=str(err)
+        )
 
     job_id = module.params.get("job_id")
     job_name = module.params.get("job_name")

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -301,8 +301,6 @@ def run_module():
         name = module.params.get("job_name")
         id = module.params.get("job_id")
         owner = module.params.get("owner")
-        if id and owner:
-            raise RuntimeError("Argument Error:job id can not be co-exist with owner")
         jobs_raw = query_jobs(name, id, owner)
         if jobs_raw:
             jobs = parsing_jobs(jobs_raw)

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -263,7 +263,6 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
 )
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
-import re
 
 
 def run_module():

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -263,6 +263,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
 )
 from ansible.module_utils.basic import AnsibleModule
 
+
 def run_module():
 
     module_args = dict(

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -40,6 +40,7 @@ options:
        - The asterisk (`*`) wildcard will match zero or more specified characters.
     type: str
     required: False
+    default: "*"
   owner:
     description:
       - Identifies the owner of the job.
@@ -266,7 +267,7 @@ from ansible.module_utils.basic import AnsibleModule
 def run_module():
 
     module_args = dict(
-        job_name=dict(type="str", required=False),
+        job_name=dict(type="str", required=False, default="*"),
         owner=dict(type="str", required=False),
         job_id=dict(type="str", required=False),
     )

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -262,8 +262,6 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     better_arg_parser
 )
 from ansible.module_utils.basic import AnsibleModule
-import re
-
 
 def run_module():
 

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -258,7 +258,9 @@ message:
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import (
     job_status,
 )
-
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
+    better_arg_parser
+)
 from ansible.module_utils.basic import AnsibleModule
 import re
 
@@ -266,7 +268,7 @@ import re
 def run_module():
 
     module_args = dict(
-        job_name=dict(type="str", required=False, default="*"),
+        job_name=dict(type="str", required=False),
         owner=dict(type="str", required=False),
         job_id=dict(type="str", required=False),
     )
@@ -275,11 +277,31 @@ def run_module():
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
 
+    args_def = dict(
+        job_name=dict(type="job_identifier", required=False),
+        owner=dict(type="str", required=False),
+        job_id=dict(type="job_identifier", required=False),
+    )
+
+    try:
+        parser = better_arg_parser.BetterArgParser(args_def)
+        parsed_args = parser.parse_args(module.params)
+        module.params = parsed_args
+    except ValueError as err:
+        module.fail_json(
+            msg='Parameter verification failed.',
+            stderr=str(err)
+        )
+
     if module.check_mode:
         return result
 
     try:
-        name, id, owner = validate_arguments(module.params)
+        name = module.params.get("job_name")
+        id = module.params.get("job_id")
+        owner = module.params.get("owner")
+        if id and owner:
+            raise RuntimeError("Argument Error:job id can not be co-exist with owner")
         jobs_raw = query_jobs(name, id, owner)
         if jobs_raw:
             jobs = parsing_jobs(jobs_raw)
@@ -290,64 +312,6 @@ def run_module():
         module.fail_json(msg=e, **result)
     result["jobs"] = jobs
     module.exit_json(**result)
-
-
-# validate_arguments returns a tuple, so we don't have to rebuild the job_name string
-def validate_arguments(params):
-    job_name_in = params.get("job_name")
-
-    job_id = params.get("job_id")
-
-    owner = params.get("owner")
-    if job_name_in or job_id:
-        if job_name_in and job_name_in != "*":
-            job_name_pattern = re.compile(r"^[a-zA-Z$#@%][0-9a-zA-Z$#@%]{0,7}$")
-            job_name_pattern_with_star = re.compile(
-                r"^[a-zA-Z$#@%][0-9a-zA-Z$#@%]{0,6}\*$"
-            )
-            test_basic = job_name_pattern.search(job_name_in)
-            test_star = job_name_pattern_with_star.search(job_name_in)
-            # logic twist: test_result should be a non-null value from test_basic or test_star
-            test_result = test_basic
-            if test_star:
-                test_result = test_star
-
-            job_name_short = "unused"
-            # if neither test_basic nor test_star were non-null, check if the string needed to be truncated to the first *
-            if not test_result:
-                ix = job_name_in.find("*")
-                if ix >= 0:
-                    job_name_short = job_name_in[0:ix + 1]
-                    test_result = job_name_pattern.search(job_name_short)
-                    if not test_result:
-                        test_result = job_name_pattern_with_star.search(job_name_short)
-
-            # so now, fail if neither test_basic, test_star or test_base from job_name_short found a match
-            if not test_result:
-                raise RuntimeError("Unable to locate job name {0}.".format(job_name_in))
-
-        if job_id:
-            job_id_pattern = re.compile("(JOB|TSU|STC)[0-9]{5}|(J|T|S)[0-9]{7}$")
-            test_basic = job_id_pattern.search(job_id)
-            test_result = None
-
-            if not test_basic:
-                ix = job_id.find("*")
-                if ix > 0:
-                    # this differs from job_name, in that we'll drop the star for the search
-                    job_id_short = job_id[0:ix]
-
-                    if job_id_short[0:3] in ['JOB', 'TSU', 'STC'] or job_id_short[0:1] in ['J', 'T', 'S']:
-                        test_result = job_id_short
-
-            if not test_basic and not test_result:
-                raise RuntimeError("Failed to validate the job id: " + job_id)
-    else:
-        raise RuntimeError("Argument Error:Either job name(s) or job id is required")
-    if job_id and owner:
-        raise RuntimeError("Argument Error:job id can not be co-exist with owner")
-
-    return job_name_in, job_id, owner
 
 
 def query_jobs(job_name, job_id, owner):

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -40,7 +40,6 @@ options:
        - The asterisk (`*`) wildcard will match zero or more specified characters.
     type: str
     required: False
-    default: "*"
   owner:
     description:
       - Identifies the owner of the job.

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -141,3 +141,10 @@ def test_zos_job_output_job_exists_with_filtered_ddname(ansible_zos_module):
                 assert job.get("ddnames")[0].get("ddname") == dd_name
     finally:
         hosts.all.file(path=TEMP_PATH, state="absent")
+
+
+def test_zos_job_submit_job_id_and_owner_included(ansible_zos_module):
+    hosts = ansible_zos_module
+    results = hosts.all.zos_job_output(job_id="STC00*", owner="MASTER")
+    for result in results.contacted.values():
+        assert result.get("jobs") is not None

--- a/tests/functional/modules/test_zos_job_query_func.py
+++ b/tests/functional/modules/test_zos_job_query_func.py
@@ -28,7 +28,6 @@ import tempfile
 def test_zos_job_query_func(ansible_zos_module):
     hosts = ansible_zos_module
     results = hosts.all.zos_job_query(job_name="*", owner="*")
-    pprint(vars(results))
     for result in results.contacted.values():
         assert result.get("changed") is False
         assert result.get("jobs") is not None
@@ -111,3 +110,17 @@ def test_zos_job_name_query_multi_wildcards_func(ansible_zos_module):
     finally:
         hosts.all.file(path=TEMP_PATH, state="absent")
         hosts.all.zos_data_set(name=NDATA_SET_NAME, state="absent")
+
+
+def test_zos_job_id_query_short_ids_func(ansible_zos_module):
+    hosts = ansible_zos_module
+    qresults = hosts.all.zos_job_query(job_id="STC003")
+    for qresult in qresults.contacted.values():
+        assert qresult.get("jobs") is not None
+
+
+def test_zos_job_id_query_short_ids_with_wilcard_func(ansible_zos_module):
+    hosts = ansible_zos_module
+    qresults = hosts.all.zos_job_query(job_id="STC00*")
+    for qresult in qresults.contacted.values():
+        assert qresult.get("jobs") is not None


### PR DESCRIPTION
##### SUMMARY
Validate identifiers of jobs with better args parser and add test cases for validate the use of wildcards on short names.

Fixes #899 and validates #900

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
job_identifier as type in better arg parser

##### ADDITIONAL INFORMATION
The new regex to validate job identifier `(^[a-zA-Z$#@%}]{1}[0-9a-zA-Z$#@%*]{2,7})|(^['\*']{1})`
And add to test cases to validate short jobs ids one with wildcard and one without.

##### PIPELINE OF REGRESSION
[Here](https://ibm.box.com/s/9d4qd4fyico0pme3ab798gfhahme5u51) 
