### PR TITLE
[v1.10.0][zos_find] Removed lineinfile dependency and test with ZOAU 1.3

### DIFF
--- a/changelogs/fragments/1228-zos_find-remove-zos_lineinfile_dep.yml
+++ b/changelogs/fragments/1228-zos_find-remove-zos_lineinfile_dep.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_find - Removed zos_lineinfile dependency from test cases.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1228).

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -63,7 +63,7 @@ def test_find_sequential_data_sets_containing_single_string(ansible_zos_module):
             batch=[dict(name=i, type='seq', state='present') for i in SEQ_NAMES]
         )
         for ds in SEQ_NAMES:
-            hosts.all.zos_lineinfile(src=ds, line=search_string)
+            hosts.all.shell(cmd=f"decho '{search_string}' \"{ds}\" ")
 
         find_res = hosts.all.zos_find(
             patterns=['TEST.FIND.SEQ.*.*'],
@@ -91,9 +91,9 @@ def test_find_sequential_data_sets_multiple_patterns(ansible_zos_module):
             batch=[dict(name=i, type='seq', state='present') for i in SEQ_NAMES]
         )
         hosts.all.zos_data_set(name=new_ds, type='seq', state='present')
-        hosts.all.zos_lineinfile(src=new_ds, line="incorrect string")
+        hosts.all.shell(cmd=f"decho 'incorrect string' \"{new_ds}\" ")
         for ds in SEQ_NAMES:
-            hosts.all.zos_lineinfile(src=ds, line=search_string)
+            hosts.all.shell(cmd=f"decho '{search_string}' \"{ds}\" ")
 
         find_res = hosts.all.zos_find(
             patterns=['TEST.FIND.SEQ.*.*', 'TEST.INVALID.*'],
@@ -131,7 +131,7 @@ def test_find_pds_members_containing_string(ansible_zos_module):
             ]
         )
         for ds in PDS_NAMES:
-            hosts.all.zos_lineinfile(src=ds + "(MEMBER)", line=search_string)
+            hosts.all.shell(cmd=f"decho '{search_string}' \"{ds}(MEMBER)\" ")
 
         find_res = hosts.all.zos_find(
             pds_paths=['TEST.FIND.PDS.FUNCTEST.*'],

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) IBM Corporation 2020, 2023
+# Copyright (c) IBM Corporation 2020, - 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) IBM Corporation 2020, - 2024
+# Copyright (c) IBM Corporation 2020 - 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removed zos_lineinfile dependency to be able to test zos_find with ZOAU 1.3 ahead of time.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1142 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_find