### PR TITLE
[zos_copy] fix for executables copied from local fail with iconv error

### DIFF
--- a/changelogs/fragments/1079-zos-copy-local-executable.yml
+++ b/changelogs/fragments/1079-zos-copy-local-executable.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_copy - When copying an executable data set from controller to managed node,
+    copy operation failed with an encoding error. Fix now avoids encoding when executable
+    option is selected.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1079).

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2679,7 +2679,7 @@ def run_module(module, arg_def):
             # When the destination is a dataset, we'll normalize the source
             # file to UTF-8 for the record length computation as Python
             # generally uses UTF-8 as the default encoding.
-            if not is_binary and not is_uss:
+            if not is_binary and not is_uss and not executable:
                 new_src = temp_path or src
                 new_src = os.path.normpath(new_src)
                 # Normalizing encoding when src is a USS file (only).
@@ -2757,6 +2757,12 @@ def run_module(module, arg_def):
             # dest_data_set.type overrides `dest_ds_type` given precedence rules
             if dest_data_set and dest_data_set.get("type"):
                 dest_ds_type = dest_data_set.get("type")
+            elif executable:
+                """ When executable is selected and dest_exists is false means an executable PDSE was copied to remote,
+                so we need to provide the correct dest_ds_type that will later be transformed into LIBRARY.
+                Not using LIBRARY at this step since there are many checks with dest_ds_type in data_set.DataSet.MVS_PARTITIONED
+                and LIBRARY is not in MVS_PARTITIONED frozen set."""
+                dest_ds_type = "PDSE"
 
             if dest_data_set and (dest_data_set.get('record_format', '') == 'FBA' or dest_data_set.get('record_format', '') == 'VBA'):
                 dest_has_asa_chars = True
@@ -3048,7 +3054,7 @@ def run_module(module, arg_def):
         # ---------------------------------------------------------------------
         # Copy to PDS/PDSE
         # ---------------------------------------------------------------------
-        elif dest_ds_type in data_set.DataSet.MVS_PARTITIONED:
+        elif dest_ds_type in data_set.DataSet.MVS_PARTITIONED or dest_ds_type == "LIBRARY":
             if not remote_src and not copy_member and os.path.isdir(temp_path):
                 temp_path = os.path.join(validation.validate_safe_path(temp_path), validation.validate_safe_path(os.path.basename(src)))
 
@@ -3268,6 +3274,7 @@ def main():
         not module.params.get("encoding")
         and not module.params.get("remote_src")
         and not module.params.get("is_binary")
