### PR TITLE
[v1.10.0] [zos_gather_facts] ZOAU 1.3 migration - zos_gather_facts

### DIFF
--- a/changelogs/fragments/1196-zoau-migration-zos_gather_facts.yml
+++ b/changelogs/fragments/1196-zoau-migration-zos_gather_facts.yml
@@ -1,0 +1,4 @@
+trivial:
+  - zos_gather_facts - Update module internally to leverage ZOAU python API
+    for zinfo.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1196).

--- a/plugins/modules/zos_gather_facts.py
+++ b/plugins/modules/zos_gather_facts.py
@@ -230,7 +230,6 @@ def run_module():
 
     gather_subset = module.params['gather_subset']
 
-
     # build out list of strings to pass to zinfo python api.
     # call this whether or not gather_subsets list is empty/valid/etc
     # rely on the helper function to report back errors. Note the function only
@@ -246,14 +245,14 @@ def run_module():
         zinfo_dict = zsystem.zinfo(json=True, facts=facts_list)
     except ValueError:
         err_msg = 'An invalid subset was detected.'
-        module.fail_json(msg = err_msg)
+        module.fail_json(msg=err_msg)
     except Exception as e:
         err_msg = (
             'An exception has occurred in Z Open Automation Utilities '
             '(ZOAU) utility \'zinfo\'. See \'zinfo_err_msg\' for '
             'additional details.'
         )
-        module.fail_json(msg = err_msg, zinfo_err_msg = e)
+        module.fail_json(msg=err_msg, zinfo_err_msg=e)
 
     # remove zinfo subsets from parsed zinfo result, flatten by one level
     flattened_d = flatten_zinfo_json(zinfo_dict)

--- a/plugins/modules/zos_gather_facts.py
+++ b/plugins/modules/zos_gather_facts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2022, 2023
+# Copyright (c) IBM Corporation 2022 - 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -108,30 +108,38 @@ ansible_facts:
 """
 
 from fnmatch import fnmatch
-import json
+import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     zoau_version_checker
 )
 
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
+    ZOAUImportError,
+)
 
-def zinfo_cmd_string_builder(gather_subset):
-    """Builds a command string for 'zinfo' based off the gather_subset list.
+try:
+    from zoautil_py import zsystem
+except ImportError:
+    zsystem = ZOAUImportError(traceback.format_exc())
+
+
+def zinfo_facts_list_builder(gather_subset):
+    """Builds a list of strings to pass into 'zinfo' based off the
+        gather_subset list.
     Arguments:
         gather_subset {list} -- A list of subsets to pass in.
     Returns:
-        [str] -- A string that contains a command line argument for calling
-                 zinfo with the appropriate options.
+        [list[str]] -- A list of strings that contains sanitized subsets.
         [None] -- An invalid value was received for the subsets.
     """
     if gather_subset is None or 'all' in gather_subset:
-        return "zinfo -j -a"
+        return ["all"]
 
     # base value
-    zinfo_arg_string = "zinfo -j"
+    subsets_list = []
 
-    # build full string
     for subset in gather_subset:
         # remove leading/trailing spaces
         subset = subset.strip()
@@ -141,9 +149,9 @@ def zinfo_cmd_string_builder(gather_subset):
         # sanitize subset against malicious (probably alphanumeric only?)
         if not subset.isalnum():
             return None
-        zinfo_arg_string += " -t " + subset
+        subsets_list.append(subset)
 
-    return zinfo_arg_string
+    return subsets_list
 
 
 def flatten_zinfo_json(zinfo_dict):
@@ -214,59 +222,38 @@ def run_module():
     if module.check_mode:
         module.exit_json(**result)
 
