### PR TITLE
[v1.10.0] [zos_job_submit] Handling of non-UTF8 chars in job output

### DIFF
--- a/changelogs/fragments/1261-job-submit-non-utf8-chars.yml
+++ b/changelogs/fragments/1261-job-submit-non-utf8-chars.yml
@@ -1,0 +1,4 @@
+trivial:
+  - zos_job_submit - Added test case to validate a bugfix in ZOAU v1.3.0 that
+    handles non-UTF8 characters correctly in a job's output.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1261).

--- a/changelogs/fragments/1261-job-submit-non-utf8-chars.yml
+++ b/changelogs/fragments/1261-job-submit-non-utf8-chars.yml
@@ -1,4 +1,9 @@
+bugfixes:
+  - module_utils/job.py - job output containing non-printable characters would
+    crash modules. Fix now handles the error gracefully and returns a message
+    to the user inside `content` of the `ddname` that failed.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1261).
 trivial:
-  - zos_job_submit - Added test case to validate a bugfix in ZOAU v1.3.0 that
+  - zos_job_submit - add test case to validate a bugfix in ZOAU v1.3.0 that
     handles non-UTF8 characters correctly in a job's output.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1261).

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -403,13 +403,6 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
                             job["ret_code"]["msg_code"] = None
                             job["ret_code"]["code"] = None
 
-                # if len(list_of_dds) > 0:
-                    # The duration should really only be returned for job submit but the code
-                    # is used job_output as well, for now we can ignore this point unless
-                    # we want to offer a wait_time_s for job output which might be reasonable.
-                    # Note: Moved this to the upper time loop, so it should always be populated.
-                    # job["duration"] = duration
-
             final_entries.append(job)
     if not final_entries:
         final_entries = _job_not_found(job_id, owner, job_name, "unavailable")

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -356,11 +356,21 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
                     tmpcont = None
                     if "step_name" in single_dd:
                         if "dd_name" in single_dd:
-                            tmpcont = jobs.read_output(
-                                entry.job_id,
-                                single_dd["step_name"],
-                                single_dd["dd_name"]
-                            )
+                            # In case ZOAU fails when reading the job output, we'll
+                            # add a message to the user telling them of this.
+                            # ZOAU cannot read partial output from a job, so we
+                            # have to make do with nothing from this step if it fails.
+                            try:
+                                tmpcont = jobs.read_output(
+                                    entry.job_id,
+                                    single_dd["step_name"],
+                                    single_dd["dd_name"]
+                                )
+                            except UnicodeDecodeError:
+                                tmpcont = (
+                                    "Non-printable UTF-8 characters were present in this output. "
+                                    "Please access it manually."
+                                )
 
                     dd["content"] = tmpcont.split("\n")
                     job["ret_code"]["steps"].extend(_parse_steps(tmpcont))

--- a/tests/functional/modules/test_zos_job_query_func.py
+++ b/tests/functional/modules/test_zos_job_query_func.py
@@ -114,7 +114,7 @@ def test_zos_job_name_query_multi_wildcards_func(ansible_zos_module):
 
 def test_zos_job_id_query_short_ids_func(ansible_zos_module):
     hosts = ansible_zos_module
-    qresults = hosts.all.zos_job_query(job_id="STC003")
+    qresults = hosts.all.zos_job_query(job_id="STC00002")
     for qresult in qresults.contacted.values():
         assert qresult.get("jobs") is not None
 

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -269,7 +269,7 @@ int main()
         unsigned char e=0x81;
         unsigned char f=0x82;
         unsigned char g=0x83;
-        unsigned char h=0x84;
+        unsigned char h=0x00;
         printf("Value of a: Hex: %X, character: %c",a,a);
         printf("Value of b: Hex: %X, character: %c",b,b);
         printf("Value of c: Hex: %X, character: %c",c,c);
@@ -771,13 +771,10 @@ def test_zoau_bugfix_invalid_utf8_chars(ansible_zos_module):
 
         # Copy C source and compile it.
         hosts.all.file(path=TEMP_PATH, state="directory")
-        print("dir created")
         hosts.all.shell(
             cmd="echo {0} > {1}/noprint.c".format(quote(C_SRC_INVALID_UTF8), TEMP_PATH)
         )
-        print("c code copied")
         hosts.all.shell(cmd="xlc -o {0}/noprint {0}/noprint.c")
-        print("code compiled")
 
         # Create local JCL and submit it.
         tmp_file = tempfile.NamedTemporaryFile(delete=True)

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -255,9 +255,55 @@ HELLO, WORLD
 //
 """
 
-JCL_FULL_INPUT="""//HLQ0  JOB MSGLEVEL=(1,1),
+JCL_FULL_INPUT = """//HLQ0  JOB MSGLEVEL=(1,1),
 //  MSGCLASS=A,CLASS=A,NOTIFY=&SYSUID
 //STEP1 EXEC PGM=BPXBATCH,PARM='PGM /bin/sleep 5'"""
