### PR TITLE
[Enhancement] [Doc scripts] Modifed doc scripts to ensure compatibility between MacOS and GNU sed commands

### DIFF
--- a/changelogs/fragments/1202-doc-gen-script-portability.yml
+++ b/changelogs/fragments/1202-doc-gen-script-portability.yml
@@ -1,0 +1,4 @@
+trivial:
+  - docs/scripts - Change to sed "-i" in place option which ensures compatibility between MacOS
+    and GNU versions of sed command.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1202).

--- a/docs/scripts/post-zos_apf.sh
+++ b/docs/scripts/post-zos_apf.sh
@@ -28,5 +28,5 @@ SCRIPT_DIR=`dirname "$0"`
 CURR_PATH=`pwd`
 # Delete any temporary index RST
 if [[ -f $CURR_PATH/source/modules/zos_apf.rst ]]; then
-    sed -i '' "s/\> \\*\//\> \\\*\//g" $CURR_PATH/source/modules/zos_apf.rst
+    sed -i'' -e "s/\> \\*\//\> \\\*\//g" $CURR_PATH/source/modules/zos_apf.rst
 fi

--- a/docs/scripts/pre-template.sh
+++ b/docs/scripts/pre-template.sh
@@ -27,6 +27,6 @@
 
 template_doc_source=`ansible-config dump|grep DEFAULT_MODULE_PATH| cut -d'=' -f2|sed 's/[][]//g' | tr -d \'\" |sed 's/modules/doc_fragments\/template.py/g'`
 cp $template_doc_source $template_doc_source.tmp
-sed -i '' "s/\"\\\\n\"/'\\\\\\\\n'/g" $template_doc_source
-sed -i '' "s/\"\\\\r\"/'\\\\\\\\r'/g" $template_doc_source
-sed -i '' "s/\"\\\\r\\\\n\"/'\\\\\\\\r\\\\\\\\n'/g" $template_doc_source
+sed -i'' -e "s/\"\\\\n\"/'\\\\\\\\n'/g" $template_doc_source
+sed -i'' -e "s/\"\\\\r\"/'\\\\\\\\r'/g" $template_doc_source
+sed -i'' -e "s/\"\\\\r\\\\n\"/'\\\\\\\\r\\\\\\\\n'/g" $template_doc_source


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Trivial change to sed "-i" in place option which ensures compatibility between MacOS and  GNU versions of sed command. This should help us use the tool via a linux based automated instance (most probably Jenkins vm).
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
doc scripts

Doc builds run successfully and do not introduce sanity issues 

```
(AC2.14PY3.9) fernandoflores@Fernandos-MacBook-Pro docs % make clean
====================================================================
Running Target clean
====================================================================
Deleting directory '/Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/docs/build'.
Deleting directory '/Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/docs/source/modules'.
Completed cleanup, run 'make module-doc' or 'make role-doc'.
(AC2.14PY3.9) fernandoflores@Fernandos-MacBook-Pro docs % sed --version
sed (GNU sed) 4.9
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Jay Fenlason, Tom Lord, Ken Pizzini,
Paolo Bonzini, Jim Meyering, and Assaf Gordon.

This sed program was built without SELinux support.

GNU sed home page: <https://www.gnu.org/software/sed/>.
General help using GNU software: <https://www.gnu.org/gethelp/>.
E-mail bug reports to: <bug-sed@gnu.org>.
(AC2.14PY3.9) fernandoflores@Fernandos-MacBook-Pro docs % make module-doc
====================================================================
Running Target module-doc
====================================================================
Make /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/docs/build directory for Sphinx generated HTML.
Make /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/docs/source/modules directory for Sphinx generated HTML.
# @if ! test -d ../plugins/modules/rexx_module_doc; then \
        # echo "Make ../plugins/modules/rexx_module_doc directory to extract REXX doc into temporary file."; \
        # mkdir -p ../plugins/modules/rexx_module_doc; \
        # else \
        # echo "Delete ../plugins/modules/rexx_module_doc directory used to extract REXX doc into temporary file."; \
        # rm -rf ../plugins/modules/rexx_module_doc; \
        # echo "Make ../plugins/modules/rexx_module_doc directory to extract REXX doc into temporary file."; \
        # mkdir -p ../plugins/modules/rexx_module_doc; \
        # fi
# @for rexx_module in `ls ../plugins/modules/*rexx`; do\
        #    REXX_FILE=`basename $rexx_module .rexx`; \
        #    echo "Extracting documentation for module $REXX_FILE into ../plugins/modules/rexx_module_doc/$REXX_FILE.py"; \
        #    touch ../plugins/modules/rexx_module_doc/$REXX_FILE.py; \
        #    sed -n "/DOCUMENTATION = '''/,/'''/p" ../plugins/modules/$REXX_FILE.rexx >> ../plugins/modules/rexx_module_doc/$REXX_FILE.py; \
        #    sed -n "/EXAMPLES = '''/,/'''/p" ../plugins/modules/$REXX_FILE.rexx >> ../plugins/modules/rexx_module_doc/$REXX_FILE.py; \
        #    sed -n "/RETURN = '''/,/'''/p" ../plugins/modules/$REXX_FILE.rexx >> ../plugins/modules/rexx_module_doc/$REXX_FILE.py; \
        #    echo "Generating ReStructuredText for module $REXX_FILE inot source/modules/$REXX_FILE.rst"; \
        #    ansible-doc-extractor --template templates/module.rst.j2 source/modules ../plugins/modules/rexx_module_doc/$REXX_FILE.py; \
        # done
# @if test -d ../plugins/modules/rexx_module_doc; then \
        # echo "Delete ../plugins/modules/rexx_module_doc directory used to extract REXX doc into temporary file."; \
        # rm -rf ../plugins/modules/rexx_module_doc; \
        # fi
Rename file '../plugins/modules/__init__.py' to ../plugins/modules/__init__.py.skip to avoid reading empty python file.'
Replacing string based carriage returns with literal escaped to produce sphynx consumable RST.
scripts/pre-template.sh
Generating ReStructuredText for all ansible modules found at '../plugins/modules/' to 'source/modules'.
Rendering ../plugins/modules/zos_apf.py
Rendering ../plugins/modules/zos_archive.py
Rendering ../plugins/modules/zos_backup_restore.py
Rendering ../plugins/modules/zos_blockinfile.py
Rendering ../plugins/modules/zos_copy.py
Rendering ../plugins/modules/zos_data_set.py
Rendering ../plugins/modules/zos_encode.py
Rendering ../plugins/modules/zos_fetch.py
Rendering ../plugins/modules/zos_find.py
Rendering ../plugins/modules/zos_gather_facts.py
Rendering ../plugins/modules/zos_job_output.py
Rendering ../plugins/modules/zos_job_query.py
Rendering ../plugins/modules/zos_job_submit.py
Rendering ../plugins/modules/zos_lineinfile.py
Rendering ../plugins/modules/zos_mount.py
Rendering ../plugins/modules/zos_mvs_raw.py
Rendering ../plugins/modules/zos_operator.py
Rendering ../plugins/modules/zos_operator_action_query.py
Rendering ../plugins/modules/zos_ping.py
Rendering ../plugins/modules/zos_script.py
Rendering ../plugins/modules/zos_tso_command.py
Rendering ../plugins/modules/zos_unarchive.py
Rendering ../plugins/modules/zos_volume_init.py
Updating zos_apf file.
scripts/post-zos_apf.sh
++ dirname scripts/post-zos_apf.sh
+ SCRIPT_DIR=scripts
++ pwd
+ CURR_PATH=/Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/docs
+ [[ -f /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/docs/source/modules/zos_apf.rst ]]
+ sed -i -e 's/\> \*\//\> \\*\//g' /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/docs/source/modules/zos_apf.rst
Reverting edited source file.
scripts/post-template.sh
Rename file '../plugins/modules/__init__.py.skip' back to ../plugins/modules/__init__.py.'
====================================================================
Completed ReStructuredText generation for modules; next run 'make html'
(AC2.14PY3.9) fernandoflores@Fernandos-MacBook-Pro ibm_zos_core % ./ac --ac-build
-----------------------------------------------------------------------
Build and install collection of the local GH branch: 'dev'.
-----------------------------------------------------------------------
Created collection for ibm.ibm_zos_core at /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/ibm-ibm_zos_core-1.8.0.tar.gz
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Installing 'ibm.ibm_zos_core:1.8.0' to '/Users/fernandoflores/.ansible/collections/ansible_collections/ibm/ibm_zos_core'
ibm.ibm_zos_core:1.8.0 was installed successfully
(AC2.14PY3.9) fernandoflores@Fernandos-MacBook-Pro ibm_zos_core % ./ac --ac-sanity
-----------------------------------------------------------------------
Running ansible-test with managed python virtual environment: /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/venv/venv-2.15.
-----------------------------------------------------------------------
Running sanity test "action-plugin-docs"
Running sanity test "ansible-doc"
Running sanity test "changelog"
Running sanity test "compile" on Python 3.10
Running sanity test "empty-init"
Running sanity test "future-import-boilerplate"
Running sanity test "ignores"
Running sanity test "import" on Python 3.10
Running sanity test "line-endings"
Running sanity test "metaclass-boilerplate"
Running sanity test "no-assert"
Running sanity test "no-basestring"
Running sanity test "no-dict-iteritems"
Running sanity test "no-dict-iterkeys"
Running sanity test "no-dict-itervalues"
Running sanity test "no-get-exception"
Running sanity test "no-illegal-filenames"
Running sanity test "no-main-display"
Running sanity test "no-smart-quotes"
Running sanity test "no-unicode-literals"
Running sanity test "pep8"
Running sanity test "pslint"
Running sanity test "pylint"
Running sanity test "replace-urlopen"
Running sanity test "runtime-metadata"
Running sanity test "shebang"
Running sanity test "shellcheck"
Running sanity test "symlinks"
Running sanity test "use-argspec-type-path"
Running sanity test "use-compat-six"
Running sanity test "validate-modules"
Running sanity test "yamllint"
```