-    if not zoau_version_checker.is_zoau_version_higher_than("1.2.1"):
+    if not zoau_version_checker.is_zoau_version_higher_than("1.3.0"):
         module.fail_json(
-            ("The zos_gather_facts module requires ZOAU >= 1.2.1. Please "
+            ("The zos_gather_facts module requires ZOAU >= 1.3.0. Please "
              "upgrade the ZOAU version on the target node.")
         )
 
     gather_subset = module.params['gather_subset']
 
-    # build out zinfo command with correct options
+
+    # build out list of strings to pass to zinfo python api.
     # call this whether or not gather_subsets list is empty/valid/etc
-    # rely on the function to report back errors. Note the function only
+    # rely on the helper function to report back errors. Note the function only
     # returns None if there's malicious or improperly formatted subsets.
-    # Invalid subsets are caught when the actual zinfo command is run.
-    cmd = zinfo_cmd_string_builder(gather_subset)
-    if not cmd:
+    # Invalid subsets are caught when the actual zinfo function is run.
+    facts_list = zinfo_facts_list_builder(gather_subset)
+    if not facts_list:
         module.fail_json(msg="An invalid subset was passed to Ansible.")
-
-    rc, fcinfo_out, err = module.run_command(cmd, encoding=None)
-
-    decode_str = fcinfo_out.decode('utf-8')
-
-    # We DO NOT return a partial list. Instead we FAIL FAST since we are
-    # targeting automation -- quiet but well-intended error messages may easily
-    # be skipped
-    if rc != 0:
-        # there are 3 known error messages in zinfo, if neither gets
-        # triggered then we send out this generic zinfo error message.
-        err_msg = ('An exception has occurred in Z Open Automation Utilities '
-                   '(ZOAU) utility \'zinfo\'. See \'zinfo_err_msg\' for '
-                   'additional details.')
-        # triggered by invalid optarg eg "zinfo -q"
-        if 'BGYSC5201E' in err.decode('utf-8'):
-            err_msg = ('Invalid call to zinfo. See \'zinfo_err_msg\' for '
-                       'additional details.')
-        # triggered when optarg does not get expected arg eg "zinfo -t"
-        elif 'BGYSC5202E' in err.decode('utf-8'):
-            err_msg = ('Invalid call to zinfo. Possibly missing a valid subset'
-                       ' See \'zinfo_err_msg\' for additional details.')
-        # triggered by illegal subset eg "zinfo -t abc"
-        elif 'BGYSC5203E' in err.decode('utf-8'):
-            err_msg = ('An invalid subset was detected. See \'zinfo_err_msg\' '
-                       'for additional details.')
-
-        module.fail_json(msg=err_msg, zinfo_err_msg=err)
 
     zinfo_dict = {}  # to track parsed zinfo facts.
 
     try:
-        zinfo_dict = json.loads(decode_str)
-    except json.JSONDecodeError:
-        # tell user something else for this error? This error is thrown when
-        # Python doesn't like the json string it parsed from zinfo.
-        module.fail_json(msg="Unsupported JSON format for the output.")
+        zinfo_dict = zsystem.zinfo(json=True, facts=facts_list)
+    except ValueError:
+        err_msg = 'An invalid subset was detected.'
+        module.fail_json(msg = err_msg)
+    except Exception as e:
+        err_msg = (
+            'An exception has occurred in Z Open Automation Utilities '
+            '(ZOAU) utility \'zinfo\'. See \'zinfo_err_msg\' for '
+            'additional details.'
+        )
+        module.fail_json(msg = err_msg, zinfo_err_msg = e)
 
     # remove zinfo subsets from parsed zinfo result, flatten by one level
     flattened_d = flatten_zinfo_json(zinfo_dict)

--- a/plugins/modules/zos_gather_facts.py
+++ b/plugins/modules/zos_gather_facts.py
@@ -248,11 +248,10 @@ def run_module():
         module.fail_json(msg=err_msg)
     except Exception as e:
         err_msg = (
-            'An exception has occurred in Z Open Automation Utilities '
-            '(ZOAU) utility \'zinfo\'. See \'zinfo_err_msg\' for '
-            'additional details.'
+            'An exception has occurred. Unable to gather facts. '
+            'See stderr for more details.'
         )
-        module.fail_json(msg=err_msg, zinfo_err_msg=e)
+        module.fail_json(msg=err_msg, stderr=str(e))
 
     # remove zinfo subsets from parsed zinfo result, flatten by one level
     flattened_d = flatten_zinfo_json(zinfo_dict)

--- a/tests/functional/modules/test_zos_gather_facts_func.py
+++ b/tests/functional/modules/test_zos_gather_facts_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2022
+# Copyright (c) IBM Corporation 2022 - 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -120,7 +120,6 @@ def test_with_gather_subset_bad(ansible_zos_module, gather_subset):
 
     for result in results.contacted.values():
         assert result is not None
-        assert re.match(r'^BGYSC5203E', result.get('zinfo_err_msg'))
         assert re.match(r'^An invalid subset', result.get('msg'))
 
 

--- a/tests/unit/test_zos_gather_facts.py
+++ b/tests/unit/test_zos_gather_facts.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2022
+# Copyright (c) IBM Corporation 2022 - 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -18,7 +18,6 @@ from ibm_zos_core.plugins.modules.zos_gather_facts import flatten_zinfo_json
 __metaclass__ = type
 
 import pytest
-from mock import call
 
 # Used my some mock modules, should match import directly below
 IMPORT_NAME = "ibm_zos_core.plugins.modules.zos_gather_facts"
@@ -26,30 +25,32 @@ IMPORT_NAME = "ibm_zos_core.plugins.modules.zos_gather_facts"
 # Tests for zos_father_facts helper functions
 
 test_data = [
-    (["ipl"], "zinfo -j -t ipl"),
-    (["ipl  "], "zinfo -j -t ipl"),
-    (["  ipl"], "zinfo -j -t ipl"),
-    (["ipl", "sys"], "zinfo -j -t ipl -t sys"),
-    (["all"], "zinfo -j -a"),
-    (None, "zinfo -j -a"),
-    (["ipl", "all", "sys"], "zinfo -j -a"),
+    (["ipl"], ["ipl"]),
+    (["ipl  "], ["ipl"]),
+    (["  ipl"], ["ipl"]),
+    (["ipl", "sys"], ["ipl", "sys"]),
+    (["all"], ["all"]),
+    (None, ["all"]),
+    (["ipl", "all", "sys"], ["all"]),
     # function does not validate legal vs illegal subsets
-    (["asdf"], "zinfo -j -t asdf"),
-    ([""], None),  # attemtped injection
+    (["asdf"], ["asdf"]),
+    ([""], None),
     (["ipl; cat /.bashrc"], None),  # attemtped injection
+    # for now, 'all' with some other invalid subset resolves to 'all'
+    (["ipl", "all", "ipl; cat /.ssh/id_rsa"], ["all"]),
 ]
 
 
 @pytest.mark.parametrize("args,expected", test_data)
-def test_zos_gather_facts_zinfo_cmd_string_builder(
+def test_zos_gather_facts_zinfo_facts_list_builder(
         zos_import_mocker, args, expected):
 
     mocker, importer = zos_import_mocker
     zos_gather_facts = importer(IMPORT_NAME)
 
     try:
-        result = zos_gather_facts.zinfo_cmd_string_builder(args)
-#         # add more logic here as the function evolves.
+        result = zos_gather_facts.zinfo_facts_list_builder(args)
+        # add more logic here as the function evolves.
     except Exception:
         result = None
     assert result == expected


### PR DESCRIPTION
Update module to leverage zoau python api for zinfo.
Update test cases accordingly.

##### SUMMARY
Fixes #1109 
Fixes #1126

The biggest change made here was leveraging the python api available for zinfo rather than constructing and calling a shell command. Much of the validation was repurposed/reused, so the code looks fairly similar.

The minumum ZOAU version has been raised to 1.3.0 since older versions will now break with these newer changes (the python api for zinfo available in prior versions of zoau has changed).

The only error the zinfo python api raises is a ValueError, so the logic handling the BGYSC520xx errors is removed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request