+
+C_SRC_INVALID_UTF8 = """#include <stdio.h>
+int main()
+{
+        unsigned char a=0x64;
+        unsigned char b=0x2A;
+        unsigned char c=0xB8;
+        unsigned char d=0xFF;
+        unsigned char e=0x81;
+        unsigned char f=0x82;
+        unsigned char g=0x83;
+        unsigned char h=0x84;
+        printf("Value of a: Hex: %X, character: %c",a,a);
+        printf("Value of b: Hex: %X, character: %c",b,b);
+        printf("Value of c: Hex: %X, character: %c",c,c);
+        printf("Value of d: Hex: %X, character: %c",d,d);
+        printf("Value of a: Hex: %X, character: %c",e,e);
+        printf("Value of b: Hex: %X, character: %c",f,f);
+        printf("Value of c: Hex: %X, character: %c",g,g);
+        printf("Value of d: Hex: %X, character: %c",h,h);
+        return 0;
+}
+"""
+
+JCL_INVALID_UTF8_CHARS_EXC = """//*
+//******************************************************************************
+//* Job that runs a C program that returns characters outside of the UTF-8 range
+//* expected by Python. This job tests a bugfix present in ZOAU v1.3.0 onwards
+//* that deals properly with these chars.
+//* The JCL needs to be formatted to give it the directory where the C program
+//* is located.
+//******************************************************************************
+//NOEBCDIC JOB (T043JM,JM00,1,0,0,0),'NOEBCDIC - JRM',
+//             MSGCLASS=X,MSGLEVEL=1,NOTIFY=&SYSUID
+//NOPRINT  EXEC PGM=BPXBATCH
+//STDPARM DD *
+SH (
+cd {0};
+./noprint;
+exit 0;
+)
+//STDIN  DD DUMMY
+//STDOUT DD SYSOUT=*
+//STDERR DD SYSOUT=*
+//
+"""
 
 TEMP_PATH = "/tmp/jcl"
 DATA_SET_NAME_SPECIAL_CHARS = "imstestl.im@1.xxx05"
@@ -712,3 +758,43 @@ def test_negative_job_submit_local_jcl_typrun_scan(ansible_zos_module):
         assert re.search(r'error ? ?', repr(result.get("msg")))
         assert result.get("jobs")[0].get("job_id") is not None
         assert result.get("jobs")[0].get("ret_code").get("msg_text") == "?"
+
+
+# This test case is related to the following GitHub issues:
+# - https://github.com/ansible-collections/ibm_zos_core/issues/677
+# - https://github.com/ansible-collections/ibm_zos_core/issues/972
+# - https://github.com/ansible-collections/ibm_zos_core/issues/1160
+# - https://github.com/ansible-collections/ibm_zos_core/issues/1255
+def test_zoau_bugfix_invalid_utf8_chars(ansible_zos_module):
+    try:
+        hosts = ansible_zos_module
+
+        # Copy C source and compile it.
+        hosts.all.file(path=TEMP_PATH, state="directory")
+        print("dir created")
+        hosts.all.shell(
+            cmd="echo {0} > {1}/noprint.c".format(quote(C_SRC_INVALID_UTF8), TEMP_PATH)
+        )
+        print("c code copied")
+        hosts.all.shell(cmd="xlc -o {0}/noprint {0}/noprint.c")
+        print("code compiled")
+
+        # Create local JCL and submit it.
+        tmp_file = tempfile.NamedTemporaryFile(delete=True)
+        with open(tmp_file.name, "w") as f:
+            f.write(JCL_INVALID_UTF8_CHARS_EXC.format(TEMP_PATH))
+
+        results = hosts.all.zos_job_submit(
+            src=tmp_file.name,
+            location="LOCAL",
+            wait_time_s=15
+        )
+
+        for result in results.contacted.values():
+            # We shouldn't get an error now that ZOAU handles invalid/unprintable
+            # UTF-8 chars correctly.
+            assert result.get("jobs")[0].get("ret_code").get("msg_code") == "0000"
+            assert result.get("jobs")[0].get("ret_code").get("code") == 0
+            assert result.get("changed") is True
+    finally:
+        hosts.all.file(path=TEMP_PATH, state="absent")


### PR DESCRIPTION
##### SUMMARY
Fixes #1160.
Fixes #677.
Fixes #972.
Fixes #1260.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- zos_job_submit

##### ADDITIONAL INFORMATION
See issue #1255 too.