+        and not module.params.get("executable")
     ):
         module.params["encoding"] = {
             "from": module.params.get("local_charset"),

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3428,6 +3428,143 @@ def test_copy_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
         hosts.all.zos_data_set(name=dest_lib, state="absent")
         hosts.all.zos_data_set(name=dest_lib_aliases, state="absent")
 
+
+@pytest.mark.pdse
+@pytest.mark.loadlib
+@pytest.mark.aliases
+@pytest.mark.parametrize("is_created", [False, True])
+def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
+
+    hosts = ansible_zos_module
+
+    cobol_src_pds = "USER.COBOL.SRC"
+    cobol_src_mem = "HELLOCBL"
+    cobol_src_mem2 = "HICBL2"
+    src_lib = "USER.LOAD.SRC"
+    dest_lib = "USER.LOAD.DEST"
+    pgm_mem = "HELLO"
+    pgm2_mem = "HELLO2"
+
+
+    try:
+        # allocate pds for cobol src code
+        hosts.all.zos_data_set(
+            name=cobol_src_pds,
+            state="present",
+            type="pds",
+            space_primary=2,
+            record_format="FB",
+            record_length=80,
+            block_size=3120,
+            replace=True,
+        )
+        # allocate pds for src loadlib
+        hosts.all.zos_data_set(
+            name=src_lib,
+            state="present",
+            type="pdse",
+            record_format="U",
+            record_length=0,
+            block_size=32760,
+            space_primary=2,
+            space_type="M",
+            replace=True
+        )
+
+        # copy cobol src
+        hosts.all.zos_copy(content=COBOL_SRC.format(COBOL_PRINT_STR), dest='{0}({1})'.format(cobol_src_pds, cobol_src_mem))
+        # copy cobol2 src
+        hosts.all.zos_copy(content=COBOL_SRC.format(COBOL_PRINT_STR2), dest='{0}({1})'.format(cobol_src_pds, cobol_src_mem2))
+
+        # run link-edit for pgm1
+        link_rc = link_loadlib_from_cobol(hosts, cobol_src_pds, cobol_src_mem, src_lib, pgm_mem)
+        assert link_rc == 0
+        # run link-edit for pgm2
+        link_rc = link_loadlib_from_cobol(hosts, cobol_src_pds, cobol_src_mem2, src_lib, pgm2_mem, loadlib_alias_mem="ALIAS2")
+        assert link_rc == 0
+
+        # execute pgm to test pgm1
+        validate_loadlib_pgm(hosts, steplib=src_lib, pgm_name=pgm_mem, expected_output_str=COBOL_PRINT_STR)
+
+        # fetch loadlib into local
+        tmp_folder = tempfile.TemporaryDirectory(prefix="tmpfetch")
+        # fetch loadlib to local
+        fetch_result = hosts.all.zos_fetch(src=src_lib, dest=tmp_folder.name, is_binary=True)
+        for res in fetch_result.contacted.values():
+            source_path = res.get("dest")
+
+        if not is_created:
+            # ensure dest data sets absent for this variation of the test case.
+            hosts.all.zos_data_set(name=dest_lib, state="absent")
+        else:
+            # allocate dest loadlib to copy over without an alias.
+            hosts.all.zos_data_set(
+                name=dest_lib,
+                state="present",
+                type="pdse",
+                record_format="U",
+                record_length=0,
+                block_size=32760,
+                space_primary=2,
+                space_type="M",
+                replace=True
+            )
+
+        if not is_created:
+            # dest data set does not exist, specify it in dest_dataset param.
+            # copy src loadlib to dest library pds w/o aliases
+            copy_res = hosts.all.zos_copy(
+                src=source_path,
+                dest="{0}".format(dest_lib),
+                executable=True,
+                aliases=False,
+                dest_data_set={
+                    'type': "PDSE",
+                    'record_format': "U",
+                    'record_length': 0,
+                    'block_size': 32760,
+                    'space_primary': 2,
+                    'space_type': "M",
+                }
+            )
+        else:
+            # copy src loadlib to dest library pds w/o aliases
+            copy_res = hosts.all.zos_copy(
+                src=source_path,
+                dest="{0}".format(dest_lib),
+                executable=True,
+                aliases=False
+            )
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == "{0}".format(dest_lib)
+
+        # check ALIAS keyword and name in mls output
+        verify_copy_mls = hosts.all.shell(
+            cmd="mls {0}".format(dest_lib),
+            executable=SHELL_EXECUTABLE
+        )
+        for v_cp in verify_copy_mls.contacted.values():
+            assert v_cp.get("rc") == 0
+            stdout = v_cp.get("stdout")
+            assert stdout is not None
+
+        # verify pgms remain executable
+        pgm_output_map = {
+            (dest_lib, pgm_mem, COBOL_PRINT_STR),
+            (dest_lib, pgm2_mem, COBOL_PRINT_STR2),
+        }
+        for steplib, pgm, output in pgm_output_map:
+            validate_loadlib_pgm(hosts, steplib=steplib, pgm_name=pgm, expected_output_str=output)
+
+    finally:
+        hosts.all.zos_data_set(name=cobol_src_pds, state="absent")
+        hosts.all.zos_data_set(name=src_lib, state="absent")
+        hosts.all.zos_data_set(name=dest_lib, state="absent")
+
+
 @pytest.mark.pdse
 @pytest.mark.loadlib
 @pytest.mark.aliases


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fixes #1080 for branch v1.8.0, essentially this removes any encoding for when a local file is sent to remote, also, when dest_type is not available i.e. dest doesn't not already exists now we set the dest_ds_type = 'PDSE' when executable is selected and we know dest is not USS (validation performed on src checking for '/'), which then gets changed to "LIBRARY", note that I also added a check when copying to PDS/PDSE, that is because when the a local file is copied to remote dest_ds_type gets changed to "LIBRARY" however this doesn't occur when copying an executable from the remote (I believe the data set type we get is PDSE) and that needs to be further investigated in #1080 for v1.9.0 fix.

This current version does solve the issue and does not break anything that we are testing for, so should be a fix for v1.8.0.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy

