### PR TITLE
[v1.9.0] [backport] [Bug] [module_util/data_set] Remove leading '-' chars from parsed volume serial strings

### DIFF
--- a/changelogs/fragments/1247-volser-parsing-leading-dash-bugfix
+++ b/changelogs/fragments/1247-volser-parsing-leading-dash-bugfix
@@ -1,0 +1,5 @@
+bugfix:
+  - zos_data_set - Fixes a small parsing bug in module_utils/data_set function 
+    which extracts volume serial(s) from a LISTCAT command output. Previously a 
+    leading '-' was left behind for volser strings under 6 chars.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1247).

--- a/changelogs/fragments/1247-volser-parsing-leading-dash-bugfix.yml
+++ b/changelogs/fragments/1247-volser-parsing-leading-dash-bugfix.yml
@@ -1,4 +1,4 @@
-bugfix:
+bugfixes:
   - zos_data_set - Fixes a small parsing bug in module_utils/data_set function 
     which extracts volume serial(s) from a LISTCAT command output. Previously a 
     leading '-' was left behind for volser strings under 6 chars.

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2020 - 2023
+# Copyright (c) IBM Corporation 2020, 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -380,9 +380,14 @@ class DataSet(object):
             "mvscmdauth --pgm=idcams --sysprint=* --sysin=stdin", data=stdin
         )
         delimiter = 'VOLSER------------'
-        arr = stdout.split(delimiter)
-        # A volume serial (VOLSER) is not always of fixed length, use ":x.find(' ')" here instead of arr[index].
-        volume_list = list(set([x[:x.find(' ')] for x in arr[1:]]))
+        arr = stdout.split(delimiter)[1:]  # throw away header
+
+        # Volume serials (VOLSER) under 6 chars will have one or more leading '-'s due to the chosen delimiter.
+        # The volser is in between the beginning of each str and the first space.
+        # Strip away any leading '-'s, then split on the next whitespace and throw away the remaining in each str.
+        volume_list = [x.strip('-').split()[0] for x in arr]
+
+        volume_list = list(set(volume_list))  # remove duplicates, order doesn't matter
         return volume_list
 
     @staticmethod


### PR DESCRIPTION
backports a fix for a minor parsing issue in the `data_set_cataloged_volume_list()` function where the contents of LISTCAT are parsed for volume serials. The issue was the volser str was assumed to be exactly 6 chars, and if it wasn't, the requisite number of `-`s where prepended. 
- See more details outlined in the bugfix - #1240

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- Fixes #1245 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
