### PR TITLE
[Enabler][Zos Job Submit]Update undocumented argument and import exception

### DIFF
--- a/changelogs/fragments/1091-Update_undocumented_argument_and_import_exception.yml
+++ b/changelogs/fragments/1091-Update_undocumented_argument_and_import_exception.yml
@@ -1,4 +1,4 @@
-trivial:
+minor_changes:
   - zos_job_submit - The module handling ZOAU import errors obscured the
     original traceback when an import error ocurred. Fix now passes correctly
     the context to the user.

--- a/changelogs/fragments/1091-Update_undocumented_argument_and_import_exception.yml
+++ b/changelogs/fragments/1091-Update_undocumented_argument_and_import_exception.yml
@@ -1,0 +1,10 @@
+trivial:
+  - zos_job_submit - The module handling ZOAU import errors obscured the
+    original traceback when an import error ocurred. Fix now passes correctly
+    the context to the user.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1091).
+
+  - zos_job_submit - The module had undocumented parameter and uses as temporary file
+    when the location of the file is LOCAL. Change now uses the same name as the src
+    for the temporary file removing the addition of tmp_file to the arguments.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1091).

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -142,6 +142,7 @@ class ActionModule(ActionBase):
                     dest=dest_path,
                     mode="0600",
                     force=True,
+                    encoding=module_args.get('encoding'),
                     remote_src=True,
                 )
             )

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -135,7 +135,6 @@ class ActionModule(ActionBase):
             result = {}
             copy_module_args = {}
             module_args = self._task.args.copy()
-            module_args["temp_file"] = dest_path
 
             copy_module_args.update(
                 dict(

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -142,7 +142,6 @@ class ActionModule(ActionBase):
                     dest=dest_path,
                     mode="0600",
                     force=True,
-                    encoding=module_args.get('encoding'),
                     remote_src=True,
                 )
             )

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -890,6 +890,8 @@ def run_module():
     return_output = parsed_args.get("return_output")
     wait_time_s = parsed_args.get("wait_time_s")
     max_rc = parsed_args.get("max_rc")
+    from_encoding = parsed_args.get("from_encoding")
+    to_encoding = parsed_args.get("to_encoding")
     if location == "LOCAL":
         temp_file = parsed_args.get("src")
 

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -620,7 +620,6 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.data_set import (
     DataSet,
 )
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import PY3
 from timeit import default_timer as timer
 from tempfile import NamedTemporaryFile
 from os import remove
@@ -637,12 +636,6 @@ try:
     from zoautil_py import jobs
 except Exception:
     jobs = ZOAUImportError(traceback.format_exc())
-
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
-
 
 JOB_COMPLETION_MESSAGES = frozenset(["CC", "ABEND", "SEC ERROR", "JCL ERROR", "JCLERR"])
 JOB_ERROR_MESSAGES = frozenset(["ABEND", "SEC ERROR", "SEC", "JCL ERROR", "JCLERR"])
@@ -922,32 +915,11 @@ def run_module():
         job_submitted_id, duration = submit_src_jcl(
             module, src, src_name=src, timeout=wait_time_s, hfs=False, volume=volume, start_time=start_time)
     elif location == "USS":
-        job_submitted_id, duration = submit_src_jcl(module, src, src_name=src, timeout=wait_time_s, hfs=True)
+        job_submitted_id, duration = submit_src_jcl(
+            module, src, src_name=src, timeout=wait_time_s, hfs=True)
     else:
-        # added -c to iconv to prevent '\r' from erroring as invalid chars to EBCDIC
-        conv_str = "iconv -c -f {0} -t {1} {2} > {3}".format(
-            from_encoding,
-            to_encoding,
-            quote(temp_file),
-            quote(temp_file_encoded.name),
-        )
-
-        conv_rc, stdout, stderr = module.run_command(
-            conv_str,
-            use_unsafe_shell=True,
-        )
-
-        if conv_rc == 0:
-            job_submitted_id, duration = submit_src_jcl(
-                module, temp_file_encoded.name, src_name=src, timeout=wait_time_s, hfs=True)
-        else:
-            result["failed"] = True
-            result["stdout"] = stdout
-            result["stderr"] = stderr
-            result["msg"] = ("Failed to convert the src {0} from encoding {1} to "
-                             "encoding {2}, unable to submit job."
-                             .format(src, from_encoding, to_encoding))
-            module.fail_json(**result)
+        job_submitted_id, duration = submit_src_jcl(
+            module, temp_file_encoded.name, src_name=src, timeout=wait_time_s, hfs=True)
 
     try:
         # Explictly pass None for the unused args else a default of '*' will be

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -911,9 +911,9 @@ def run_module():
     elif location == "USS":
         job_submitted_id, duration = submit_src_jcl(
             module, src, src_name=src, timeout=wait_time_s, hfs=True)
-    else:
+    elif location == "LOCAL":
         job_submitted_id, duration = submit_src_jcl(
-            module, temp_file, src_name=src, timeout=wait_time_s, hfs=True)
+            module, src, src_name=src, timeout=wait_time_s, hfs=True)
 
     try:
         # Explictly pass None for the unused args else a default of '*' will be
@@ -1002,7 +1002,7 @@ def run_module():
         module.exit_json(**result)
 
     finally:
-        if location == "LOCAL":
+        if temp_file is not None:
             remove(temp_file)
 
     # If max_rc is set, we don't want to default to changed=True, rely on 'is_changed'

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -890,8 +890,7 @@ def run_module():
     return_output = parsed_args.get("return_output")
     wait_time_s = parsed_args.get("wait_time_s")
     max_rc = parsed_args.get("max_rc")
-    if location == "LOCAL":
-        temp_file = parsed_args.get("src")
+    temp_file = parsed_args.get("src") if location == "LOCAL" else None
 
     # Default 'changed' is False in case the module is not able to execute
     result = dict(changed=False)

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -621,7 +621,6 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.data_set import (
 )
 from ansible.module_utils.basic import AnsibleModule
 from timeit import default_timer as timer
-from tempfile import NamedTemporaryFile
 from os import remove
 import traceback
 from time import sleep

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -890,8 +890,6 @@ def run_module():
     return_output = parsed_args.get("return_output")
     wait_time_s = parsed_args.get("wait_time_s")
     max_rc = parsed_args.get("max_rc")
-    from_encoding = parsed_args.get("from_encoding")
-    to_encoding = parsed_args.get("to_encoding")
     if location == "LOCAL":
         temp_file = parsed_args.get("src")
 

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -343,6 +343,7 @@ def test_job_submit_LOCAL(ansible_zos_module):
     results = hosts.all.zos_job_submit(src=tmp_file.name, location="LOCAL", wait=True)
 
     for result in results.contacted.values():
+        print(result)
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
         assert result.get("jobs")[0].get("ret_code").get("code") == 0
         assert result.get("changed") is True

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -343,7 +343,6 @@ def test_job_submit_LOCAL(ansible_zos_module):
     results = hosts.all.zos_job_submit(src=tmp_file.name, location="LOCAL", wait=True)
 
     for result in results.contacted.values():
-        print(result)
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
         assert result.get("jobs")[0].get("ret_code").get("code") == 0
         assert result.get("changed") is True

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -17,9 +17,6 @@ plugins/modules/zos_find.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/zos_job_output.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_query.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_submit.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/zos_job_submit.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
-plugins/modules/zos_job_submit.py validate-modules:undocumented-parameter # Passing args from action plugin
-plugins/modules/zos_job_submit.py pylint:catching-non-exception # False positive, Exception is inherited
 plugins/modules/zos_lineinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_mount.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_mvs_raw.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -17,9 +17,6 @@ plugins/modules/zos_find.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/zos_job_output.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_query.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_submit.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/zos_job_submit.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
-plugins/modules/zos_job_submit.py validate-modules:undocumented-parameter # Passing args from action plugin
-plugins/modules/zos_job_submit.py pylint:catching-non-exception # False positive, Exception is inherited
 plugins/modules/zos_lineinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_mount.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_mvs_raw.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -17,9 +17,6 @@ plugins/modules/zos_find.py validate-modules:missing-gplv3-license # Licensed un
 plugins/modules/zos_job_output.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_query.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_submit.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/zos_job_submit.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
-plugins/modules/zos_job_submit.py validate-modules:undocumented-parameter # Passing args from action plugin
-plugins/modules/zos_job_submit.py pylint:catching-non-exception # False positive, Exception is inherited
 plugins/modules/zos_lineinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_mount.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_mvs_raw.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0


### PR DESCRIPTION
##### SUMMARY
Update temp_path and how to import exceptions.

Fiexes #997 #998 #999 

##### ISSUE TYPE
- Sanity Issue Pull Request

##### ADDITIONAL INFORMATION
Remove tmp path from options and only work with source as name of tmp file, because it was undocumented argument for ansible and could be any name, also only in case is local make the tmp file, so didn't expect a dataset or file with the same name on the system. Also make a implementation of imports of exceptions by using new implementation to avoid losing context when an import fails.

Pipeline Without Zos_copy
<img width="1097" alt="Captura de pantalla 2023-12-12 a la(s) 4 08 41 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/66d7ae6f-afaf-402f-8dbc-0ec11a367e3f">
<img width="572" alt="Captura de pantalla 2023-12-12 a la(s) 4 09 21 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/7d927c06-1fb4-4449-acfd-323d5b936adc">


Pipeline with zos_copy
