### PR TITLE
[v1.10.0] [zos_backup_restore]Added choices for space type

### DIFF
--- a/changelogs/fragments/1200-zos_backup_restore-sanity-issues.yml
+++ b/changelogs/fragments/1200-zos_backup_restore-sanity-issues.yml
@@ -1,0 +1,4 @@
+trivial:
+  - zos_backup_restore - Added space type choices to argument spec to remove
+    validate-modules:doc-choices-do-not-match-spec.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1200).

--- a/plugins/modules/zos_backup_restore.py
+++ b/plugins/modules/zos_backup_restore.py
@@ -337,7 +337,7 @@ def main():
             ),
         ),
         space=dict(type="int", required=False, aliases=["size"]),
-        space_type=dict(type="str", required=False, aliases=["unit"]),
+        space_type=dict(type="str", required=False, aliases=["unit"], choices=["K", "M", "G", "CYL", "TRK"]),
         volume=dict(type="str", required=False),
         full_volume=dict(type="bool", default=False),
         temp_volume=dict(type="str", required=False, aliases=["dest_volume"]),

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,5 +1,4 @@
 plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-spec # We use our own argument parser for advanced conditional and dependent arguments.
 plugins/modules/zos_backup_restore.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_blockinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_copy.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,5 +1,4 @@
 plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-spec # We use our own argument parser for advanced conditional and dependent arguments.
 plugins/modules/zos_backup_restore.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_blockinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_copy.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,5 +1,4 @@
 plugins/modules/zos_apf.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/zos_backup_restore.py validate-modules:doc-choices-do-not-match-spec # We use our own argument parser for advanced conditional and dependent arguments.
 plugins/modules/zos_backup_restore.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_blockinfile.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_copy.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added the documented choices for `space_primary` into the module_args later used in argument spec, this change does not affect functionality.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1197 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_backup_restore