### PR TITLE
[v1.9.0] [zos_copy] Enhancement/764/copy members

### DIFF
--- a/changelogs/fragments/1176-copy-members.yml
+++ b/changelogs/fragments/1176-copy-members.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zos_copy - Improve zos_copy performance when copying multiple members from one PDS/E to another.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1176).

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -57,9 +57,10 @@ class ActionModule(ActionBase):
             source = self._task.args.get("src", None)
 
             # Get a temporary file on the managed node
-            dest_path = self._execute_module(
+            tempfile = self._execute_module(
                 module_name="tempfile", module_args={}, task_vars=task_vars,
-            ).get("path")
+            )
+            dest_path = tempfile.get("path")
             # Calling execute_module from this step with tempfile leaves behind a tmpdir.
             # This is called to ensure the proper removal.
             tmpdir = self._connection._shell.tmpdir

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -283,8 +283,8 @@ options:
       - If C(src) is a directory and ends with "/", the contents of it will be copied
         into the root of C(dest). If it doesn't end with "/", the directory itself
         will be copied.
-      - If src is USS, file names will be truncated and/or modified to ensure a valid
-        name for a data set or member.
+      - If C(src) is a directory or file, file names will be truncated and/or modified
+        to ensure a valid name for a data set or member.
       - If C(src) is a VSAM data set, C(dest) must also be a VSAM.
       - Wildcards can be used to copy multiple PDS/PDSE members to another
         PDS/PDSE.

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1737,11 +1737,18 @@ class PDSECopyHandler(CopyHandler):
             #         overwritten_members=overwritten_members,
             #         new_members=new_members
             #     )
