### PR TITLE
[Enabler] [zos_copy] Remove zos_fetch call in loadlib test

### DIFF
--- a/changelogs/fragments/1184-remove-zos-fetch-dep-from-zos-copy.yml
+++ b/changelogs/fragments/1184-remove-zos-fetch-dep-from-zos-copy.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_copy - Remove zos_fetch dependency from zos_copy test cases.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1184).

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3502,18 +3502,19 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
         # string instead of a list.
         remote_host = hosts["options"]["inventory"].replace(",", "")
 
-        tmp_folder =  tempfile.TemporaryDirectory(prefix="tmpfetch")
+        tmp_folder =  tempfile.mkdtemp(prefix="tmpfetch")
+        print(tmp_folder)
         cmd = [
             "scp",
             "-r",
             f"{remote_user}@{remote_host}:{uss_location}",
-            f"{tmp_folder.name}"
+            f"{tmp_folder}"
         ]
         with subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE) as scp_proc:
             result = scp_proc.stdout.read()
             print(result)
 
-        source_path = os.path.join(tmp_folder.name, os.path.basename(uss_location))
+        source_path = os.path.join(tmp_folder, os.path.basename(uss_location))
 
         if not is_created:
             # ensure dest data sets absent for this variation of the test case.

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3444,6 +3444,7 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
     dest_lib = "USER.LOAD.DEST"
     pgm_mem = "HELLO"
     pgm2_mem = "HELLO2"
+    uss_location = "/tmp/loadlib"
 
 
     try:
@@ -3487,11 +3488,33 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
         validate_loadlib_pgm(hosts, steplib=src_lib, pgm_name=pgm_mem, expected_output_str=COBOL_PRINT_STR)
 
         # fetch loadlib into local
-        tmp_folder = tempfile.TemporaryDirectory(prefix="tmpfetch")
-        # fetch loadlib to local
-        fetch_result = hosts.all.zos_fetch(src=src_lib, dest=tmp_folder.name, is_binary=True)
-        for res in fetch_result.contacted.values():
-            source_path = res.get("dest")
+        # Copying the loadlib to USS.
+        hosts.all.file(name=uss_location, state='directory')
+        hosts.all.shell(
+            cmd=f"cp -B \"//'{src_lib}'\" {uss_location}",
+            executable=SHELL_EXECUTABLE
+        )
+
+        # Copying the remote loadlibs in USS to a local dir.
+        # This section ONLY handles ONE host, so if we ever use multiple hosts to
+        # test, we will need to update this code.
+        remote_user = hosts["options"]["user"]
+        # Removing a trailing comma because the framework saves the hosts list as a
+        # string instead of a list.
+        remote_host = hosts["options"]["inventory"].replace(",", "")
+
+        tmp_folder =  tempfile.TemporaryDirectory(prefix="tmpfetch")
+        cmd = [
+            "scp",
+            "-r",
+            f"{remote_user}@{remote_host}:{uss_location}",
+            f"{tmp_folder.name}"
+        ]
+        with subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE) as scp_proc:
+            result = scp_proc.stdout.read()
+            print(result)
+
+        source_path = os.path.join(tmp_folder.name, os.path.basename(uss_location))
 
         if not is_created:
             # ensure dest data sets absent for this variation of the test case.
@@ -3562,6 +3585,7 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
         hosts.all.zos_data_set(name=cobol_src_pds, state="absent")
         hosts.all.zos_data_set(name=src_lib, state="absent")
         hosts.all.zos_data_set(name=dest_lib, state="absent")
+        hosts.all.file(name=uss_location, state="absent")
 
 
 @pytest.mark.pdse

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3434,6 +3434,7 @@ def test_copy_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
 @pytest.mark.aliases
 @pytest.mark.parametrize("is_created", [False, True])
 def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
+    import time
 
     hosts = ansible_zos_module
 
@@ -3532,6 +3533,8 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
                 space_type="M",
                 replace=True
             )
+
+        time.sleep(15)
 
         if not is_created:
             # dest data set does not exist, specify it in dest_dataset param.

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3511,7 +3511,6 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
         ]
         with subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE) as sftp_proc:
             result = sftp_proc.stdout.read()
-            print(result)
 
         source_path = os.path.join(tmp_folder.name, os.path.basename(uss_location))
 

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3434,8 +3434,6 @@ def test_copy_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
 @pytest.mark.aliases
 @pytest.mark.parametrize("is_created", [False, True])
 def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
-    import time
-
     hosts = ansible_zos_module
 
     cobol_src_pds = "USER.COBOL.SRC"
