### PR TITLE
[v1.9.0][zos_apf] Fix list operation only returning one data set

### DIFF
--- a/changelogs/fragments/1236-bugfix-zos_apf-return-list.yml
+++ b/changelogs/fragments/1236-bugfix-zos_apf-return-list.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_apf - When operation=list was selected and more than one data set entry
+    was fetched, the module only returned one data set. Fix now returns the complete
+    list.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1236).

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -538,9 +538,11 @@ def main():
                 vol = d.get('vol')
                 try:
                     if (library and re.match(library, ds)) or (volume and re.match(volume, vol)) or (sms and sms == vol):
-                        result['stdout'] = "{0} {1}\n".format(vol, ds)
+                        operOut = operOut + "{0} {1}\n".format(vol, ds)
                 except re.error:
+                    result['stdout'] = operOut
                     module.exit_json(**result)
+            result['stdout'] = operOut
     module.exit_json(**result)
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a concatenation of data sets when the list option is selected instead of just returning the last data set.

There is no need to forward port this into v1.10.0, since it is already fixed there.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1235 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_apf
