### PR TITLE
[v1.10.0][zos_job_query] Removed wait argument from test cases

### DIFF
--- a/changelogs/fragments/1217-validate-job-query.yml
+++ b/changelogs/fragments/1217-validate-job-query.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_job_query - Removed zos_job_submit wait argument from tests.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1217).

--- a/tests/functional/modules/test_zos_job_query_func.py
+++ b/tests/functional/modules/test_zos_job_query_func.py
@@ -63,7 +63,7 @@ def test_zos_job_id_query_multi_wildcards_func(ansible_zos_module):
             cmd="cp {0}/SAMPLE \"//'{1}(SAMPLE)'\"".format(TEMP_PATH, JDATA_SET_NAME)
         )
         results = hosts.all.zos_job_submit(
-            src="{0}(SAMPLE)".format(JDATA_SET_NAME), location="DATA_SET", wait=True
+            src="{0}(SAMPLE)".format(JDATA_SET_NAME), location="DATA_SET", wait_time_s=10
         )
         for result in results.contacted.values():
             assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
@@ -96,7 +96,7 @@ def test_zos_job_name_query_multi_wildcards_func(ansible_zos_module):
             cmd="cp {0}/SAMPLE \"//'{1}(SAMPLE)'\"".format(TEMP_PATH, NDATA_SET_NAME)
         )
         results = hosts.all.zos_job_submit(
-            src="{0}(SAMPLE)".format(NDATA_SET_NAME), location="DATA_SET", wait=True
+            src="{0}(SAMPLE)".format(NDATA_SET_NAME), location="DATA_SET", wait_time_s=10
         )
         for result in results.contacted.values():
             assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As part of ZOAU 1.3 migration tasks I validated that zos_job_query works correctly, but in `zos_job_submit` wait option was removed so I removed it from the test cases and set a maximum wait time of 10 sec. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
 

Fixes #1141 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_query