@@ -3492,7 +3490,7 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
         # Copying the loadlib to USS.
         hosts.all.file(name=uss_location, state='directory')
         hosts.all.shell(
-            cmd=f"dcp -XI \"{src_lib}\" {uss_location}",
+            cmd=f"dcp -X -I \"{src_lib}\" {uss_location}",
             executable=SHELL_EXECUTABLE
         )
 
@@ -3533,8 +3531,6 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
                 space_type="M",
                 replace=True
             )
-
-        time.sleep(15)
 
         if not is_created:
             # dest data set does not exist, specify it in dest_dataset param.

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3491,7 +3491,7 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
         # Copying the loadlib to USS.
         hosts.all.file(name=uss_location, state='directory')
         hosts.all.shell(
-            cmd=f"cp -B \"//'{src_lib}'\" {uss_location}",
+            cmd=f"dcp -XI \"{src_lib}\" {uss_location}",
             executable=SHELL_EXECUTABLE
         )
 

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3505,13 +3505,13 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
         tmp_folder =  tempfile.mkdtemp(prefix="tmpfetch")
         print(tmp_folder)
         cmd = [
-            "scp",
+            "sftp",
             "-r",
             f"{remote_user}@{remote_host}:{uss_location}",
             f"{tmp_folder}"
         ]
-        with subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE) as scp_proc:
-            result = scp_proc.stdout.read()
+        with subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE) as sftp_proc:
+            result = sftp_proc.stdout.read()
             print(result)
 
         source_path = os.path.join(tmp_folder, os.path.basename(uss_location))

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3502,19 +3502,18 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
         # string instead of a list.
         remote_host = hosts["options"]["inventory"].replace(",", "")
 
-        tmp_folder =  tempfile.mkdtemp(prefix="tmpfetch")
-        print(tmp_folder)
+        tmp_folder =  tempfile.TemporaryDirectory(prefix="tmpfetch")
         cmd = [
             "sftp",
             "-r",
             f"{remote_user}@{remote_host}:{uss_location}",
-            f"{tmp_folder}"
+            f"{tmp_folder.name}"
         ]
         with subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE) as sftp_proc:
             result = sftp_proc.stdout.read()
             print(result)
 
-        source_path = os.path.join(tmp_folder, os.path.basename(uss_location))
+        source_path = os.path.join(tmp_folder.name, os.path.basename(uss_location))
 
         if not is_created:
             # ensure dest data sets absent for this variation of the test case.
@@ -3582,11 +3581,10 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
             validate_loadlib_pgm(hosts, steplib=steplib, pgm_name=pgm, expected_output_str=output)
 
     finally:
-        pass
-        # hosts.all.zos_data_set(name=cobol_src_pds, state="absent")
-        # hosts.all.zos_data_set(name=src_lib, state="absent")
-        # hosts.all.zos_data_set(name=dest_lib, state="absent")
-        # hosts.all.file(name=uss_location, state="absent")
+        hosts.all.zos_data_set(name=cobol_src_pds, state="absent")
+        hosts.all.zos_data_set(name=src_lib, state="absent")
+        hosts.all.zos_data_set(name=dest_lib, state="absent")
+        hosts.all.file(name=uss_location, state="absent")
 
 
 @pytest.mark.pdse

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3581,10 +3581,11 @@ def test_copy_local_pds_loadlib_to_pds_loadlib(ansible_zos_module, is_created):
             validate_loadlib_pgm(hosts, steplib=steplib, pgm_name=pgm, expected_output_str=output)
 
     finally:
-        hosts.all.zos_data_set(name=cobol_src_pds, state="absent")
-        hosts.all.zos_data_set(name=src_lib, state="absent")
-        hosts.all.zos_data_set(name=dest_lib, state="absent")
-        hosts.all.file(name=uss_location, state="absent")
+        pass
+        # hosts.all.zos_data_set(name=cobol_src_pds, state="absent")
+        # hosts.all.zos_data_set(name=src_lib, state="absent")
+        # hosts.all.zos_data_set(name=dest_lib, state="absent")
+        # hosts.all.file(name=uss_location, state="absent")
 
 
 @pytest.mark.pdse


### PR DESCRIPTION
##### SUMMARY
Fixes #1147.

##### ISSUE TYPE
- Enabler Pull Request

##### COMPONENT NAME
- zos_copy (tests)

##### ADDITIONAL INFORMATION
One of the loadlib tests had a call to zos_fetch, so our dependency finder dictated that every time zos_fetch got updated, we had to run all tests for zos_copy, which takes forever.
This change replaces that call to instead use `scp` to transfer loadlibs to the local filesystem.
