### PR TITLE
[Conftest]Add_prefer_volumes_user

### DIFF
--- a/changelogs/fragments/1195-Add_prefer_volumes_user.yml
+++ b/changelogs/fragments/1195-Add_prefer_volumes_user.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_apf - Add option to the user to decide prefer volumes to run test suite.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1195)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,9 +87,10 @@ def ansible_zos_module(request, z_python_interpreter):
     # Call of the class by the class ls_Volume (volumes.py file) as many times needed
     # one time the array is filled
 @pytest.fixture(scope="session")
-def volumes_on_systems(ansible_zos_module):
+def volumes_on_systems(ansible_zos_module, request):
     """ Call the pytest-ansible plugin to check volumes on the system and work properly a list by session."""
-    list_Volumes = get_volumes(ansible_zos_module)
+    path = request.config.getoption("--zinventory")
+    list_Volumes = get_volumes(ansible_zos_module, path)
     yield list_Volumes
 
 # * We no longer edit sys.modules directly to add zoautil_py mock

--- a/tests/helpers/volumes.py
+++ b/tests/helpers/volumes.py
@@ -17,6 +17,7 @@ __metaclass__ = type
 
 import pytest
 import time
+import yaml
 
 class Volume:
     """ Volume class represents a volume on the z system, it tracks if the volume name
@@ -68,7 +69,7 @@ class Volume_Handler:
         self.volumes =list_volumes
 
 
-def get_volumes(ansible_zos_module):
+def get_volumes(ansible_zos_module, path):
     """Get an array of available volumes"""
     # Using the command d u,dasd,online to fill an array of available volumes with the priority
     # of of actives (A) and storage (STRG) first then online (O) and storage and if is needed, the
@@ -76,10 +77,10 @@ def get_volumes(ansible_zos_module):
     # is a instance of a class to manage the use.
     hosts = ansible_zos_module
     list_volumes = []
-    active_storage = []
     storage_online = []
     flag = False
     iteration = 5
+    prefer_vols = read_test_config(path)
     # The first run of the command d u,dasd,online,,n in the system can conclude with empty data
     # to ensure get volumes is why require not more 5 runs and lastly one second of wait.
     while not flag and iteration > 0:
@@ -98,8 +99,20 @@ def get_volumes(ansible_zos_module):
         if vol_w_info[2] == 'O' and vol_w_info[4] == "STRG/RSDNT":
             storage_online.append(vol_w_info[3])
     # Insert a volumes for the class ls_Volumes to give flag of in_use and correct manage
-    for vol in active_storage:
-        list_volumes.append(vol)
     for vol in storage_online:
         list_volumes.append(vol)
-    return list_volumes
+    if prefer_vols is not None:
+        prefer_vols.extend(list_volumes)
+        return prefer_vols
+    else:
+        return list_volumes
+
+
+def read_test_config(path):
+    p = path
+    with open(p, 'r') as file:
+        config = yaml.safe_load(file)
+    if "VOLUMES" in config.keys():
+        return config["VOLUMES"]
+    else:
+        return []


### PR DESCRIPTION
##### SUMMARY
Add the option to add variable volumes as a list in test config to help avoid some volumes that fail.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Add read test_config to add prefer volumes

##### ADDITIONAL INFORMATION
Use as fixture to call a list of volumes now read also user preference.

<img width="913" alt="Captura de pantalla 2024-01-29 a la(s) 3 40 37 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/73225c41-b3e9-4576-baed-02c771e745f0">