-        result = self.copy_to_member(
-            bulk_src_members,
-            dest,
-            src_ds_type
-        )
+        if len(src_members) > 1:
+            result = self.copy_to_member(
+                bulk_src_members,
+                dest,
+                src_ds_type
+            )
+        else:
+            result = self.copy_to_member(
+                src_member,
+                "{0}({1})".format(dest, destination_member),
+                src_ds_type
+            )
 
         if result["rc"] != 0:
             msg = "Unable to copy source {0} to data set member {1}({2})".format(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -283,6 +283,8 @@ options:
       - If C(src) is a directory and ends with "/", the contents of it will be copied
         into the root of C(dest). If it doesn't end with "/", the directory itself
         will be copied.
+      - If src is USS, file names will be truncated and/or modified to ensure a valid
+        name for a data set or member.
       - If C(src) is a VSAM data set, C(dest) must also be a VSAM.
       - Wildcards can be used to copy multiple PDS/PDSE members to another
         PDS/PDSE.

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1710,22 +1710,28 @@ class PDSECopyHandler(CopyHandler):
         overwritten_members = []
         new_members = []
         bulk_src_members = ""
+        result = dict()
 
         for src_member, destination_member in zip(src_members, dest_members):
             if destination_member in existing_members:
                 overwritten_members.append(destination_member)
             else:
                 new_members.append(destination_member)
+            bulk_src_members += "{0} ".format(src_member)
 
-            if src_ds_type == "USS":
+        """
+        Copy section:
+        USS -> MVS
+        MVS -> MVS (Except when ASA is True)
+        """
+        if src_ds_type == "USS" or self.asa_text:
+            for src_member, destination_member in zip(src_members, dest_members):
                 result = self.copy_to_member(
                     src_member,
                     "{0}({1})".format(dest, destination_member),
                     src_ds_type
                 )
-            bulk_src_members += "{0} ".format(src_member)
-
-        if src_ds_type != "USS":
+        else:
             if len(src_members) == 1:
                 destination = "{0}({1})".format(dest, destination_member)
                 source = src_member
@@ -1735,11 +1741,11 @@ class PDSECopyHandler(CopyHandler):
                 """
                 destination = dest
                 source = bulk_src_members
-                result = self.copy_to_member(
-                    source,
-                    destination,
-                    src_ds_type
-                )
+            result = self.copy_to_member(
+                source,
+                destination,
+                src_ds_type
+            )
 
         if result["rc"] != 0:
             msg = "Unable to copy source {0} to {1}. members : {2} destination: {3}".format(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1727,16 +1727,20 @@ class PDSECopyHandler(CopyHandler):
                     "{0}({1})".format(dest, destination_member),
                     src_ds_type
                 )
+                operation = "individual member copy"
         else:
             if len(src_members) == 1:
                 destination = "{0}({1})".format(dest, destination_member)
                 source = src_member
-            else:
+                operation = "single member copy"
+            elif len(src_members) > 1:
                 """
-                This means we have to copy more than one member at a time
+                This means we have to copy more than one member at a time,
+                if src_members is 0, then is copy a pds/pdse to a pdse
                 """
                 destination = dest
                 source = bulk_src_members
+                operation = "bulk copy"
             result = self.copy_to_member(
                 source,
                 destination,
@@ -1744,12 +1748,13 @@ class PDSECopyHandler(CopyHandler):
             )
 
         if result["rc"] != 0:
-            msg = "Unable to copy source {0} to {1}. members : {2} destination: {3} src_ds_type: {4}".format(
+            msg = "Unable to copy source {0} to {1}. members : {2} dest_members: {3} src_ds_type: {4}, oper: {5}".format(
                 new_src,
                 destination,
                 source,
                 dest_members,
-                src_ds_type
+                src_ds_type,
+                operation
             )
             raise CopyOperationError(
                 msg=msg,

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1716,27 +1716,37 @@ class PDSECopyHandler(CopyHandler):
                 overwritten_members.append(destination_member)
             else:
                 new_members.append(destination_member)
+
+            if src_ds_type == "USS":
+                result = self.copy_to_member(
+                src_member,
+                "{0}({1})".format(dest, destination_member),
+                src_ds_type
+                )
             bulk_src_members += "{0} ".format(src_member)
 
-        if len(src_members) == 1:
-            destination = "{0}({1})".format(dest, destination_member)
-            source = src_member
-        else:
-            """
-            This means we have to copy more than one member at a time
-            """
-            destination = dest
-            source = bulk_src_members
-        result = self.copy_to_member(
-            source,
-            destination,
-            src_ds_type
-        )
+        if src_ds_type != "USS":
+            if len(src_members) == 1:
+                destination = "{0}({1})".format(dest, destination_member)
+                source = src_member
+            else:
+                """
+                This means we have to copy more than one member at a time
+                """
+                destination = dest
+                source = bulk_src_members
+                result = self.copy_to_member(
+                    source,
+                    destination,
+                    src_ds_type
+                )
 
         if result["rc"] != 0:
-            msg = "Unable to copy source {0} to {1}".format(
+            msg = "Unable to copy source {0} to {1}. members : {2} destination: {3}".format(
                 new_src,
-                destination
+                destination,
+                source,
+                dest_members
             )
             raise CopyOperationError(
                 msg=msg,

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1709,33 +1709,54 @@ class PDSECopyHandler(CopyHandler):
         existing_members = datasets.list_members(dest)  # fyi - this list includes aliases
         overwritten_members = []
         new_members = []
+        bulk_src_members = ""
 
         for src_member, destination_member in zip(src_members, dest_members):
             if destination_member in existing_members:
                 overwritten_members.append(destination_member)
             else:
                 new_members.append(destination_member)
+            bulk_src_members += "{0} ".format(src_member)
+            # result = self.copy_to_member(
+            #     src_member,
+            #     "{0}({1})".format(dest, destination_member),
+            #     src_ds_type
+            # )
 
-            result = self.copy_to_member(
-                src_member,
-                "{0}({1})".format(dest, destination_member),
-                src_ds_type
+            # if result["rc"] != 0:
+            #     msg = "Unable to copy source {0} to data set member {1}({2})".format(
+            #         new_src,
+            #         dest,
+            #         destination_member
+            #     )
+            #     raise CopyOperationError(
+            #         msg=msg,
+            #         rc=result["rc"],
+            #         stdout=result["out"],
+            #         stderr=result["err"],
+            #         overwritten_members=overwritten_members,
+            #         new_members=new_members
+            #     )
+        result = self.copy_to_member(
+            bulk_src_members,
+            dest,
+            src_ds_type
+        )
+
+        if result["rc"] != 0:
+            msg = "Unable to copy source {0} to data set member {1}({2})".format(
+                new_src,
+                dest,
+                destination_member
             )
-
-            if result["rc"] != 0:
-                msg = "Unable to copy source {0} to data set member {1}({2})".format(
-                    new_src,
-                    dest,
-                    destination_member
-                )
-                raise CopyOperationError(
-                    msg=msg,
-                    rc=result["rc"],
-                    stdout=result["out"],
-                    stderr=result["err"],
-                    overwritten_members=overwritten_members,
-                    new_members=new_members
-                )
+            raise CopyOperationError(
+                msg=msg,
+                rc=result["rc"],
+                stdout=result["out"],
+                stderr=result["err"],
+                overwritten_members=overwritten_members,
+                new_members=new_members
+            )
 
     def copy_to_member(
         self,

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1717,44 +1717,26 @@ class PDSECopyHandler(CopyHandler):
             else:
                 new_members.append(destination_member)
             bulk_src_members += "{0} ".format(src_member)
-            # result = self.copy_to_member(
-            #     src_member,
-            #     "{0}({1})".format(dest, destination_member),
-            #     src_ds_type
-            # )
 
-            # if result["rc"] != 0:
-            #     msg = "Unable to copy source {0} to data set member {1}({2})".format(
-            #         new_src,
-            #         dest,
-            #         destination_member
-            #     )
-            #     raise CopyOperationError(
-            #         msg=msg,
-            #         rc=result["rc"],
-            #         stdout=result["out"],
-            #         stderr=result["err"],
-            #         overwritten_members=overwritten_members,
-            #         new_members=new_members
-            #     )
-        if len(src_members) > 1:
-            result = self.copy_to_member(
-                bulk_src_members,
-                dest,
-                src_ds_type
-            )
+        if len(src_members) == 1:
+            destination = "{0}({1})".format(dest, destination_member)
+            source = src_member
         else:
-            result = self.copy_to_member(
-                src_member,
-                "{0}({1})".format(dest, destination_member),
-                src_ds_type
-            )
+            """
+            This means we have to copy more than one member at a time
+            """
+            destination = dest
+            source = bulk_src_members
+        result = self.copy_to_member(
+            source,
+            destination,
+            src_ds_type
+        )
 
         if result["rc"] != 0:
-            msg = "Unable to copy source {0} to data set member {1}({2})".format(
+            msg = "Unable to copy source {0} to {1}".format(
                 new_src,
-                dest,
-                destination_member
+                destination
             )
             raise CopyOperationError(
                 msg=msg,

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1716,7 +1716,7 @@ class PDSECopyHandler(CopyHandler):
             bulk_src_members += "{0} ".format(src_member)
 
         # Copy section
-        if src_ds_type == "USS" or self.asa_text:
+        if src_ds_type == "USS" or self.asa_text or len(src_members) == 1:
             """
             USS -> MVS : Was kept on member by member basis bc file names longer that 8
             characters will throw an error when copying to a PDS, because of the member name

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1744,11 +1744,12 @@ class PDSECopyHandler(CopyHandler):
             )
 
         if result["rc"] != 0:
-            msg = "Unable to copy source {0} to {1}. members : {2} destination: {3}".format(
+            msg = "Unable to copy source {0} to {1}. members : {2} destination: {3} src_ds_type: {4}".format(
                 new_src,
                 destination,
                 source,
-                dest_members
+                dest_members,
+                src_ds_type
             )
             raise CopyOperationError(
                 msg=msg,

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -283,7 +283,7 @@ options:
       - If C(src) is a directory and ends with "/", the contents of it will be copied
         into the root of C(dest). If it doesn't end with "/", the directory itself
         will be copied.
-      - If C(src) is a directory or file, file names will be truncated and/or modified
+      - If C(src) is a directory or a file, file names will be truncated and/or modified
         to ensure a valid name for a data set or member.
       - If C(src) is a VSAM data set, C(dest) must also be a VSAM.
       - Wildcards can be used to copy multiple PDS/PDSE members to another

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1719,9 +1719,9 @@ class PDSECopyHandler(CopyHandler):
 
             if src_ds_type == "USS":
                 result = self.copy_to_member(
-                src_member,
-                "{0}({1})".format(dest, destination_member),
-                src_ds_type
+                    src_member,
+                    "{0}({1})".format(dest, destination_member),
+                    src_ds_type
                 )
             bulk_src_members += "{0} ".format(src_member)
 

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1971,8 +1971,8 @@ def test_copy_dest_lock(ansible_zos_module, ds_type):
         dest_data_set = DATASET_2
     try:
         hosts = ansible_zos_module
-        hosts.all.zos_data_set(name=DATASET_1, state="present", type="pdse", replace=True)
-        hosts.all.zos_data_set(name=DATASET_2, state="present", type="pdse", replace=True)
+        hosts.all.zos_data_set(name=DATASET_1, state="present", type=ds_type, replace=True)
+        hosts.all.zos_data_set(name=DATASET_2, state="present", type=ds_type, replace=True)
         if ds_type == "PDS" or ds_type == "PDSE":
             hosts.all.zos_data_set(name=src_data_set, state="present", type="member", replace=True)
             hosts.all.zos_data_set(name=dest_data_set, state="present", type="member", replace=True)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1958,7 +1958,7 @@ def test_ensure_copy_file_does_not_change_permission_on_dest(ansible_zos_module,
 
 
 @pytest.mark.seq
-@pytest.mark.parametrize("ds_type", ["PDS", "PDSE", "SEQ"])
+@pytest.mark.parametrize("ds_type", [ "PDS", "PDSE", "SEQ"])
 def test_copy_dest_lock(ansible_zos_module, ds_type):
     DATASET_1 = "USER.PRIVATE.TESTDS"
     DATASET_2 = "ADMI.PRIVATE.TESTDS"

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -112,7 +112,9 @@ ASA_COPY_CONTENT = """  Space, do not advance.
 
 # SHELL_EXECUTABLE = "/usr/lpp/rsusr/ported/bin/bash"
 SHELL_EXECUTABLE = "/bin/sh"
-TEST_PS = "USER.PRIVATE.TESTSRC"
+TEST_PS = "IMSTESTL.IMS01.DDCHKPT"
+TEST_PDS = "IMSTESTL.COMNUC"
+TEST_PDS_MEMBER = "IMSTESTL.COMNUC(ATRQUERY)"
 TEST_VSAM = "IMSTESTL.LDS01.WADS2"
 TEST_VSAM_KSDS = "SYS1.STGINDEX"
 TEST_PDSE = "SYS1.NFSLIBE"
@@ -1969,8 +1971,8 @@ def test_copy_dest_lock(ansible_zos_module, ds_type):
         dest_data_set = DATASET_2
     try:
         hosts = ansible_zos_module
-        hosts.all.zos_data_set(name=DATASET_1, state="present", type=ds_type, replace=True)
-        hosts.all.zos_data_set(name=DATASET_2, state="present", type=ds_type, replace=True)
+        hosts.all.zos_data_set(name=DATASET_1, state="present", type="pdse", replace=True)
+        hosts.all.zos_data_set(name=DATASET_2, state="present", type="pdse", replace=True)
         if ds_type == "PDS" or ds_type == "PDSE":
             hosts.all.zos_data_set(name=src_data_set, state="present", type="member", replace=True)
             hosts.all.zos_data_set(name=dest_data_set, state="present", type="member", replace=True)
@@ -2314,8 +2316,6 @@ def test_copy_ps_to_non_existing_uss_file(ansible_zos_module):
     dest = "/tmp/ddchkpt"
 
     try:
-        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
-        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
         stat_res = hosts.all.stat(path=dest)
         verify_copy = hosts.all.shell(
@@ -2333,7 +2333,6 @@ def test_copy_ps_to_non_existing_uss_file(ansible_zos_module):
             assert result.get("stdout") != ""
     finally:
         hosts.all.file(path=dest, state="absent")
-        hosts.all.file(path=src_ds, state="absent")
 
 
 @pytest.mark.uss
@@ -2346,8 +2345,6 @@ def test_copy_ps_to_existing_uss_file(ansible_zos_module, force):
 
     try:
         hosts.all.file(path=dest, state="touch")
-        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
-        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
 
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True, force=force)
         stat_res = hosts.all.stat(path=dest)
@@ -2369,7 +2366,6 @@ def test_copy_ps_to_existing_uss_file(ansible_zos_module, force):
             assert result.get("rc") == 0
     finally:
         hosts.all.file(path=dest, state="absent")
-        hosts.all.file(path=src_ds, state="absent")
 
 
 @pytest.mark.uss
@@ -2382,8 +2378,6 @@ def test_copy_ps_to_existing_uss_dir(ansible_zos_module):
 
     try:
         hosts.all.file(path=dest, state="directory")
-        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
-        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
         stat_res = hosts.all.stat(path=dest_path)
         verify_copy = hosts.all.shell(
@@ -2400,7 +2394,6 @@ def test_copy_ps_to_existing_uss_dir(ansible_zos_module):
             assert result.get("stdout") != ""
     finally:
         hosts.all.file(path=dest, state="absent")
-        hosts.all.file(path=src_ds, state="absent")
 
 
 @pytest.mark.seq
@@ -2411,8 +2404,6 @@ def test_copy_ps_to_non_existing_ps(ansible_zos_module):
 
     try:
         hosts.all.zos_data_set(name=dest, state="absent")
-        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
-        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
         verify_copy = hosts.all.shell(
             cmd="cat \"//'{0}'\"".format(dest), executable=SHELL_EXECUTABLE
@@ -2428,7 +2419,6 @@ def test_copy_ps_to_non_existing_ps(ansible_zos_module):
             assert result.get("stdout") != ""
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
-        hosts.all.zos_data_set(name=src_ds, state="absent")
 
 
 @pytest.mark.seq
@@ -2440,9 +2430,6 @@ def test_copy_ps_to_empty_ps(ansible_zos_module, force):
 
     try:
         hosts.all.zos_data_set(name=dest, type="seq", state="present")
-
-        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
-        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
 
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True, force=force)
         verify_copy = hosts.all.shell(
@@ -2471,9 +2458,6 @@ def test_copy_ps_to_non_empty_ps(ansible_zos_module, force):
         hosts.all.zos_data_set(name=dest, type="seq", state="absent")
         hosts.all.zos_copy(content="Inline content", dest=dest)
 
-        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
-        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
-
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True, force=force)
         verify_copy = hosts.all.shell(
             cmd="cat \"//'{0}'\"".format(dest), executable=SHELL_EXECUTABLE
@@ -2492,7 +2476,6 @@ def test_copy_ps_to_non_empty_ps(ansible_zos_module, force):
             assert result.get("stdout") != ""
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
-        hosts.all.zos_data_set(name=src_ds, state="absent")
 
 
 @pytest.mark.seq
@@ -2506,9 +2489,6 @@ def test_copy_ps_to_non_empty_ps_with_special_chars(ansible_zos_module, force):
         hosts.all.zos_data_set(name=dest, type="seq", state="absent")
         hosts.all.zos_copy(content=DUMMY_DATA_SPECIAL_CHARS, dest=dest)
 
-        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
-        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA_SPECIAL_CHARS, src_ds))
-
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True, force=force)
         verify_copy = hosts.all.shell(
             cmd="cat \"//'{0}'\"".format(dest), executable=SHELL_EXECUTABLE
@@ -2527,7 +2507,6 @@ def test_copy_ps_to_non_empty_ps_with_special_chars(ansible_zos_module, force):
             assert result.get("stdout") != ""
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
-        hosts.all.zos_data_set(name=src_ds, type="seq", state="absent")
 
 
 @pytest.mark.seq
@@ -3571,8 +3550,13 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
             assert v_cp.get("rc") == 0
             stdout = v_cp.get("stdout")
             assert stdout is not None
-            # number of members
-            assert len(stdout.splitlines()) == 2
+        # verify pgms remain executable
+        pgm_output_map = {
+            (dest_lib, pgm_mem, COBOL_PRINT_STR),
+            (dest_lib, pgm2_mem, COBOL_PRINT_STR2),
+        }
+        for steplib, pgm, output in pgm_output_map:
+            validate_loadlib_pgm(hosts, steplib=steplib, pgm_name=pgm, expected_output_str=output)
 
     finally:
         hosts.all.zos_data_set(name=cobol_src_pds, state="absent")

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020, 2021, 2023
+# Copyright (c) IBM Corporation 2020 - 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -4323,9 +4323,10 @@ def test_copy_data_set_to_volume(ansible_zos_module, src_type):
     hosts = ansible_zos_module
     source = "USER.TEST.FUNCTEST.SRC"
     dest = "USER.TEST.FUNCTEST.DEST"
-
+    source_member = "USER.TEST.FUNCTEST.SRC(MEMBER)"
     try:
         hosts.all.zos_data_set(name=source, type=src_type, state='present')
+        hosts.all.zos_data_set(name=source_member, type="member", state='present')
         copy_res = hosts.all.zos_copy(
             src=source,
             dest=dest,

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -112,9 +112,7 @@ ASA_COPY_CONTENT = """  Space, do not advance.
 
 # SHELL_EXECUTABLE = "/usr/lpp/rsusr/ported/bin/bash"
 SHELL_EXECUTABLE = "/bin/sh"
-TEST_PS = "IMSTESTL.IMS01.DDCHKPT"
-TEST_PDS = "IMSTESTL.COMNUC"
-TEST_PDS_MEMBER = "IMSTESTL.COMNUC(ATRQUERY)"
+TEST_PS = "USER.PRIVATE.TESTSRC"
 TEST_VSAM = "IMSTESTL.LDS01.WADS2"
 TEST_VSAM_KSDS = "SYS1.STGINDEX"
 TEST_PDSE = "SYS1.NFSLIBE"
@@ -2316,6 +2314,8 @@ def test_copy_ps_to_non_existing_uss_file(ansible_zos_module):
     dest = "/tmp/ddchkpt"
 
     try:
+        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
+        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
         stat_res = hosts.all.stat(path=dest)
         verify_copy = hosts.all.shell(
@@ -2333,6 +2333,7 @@ def test_copy_ps_to_non_existing_uss_file(ansible_zos_module):
             assert result.get("stdout") != ""
     finally:
         hosts.all.file(path=dest, state="absent")
+        hosts.all.file(path=src_ds, state="absent")
 
 
 @pytest.mark.uss
@@ -2345,6 +2346,8 @@ def test_copy_ps_to_existing_uss_file(ansible_zos_module, force):
 
     try:
         hosts.all.file(path=dest, state="touch")
+        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
+        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
 
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True, force=force)
         stat_res = hosts.all.stat(path=dest)
@@ -2366,6 +2369,7 @@ def test_copy_ps_to_existing_uss_file(ansible_zos_module, force):
             assert result.get("rc") == 0
     finally:
         hosts.all.file(path=dest, state="absent")
+        hosts.all.file(path=src_ds, state="absent")
 
 
 @pytest.mark.uss
@@ -2378,6 +2382,8 @@ def test_copy_ps_to_existing_uss_dir(ansible_zos_module):
 
     try:
         hosts.all.file(path=dest, state="directory")
+        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
+        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
         stat_res = hosts.all.stat(path=dest_path)
         verify_copy = hosts.all.shell(
@@ -2394,6 +2400,7 @@ def test_copy_ps_to_existing_uss_dir(ansible_zos_module):
             assert result.get("stdout") != ""
     finally:
         hosts.all.file(path=dest, state="absent")
+        hosts.all.file(path=src_ds, state="absent")
 
 
 @pytest.mark.seq
@@ -2404,6 +2411,8 @@ def test_copy_ps_to_non_existing_ps(ansible_zos_module):
 
     try:
         hosts.all.zos_data_set(name=dest, state="absent")
+        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
+        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
         verify_copy = hosts.all.shell(
             cmd="cat \"//'{0}'\"".format(dest), executable=SHELL_EXECUTABLE
@@ -2419,6 +2428,7 @@ def test_copy_ps_to_non_existing_ps(ansible_zos_module):
             assert result.get("stdout") != ""
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
+        hosts.all.zos_data_set(name=src_ds, state="absent")
 
 
 @pytest.mark.seq
@@ -2430,6 +2440,9 @@ def test_copy_ps_to_empty_ps(ansible_zos_module, force):
 
     try:
         hosts.all.zos_data_set(name=dest, type="seq", state="present")
+
+        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
+        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
 
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True, force=force)
         verify_copy = hosts.all.shell(
@@ -2458,6 +2471,9 @@ def test_copy_ps_to_non_empty_ps(ansible_zos_module, force):
         hosts.all.zos_data_set(name=dest, type="seq", state="absent")
         hosts.all.zos_copy(content="Inline content", dest=dest)
 
+        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
+        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA, src_ds))
+
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True, force=force)
         verify_copy = hosts.all.shell(
             cmd="cat \"//'{0}'\"".format(dest), executable=SHELL_EXECUTABLE
@@ -2476,6 +2492,7 @@ def test_copy_ps_to_non_empty_ps(ansible_zos_module, force):
             assert result.get("stdout") != ""
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
+        hosts.all.zos_data_set(name=src_ds, state="absent")
 
 
 @pytest.mark.seq
@@ -2489,6 +2506,9 @@ def test_copy_ps_to_non_empty_ps_with_special_chars(ansible_zos_module, force):
         hosts.all.zos_data_set(name=dest, type="seq", state="absent")
         hosts.all.zos_copy(content=DUMMY_DATA_SPECIAL_CHARS, dest=dest)
 
+        hosts.all.zos_data_set(name=src_ds, type="seq", state="present", replace=True)
+        hosts.all.shell(cmd="decho \"{0}\" {1}".format(DUMMY_DATA_SPECIAL_CHARS, src_ds))
+
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True, force=force)
         verify_copy = hosts.all.shell(
             cmd="cat \"//'{0}'\"".format(dest), executable=SHELL_EXECUTABLE
@@ -2507,6 +2527,7 @@ def test_copy_ps_to_non_empty_ps_with_special_chars(ansible_zos_module, force):
             assert result.get("stdout") != ""
     finally:
         hosts.all.zos_data_set(name=dest, state="absent")
+        hosts.all.zos_data_set(name=src_ds, type="seq", state="absent")
 
 
 @pytest.mark.seq


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Improved the performance of copying a PDS/PDSE with multiple members into another PDS/PDSE by providing the complete list of members to copy to datasets._copy zoau call.

This is some performance numbers comparing current dev copy as "old copy" and proposed solution as "new copy"

Testing copy with 30 members

old copy 474.17s, 339.17s, 310.62s, 607.13s
new copy 35.75s, 55.13s, 45.11, 51.61s

Testing copy with 100 members

old copy 1275.75s (21 mins), 1400.44s(23 mins)

new copy 47.15s, 115.71s

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

Also corrected a couple of false positives in the test cases section, one was trying to copy an empty PDS into another and was a false positive in the module code. Another, was always creating a PDSE regardless of the type described in the test.

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy