### PR TITLE
[Enabler][zos_copy]Refactor calls to use new alias and execute options

### DIFF
--- a/changelogs/fragments/1163-Refactor_calls_to_use_new_alias_and_execute_options.yml
+++ b/changelogs/fragments/1163-Refactor_calls_to_use_new_alias_and_execute_options.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_copy - Change call to ZOAU python API by using a dictionary to arguments.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1163).

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1548,7 +1548,7 @@ class USSCopyHandler(CopyHandler):
                 if self.asa_text:
                     response = copy.copy_asa_mvs2uss(src, dest)
                 elif self.executable:
-                    response = datasets._copy(src, dest, alias=self.aliases, executable=self.executable)
+                    response = datasets._copy(src, dest, alias=True, executable=True)
                 else:
                     response = datasets._copy(src, dest)
 
@@ -1561,7 +1561,7 @@ class USSCopyHandler(CopyHandler):
                     )
             else:
                 if self.executable:
-                    response = datasets._copy(src, dest, None, alias=self.aliases, executable=self.executable)
+                    response = datasets._copy(src, dest, None, alias=True, executable=True)
 
                     if response.rc != 0:
                         raise CopyOperationError(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1545,12 +1545,15 @@ class USSCopyHandler(CopyHandler):
 
         opts = dict()
 
+        if self.executable:
+            opts["options"] = "-IX"
+
         try:
             if src_member or src_ds_type in data_set.DataSet.MVS_SEQ:
                 if self.asa_text:
                     response = copy.copy_asa_mvs2uss(src, dest)
                 elif self.executable:
-                    response = datasets._copy(src, dest, alias=True, executable=self.executable, **opts)
+                    response = datasets._copy(src, dest, None, **opts)
                 else:
                     response = datasets._copy(src, dest)
 

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1543,17 +1543,12 @@ class USSCopyHandler(CopyHandler):
                 except FileExistsError:
                     pass
 
-        opts = dict()
-
-        if self.executable:
-            opts["options"] = "-IX"
-
         try:
             if src_member or src_ds_type in data_set.DataSet.MVS_SEQ:
                 if self.asa_text:
                     response = copy.copy_asa_mvs2uss(src, dest)
                 elif self.executable:
-                    response = datasets._copy(src, dest, None, **opts)
+                    response = datasets._copy(src, dest, alias=self.aliases, executable=self.executable)
                 else:
                     response = datasets._copy(src, dest)
 
@@ -1566,7 +1561,7 @@ class USSCopyHandler(CopyHandler):
                     )
             else:
                 if self.executable:
-                    response = datasets._copy(src, dest, None, **opts)
+                    response = datasets._copy(src, dest, None, alias=self.aliases, executable=self.executable)
 
                     if response.rc != 0:
                         raise CopyOperationError(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1544,15 +1544,13 @@ class USSCopyHandler(CopyHandler):
                     pass
 
         opts = dict()
-        if self.executable:
-            opts["options"] = "-IX "
 
         try:
             if src_member or src_ds_type in data_set.DataSet.MVS_SEQ:
                 if self.asa_text:
                     response = copy.copy_asa_mvs2uss(src, dest)
                 elif self.executable:
-                    response = datasets._copy(src, dest, None, **opts)
+                    response = datasets._copy(src, dest, alias=True, executable=self.executable, **opts)
                 else:
                     response = datasets._copy(src, dest)
 
@@ -1770,19 +1768,10 @@ class PDSECopyHandler(CopyHandler):
             if self.is_binary or self.asa_text:
                 opts["options"] = "-B"
 
-            if self.aliases and not self.executable:
-                # lower case 'i' for text-based copy (dcp)
-                opts["options"] = "-i"
-
-            if self.executable:
-                opts["options"] = "-X"
-                if self.aliases:
-                    opts["options"] = "-IX"
-
             if self.force_lock:
                 opts["options"] += " -f"
 
-            response = datasets._copy(src, dest, None, **opts)
+            response = datasets._copy(src, dest, alias=self.aliases, executable=self.executable, **opts)
         rc, out, err = response.rc, response.stdout_response, response.stderr_response
 
         return dict(

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3694,7 +3694,7 @@ def test_copy_pds_loadlib_to_uss_to_pds_loadlib(ansible_zos_module):
         )
         # copy USS dir to dest library pds w aliases
         copy_res_aliases = hosts.all.zos_copy(
-            src="{0}{1}".format(uss_dir_path, src_lib.upper()),
+            src="{0}/{1}".format(uss_dir_path, src_lib.upper()),
             dest="{0}".format(dest_lib_aliases),
             remote_src=True,
             executable=True,

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3550,8 +3550,13 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
             assert v_cp.get("rc") == 0
             stdout = v_cp.get("stdout")
             assert stdout is not None
-            # number of members
-            assert len(stdout.splitlines()) == 2
+        # verify pgms remain executable
+        pgm_output_map = {
+            (dest_lib, pgm_mem, COBOL_PRINT_STR),
+            (dest_lib, pgm2_mem, COBOL_PRINT_STR2),
+        }
+        for steplib, pgm, output in pgm_output_map:
+            validate_loadlib_pgm(hosts, steplib=steplib, pgm_name=pgm, expected_output_str=output)
 
     finally:
         hosts.all.zos_data_set(name=cobol_src_pds, state="absent")


### PR DESCRIPTION
##### SUMMARY
Refactor call of dataset._copy module to avoid dictionaries and change for options for executable and aliases.

Fixes #944 

##### ISSUE TYPE
- Enable Pull Request

##### ADDITIONAL INFORMATION
Change the 3 calls of dataset.copy from option -IX to aliases=True/False and executable=True/False
(https://ibm.box.com/s/yqfis1sgb2e38moo2knx52go0x86oo2n)
