### PR TITLE
[Sanity] Changelog has wrong value "minor_change" instead of "minor_changes"

### DIFF
--- a/changelogs/fragments/1078-short_job_name_sends_back_a_value_error.yaml
+++ b/changelogs/fragments/1078-short_job_name_sends_back_a_value_error.yaml
@@ -6,6 +6,6 @@ bugfixes:
     Change now allows the use of a shorter job ID or name, as well as wildcards.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1078).
 
-minor_change:
+minor_changes:
   - zos_job_output - When passing a job ID and owner the module take as mutually exclusive. Change now allows the use of a job ID and owner at the same time.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1078).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated a changelog that was breaking the `antsibull-changelog lint` command to the correct key value.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
changelog