### PR TITLE
[v1.9.0] Collaboration 1246 to add typrun support for zos_job_submit

### DIFF
--- a/changelogs/fragments/1246-bugfix-zos_job_submit-typrun.yml
+++ b/changelogs/fragments/1246-bugfix-zos_job_submit-typrun.yml
@@ -1,0 +1,38 @@
+bugfixes:
+  - zos_job_submit - when typrun=scan was used in JCL, it would fail the module. Now
+    typrun=scan no longer fails the module and an appropriate message is returned with
+    appropriate return code values.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1283).
+  - zos_job_submit - when typrun=hold was used in JCL it would fail the module with an
+    improper message and error condition. While this case continues to be considered
+    a failure, the message has been corrected and it fails under the condition that
+    not enough time has been added to the modules execution.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1283).
+  - zos_job_submit - when typrun=jchhold was used in JCL it would fail the module with an
+    improper message and error condition. While this case continues to be considered
+    a failure, the message has been corrected and it fails under the condition that
+    not enough time has been added to the modules execution.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1283).
+  - zos_job_submit - when typrun=copy was used in JCL it would fail the module with an
+    improper message and error condition. While this case continues to be considered
+    a failure, the message has been corrected and it fails under the condition that
+    not enough time has been added to the modules execution.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1283).
+  - zos_job_submit - when wait_time_s was used, the duration would run
+    approximately 5 second longer than reported in the duration. Now the when
+    duration is returned, it is the actual accounting from when the job is submitted
+    to when the module reads the job output.
+  - zos_job_submit - when a response was returned, it contained an undocumented
+    property; ret_code[msg_text]. Now when a response is returned, it correctly
+    returns property ret_code[msg_txt].
+  - zos_job_submit - when a JCL error occurred, the ret_code[msg_code] contained
+    JCLERROR followed by an integer where the integer appeared to be a reason code
+    when actually it is a multi line marker used to coordinate errors spanning more
+    than one line. Now when a JCLERROR occurs, only the JCLERROR is returned for
+    property ret_code[msg_code].
+major_changes:
+  - zos_job_submit - when job statuses were read, were limited to AC (active),
+    CC (completed normally), ABEND (ended abnormally) and ? (error unknown),
+    SEC (security error), JCLERROR (job had a jcl error). Now the additional statuses
+    are supported, CANCELLED (job was cancelled), CAB (converter abend),
+    CNV (converter error), SYS (system failure) and FLU (job was flushed).

--- a/changelogs/fragments/1246-bugfix-zos_job_submit-typrun.yml
+++ b/changelogs/fragments/1246-bugfix-zos_job_submit-typrun.yml
@@ -22,17 +22,21 @@ bugfixes:
     approximately 5 second longer than reported in the duration. Now the when
     duration is returned, it is the actual accounting from when the job is submitted
     to when the module reads the job output.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1283).
   - zos_job_submit - when a response was returned, it contained an undocumented
     property; ret_code[msg_text]. Now when a response is returned, it correctly
     returns property ret_code[msg_txt].
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1283).
   - zos_job_submit - when a JCL error occurred, the ret_code[msg_code] contained
     JCLERROR followed by an integer where the integer appeared to be a reason code
     when actually it is a multi line marker used to coordinate errors spanning more
     than one line. Now when a JCLERROR occurs, only the JCLERROR is returned for
     property ret_code[msg_code].
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1283).
 major_changes:
   - zos_job_submit - when job statuses were read, were limited to AC (active),
     CC (completed normally), ABEND (ended abnormally) and ? (error unknown),
     SEC (security error), JCLERROR (job had a jcl error). Now the additional statuses
     are supported, CANCELLED (job was cancelled), CAB (converter abend),
     CNV (converter error), SYS (system failure) and FLU (job was flushed).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1283).

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -258,7 +258,8 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
             job["owner"] = entry.owner
 
             job["ret_code"] = {}
-            job["ret_code"]["msg"] = entry.status + " " + entry.rc
+            job["ret_code"]["msg"] = entry.status
+            # job["ret_code"]["msg"] = entry.status + " " + entry.rc
             job["ret_code"]["msg_code"] = entry.rc
             job["ret_code"]["code"] = None
             if len(entry.rc) > 0:

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -260,7 +260,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
             if len(entry.rc) > 0:
                 if entry.rc.isdigit():
                     job["ret_code"]["code"] = int(entry.rc)
-            job["ret_code"]["msg_text"] = entry.status
+            job["ret_code"]["msg_txt"] = entry.status
 
             # this section only works on zoau 1.2.3/+ vvv
 

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -26,9 +26,11 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler im
     ZOAUImportError
 )
 
-from zoautil_py.exceptions import (
-    DDQueryException
-)
+try:
+    from zoautil_py import exceptions
+except ImportError:
+    exceptions = ZOAUImportError(traceback.format_exc())
+
 
 try:
     # For files that import individual functions from a ZOAU module,
@@ -297,7 +299,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
 
                 try:
                     list_of_dds = jobs.list_dds(entry.id)
-                except DDQueryException as err:
+                except exceptions.DDQueryException as err:
                     if 'BGYSC5201E' in str(err):
                         is_dd_query_exception = True
                         pass
@@ -314,7 +316,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
                         # list_of_dds will still be populated with valuable content
                         list_of_dds = jobs.list_dds(entry.id)
                         is_jesjcl = True if search_dictionaries("dataset", "JESJCL", list_of_dds) else False
-                    except DDQueryException as err:
+                    except exceptions.DDQueryException as err:
                         if 'BGYSC5201E' in str(err):
                             is_dd_query_exception = True
                             continue
@@ -453,7 +455,7 @@ def search_dictionaries(key, value, list_of_dictionaries):
             TypeError -- When input is not a list of dictionaries
     """
     if not isinstance(list_of_dictionaries, list):
-            raise TypeError(
-                "Unsupported type for 'list_of_dictionaries', must be a list of dictionaries")
+        raise TypeError(
+            "Unsupported type for 'list_of_dictionaries', must be a list of dictionaries")
 
     return [element for element in list_of_dictionaries if element[key] == value]

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -992,7 +992,8 @@ def run_module():
 
                     jes_jcl_dd_content=jes_jcl_dd[0].get("content")
                     jes_jcl_dd_content_str=" ".join(jes_jcl_dd_content)
-                    special_processing_keyword = re.search("({0})\s*=\s*(COPY|HOLD|JCLHOLD|SCAN)"
+                    # The regex can be "({0})\s*=\s*(COPY|HOLD|JCLHOLD|SCAN)" once zoau support is in.
+                    special_processing_keyword = re.search("({0})\s*=\s*(SCAN)"
                                                           .format("|".join(JOB_SPECIAL_PROCESSING))
                                                           , jes_jcl_dd_content_str)
 

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -608,7 +608,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser
     BetterArgParser,
 )
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.job import (
-    job_output,search_dictionaries
+    job_output, search_dictionaries,
 )
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
     ZOAUImportError,
@@ -935,11 +935,11 @@ def run_module():
             result["failed"] = True
             result["changed"] = False
             _msg = ("The JCL submitted with job id {0} but appears to be a long "
-                "running job that exceeded its maximum wait time of {1} "
-                "second(s). Consider using module zos_job_query to poll for "
-                "a long running job or increase option 'wait_times_s' to a value "
-                "greater than {2}.".format(
-                    str(job_submitted_id), str(wait_time_s), str(duration)))
+                    "running job that exceeded its maximum wait time of {1} "
+                    "second(s). Consider using module zos_job_query to poll for "
+                    "a long running job or increase option 'wait_times_s' to a value "
+                    "greater than {2}.".format(
+                        str(job_submitted_id), str(wait_time_s), str(duration)))
 
             if job_output_txt is not None:
                 result["jobs"] = job_output_txt
@@ -985,33 +985,33 @@ def run_module():
                     # JESJCL DD to figure out if its a TYPRUN job
 
                     job_dd_names = job_output_txt[0].get("ddnames")
-                    jes_jcl_dd= search_dictionaries("ddname", "JESJCL", job_dd_names)
+                    jes_jcl_dd = search_dictionaries("ddname", "JESJCL", job_dd_names)
 
                     # Its possible jobs don't have a JESJCL which are active and this would
                     # cause an index out of range error.
                     if not jes_jcl_dd:
                         raise Exception("The job return code was not available in the job log, "
-                                    "please review the job log and error {0}.".format(job_msg))
+                                        "please review the job log and error {0}.".format(job_msg))
 
-                    jes_jcl_dd_content=jes_jcl_dd[0].get("content")
-                    jes_jcl_dd_content_str=" ".join(jes_jcl_dd_content)
-                    # The regex can be "({0})\s*=\s*(COPY|HOLD|JCLHOLD|SCAN)" once zoau support is in.
-                    special_processing_keyword = re.search("({0})\s*=\s*(SCAN)"
-                                                          .format("|".join(JOB_SPECIAL_PROCESSING))
-                                                          , jes_jcl_dd_content_str)
+                    jes_jcl_dd_content = jes_jcl_dd[0].get("content")
+                    jes_jcl_dd_content_str = " ".join(jes_jcl_dd_content)
+                    # The regex can be r"({0})\s*=\s*(COPY|HOLD|JCLHOLD|SCAN)" once zoau support is in.
+                    special_processing_keyword = re.search(r"({0})\s*=\s*(SCAN)"
+                                                           .format("|".join(JOB_SPECIAL_PROCESSING))
+                                                           , jes_jcl_dd_content_str)
 
                     if special_processing_keyword:
-                      job_ret_code.update({"msg": special_processing_keyword[0]})
-                      job_ret_code.update({"code": None})
-                      job_ret_code.update({"msg_code": None})
-                      job_ret_code.update({"msg_txt": "The job {0} was run with special job "
-                                           "processing {1}. This will result in no completion, "
-                                           "return code or job steps and changed will be false."
-                                           .format(job_submitted_id,special_processing_keyword[0])})
-                      is_changed = False
+                        job_ret_code.update({"msg": special_processing_keyword[0]})
+                        job_ret_code.update({"code": None})
+                        job_ret_code.update({"msg_code": None})
+                        job_ret_code.update({"msg_txt": "The job {0} was run with special job "
+                                             "processing {1}. This will result in no completion, "
+                                             "return code or job steps and changed will be false."
+                                             .format(job_submitted_id, special_processing_keyword[0])})
+                        is_changed = False
                     else:
                         raise Exception("The job return code was not available in the job log, "
-                                    "please review the job log and error {0}.".format(job_msg))
+                                        "please review the job log and error {0}.".format(job_msg))
 
                 elif job_code != 0 and max_rc is None:
                     raise Exception("The job return code {0} was non-zero in the "
@@ -1048,6 +1048,7 @@ def run_module():
     result["changed"] = True if is_changed else False
     result["failed"] = False
     module.exit_json(**result)
+
 
 def assert_valid_return_code(max_rc, job_rc, ret_code):
     if job_rc is None:

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -934,15 +934,18 @@ def run_module():
         if duration >= wait_time_s:
             result["failed"] = True
             result["changed"] = False
-            if job_output_txt is not None:
-                result["jobs"] = job_output_txt
-            result["msg"] = (
-                "The JCL submitted with job id {0} but appears to be a long "
+            _msg = ("The JCL submitted with job id {0} but appears to be a long "
                 "running job that exceeded its maximum wait time of {1} "
                 "second(s). Consider using module zos_job_query to poll for "
                 "a long running job or increase option 'wait_times_s' to a value "
                 "greater than {2}.".format(
                     str(job_submitted_id), str(wait_time_s), str(duration)))
+
+            if job_output_txt is not None:
+                result["jobs"] = job_output_txt
+                job_ret_code = job_output_txt[0].get("ret_code")
+                job_ret_code.update({"msg_txt": _msg})
+            result["msg"] = _msg
             module.exit_json(**result)
 
         # Job has submitted, the module changed the managed node

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -234,22 +234,102 @@ HELLO, WORLD
 
 JCL_FILE_CONTENTS_TYPRUN_SCAN = """//*
 //******************************************************************************
-//* Job containing a TYPRUN=SCAN that will cause JES to run a syntax check and
-//* not actually run the JCL.
+//* Job containing a TYPRUN=SCAN will cause JES to run a syntax check and
+//* not actually run the JCL. The job will be put on the H output queue, DDs
+//* JESJCL and JESMSGLG are available. Ansible considers this a passing job.
 //* Returns:
-//*   ret_code->(code=null, msg=? ?, msg_text=?, msg_code=?)
-//*   msg --> The JCL submitted with job id JOB00620 but there was an error,
-//*           please review the error for further details: The job return code
-//*           was not available in the job log, please review the job log
-//*           and error ? ?.",
+//*   ret_code->(code=null, msg=TYPRUN=SCAN, msg_text=<msg>, msg_code=null)
+//*   msg --> The job JOB00551 was run with special job processing TYPRUN=SCAN.
+//*           This will result in no completion, return code or job steps and
+//*           changed will be false."
 //******************************************************************************
-//TYPESCAN JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,
-//             MSGCLASS=X,MSGLEVEL=1,NOTIFY=S0JM,TYPRUN=SCAN
+//SCAN JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,
+//             MSGCLASS=H,MSGLEVEL=1,NOTIFY=S0JM,TYPRUN=SCAN
 //STEP0001 EXEC PGM=IEBGENER
 //SYSIN    DD DUMMY
 //SYSPRINT DD SYSOUT=*
 //SYSUT1   DD *
-HELLO, WORLD
+HELLO, WORLD. SCAN OPERATION
+/*
+//SYSUT2   DD SYSOUT=*
+//
+"""
+
+JCL_FILE_CONTENTS_TYPRUN_COPY = """//*
+//******************************************************************************
+//* Job containing a TYPRUN=COPY will cause JES to copy the input job
+//* (source content) stream directly to a sysout data set (device specified in
+//* the message class parameter (H)) and schedule it for output processing, in
+//* other words, the job will be put on the H output queue; DD's
+//* JESMSGLG and JESJCLIN are available. Ansible considers this a failing job
+//* given currently the jobs status can not be determined so it times out.
+//* Returns:
+//*   ret_code->(code=null, msg=?, msg_text=<msg>, msg_code=?)
+//*   msg --> The JCL submitted with job id JOB00555 but appears to be a long
+//*           running job that exceeded its maximum wait time of 10 second(s).
+//*           Consider using module zos_job_query to poll for a long running
+//*           job or increase option 'wait_times_s' to a value greater than 11.
+//******************************************************************************
+//COPY JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,
+//             MSGCLASS=H,MSGLEVEL=1,NOTIFY=S0JM,TYPRUN=COPY
+//STEP0001 EXEC PGM=IEBGENER
+//SYSIN    DD DUMMY
+//SYSPRINT DD SYSOUT=*
+//SYSUT1   DD *
+HELLO, WORLD. COPY OPERATION
+/*
+//SYSUT2   DD SYSOUT=*
+//
+"""
+
+JCL_FILE_CONTENTS_TYPRUN_HOLD = """//*
+//******************************************************************************
+//* Job containing a TYPRUN=HOLD will cause JES to hold this JCL without
+//* executing it until a special event occurs at which time, the operator will
+//* release the job from HOLD and allow the job to to continue processing.
+//* Ansible considers this a failing job
+//* given currently the jobs status can not be determined so it times out.
+//* Returns:
+//*   ret_code->(code=null, msg=AC, msg_text=<msg>, msg_code=?)
+//*   msg --> The JCL submitted with job id JOB00555 but appears to be a long
+//*           running job that exceeded its maximum wait time of 10 second(s).
+//*           Consider using module zos_job_query to poll for a long running
+//*           job or increase option 'wait_times_s' to a value greater than 11.
+//******************************************************************************
+//HOLD JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,
+//             MSGCLASS=H,MSGLEVEL=1,NOTIFY=S0JM,TYPRUN=HOLD
+//STEP0001 EXEC PGM=IEBGENER
+//SYSIN    DD DUMMY
+//SYSPRINT DD SYSOUT=*
+//SYSUT1   DD *
+HELLO, WORLD. HOLD OPERATION
+/*
+//SYSUT2   DD SYSOUT=*
+//
+"""
+
+JCL_FILE_CONTENTS_TYPRUN_JCLHOLD = """//*
+//******************************************************************************
+//* Job containing a TYPRUN=JCLHOLD will cause JES to will keep the submitted
+//* job in the input queue until it's released by an operator or by the default
+//* time assigned to the class parameter. As the operator you enter 'A' or 'R'
+//* to release it from the queue.
+//* Ansible considers this a failing job
+//* given currently the jobs status can not be determined so it times out.
+//* Returns:
+//*   ret_code->(code=null, msg=AC, msg_text=<msg>, msg_code=?)
+//*   msg --> The JCL submitted with job id JOB00555 but appears to be a long
+//*           running job that exceeded its maximum wait time of 10 second(s).
+//*           Consider using module zos_job_query to poll for a long running
+//*           job or increase option 'wait_times_s' to a value greater than 11.
+//******************************************************************************
+//JCLHOLD JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,
+//             MSGCLASS=H,MSGLEVEL=1,NOTIFY=S0JM,TYPRUN=JCLHOLD
+//STEP0001 EXEC PGM=IEBGENER
+//SYSIN    DD DUMMY
+//SYSPRINT DD SYSOUT=*
+//SYSUT1   DD *
+HELLO, WORLD. JCLHOLD OPERATION
 /*
 //SYSUT2   DD SYSOUT=*
 //
@@ -693,16 +773,87 @@ def test_negative_job_submit_local_jcl_invalid_user(ansible_zos_module):
         assert re.search(r'SEC', repr(result.get("jobs")[0].get("ret_code").get("msg_text")))
 
 
-def test_negative_job_submit_local_jcl_typrun_scan(ansible_zos_module):
+def test_job_submit_local_jcl_typrun_scan(ansible_zos_module):
     tmp_file = tempfile.NamedTemporaryFile(delete=True)
     with open(tmp_file.name, "w") as f:
         f.write(JCL_FILE_CONTENTS_TYPRUN_SCAN)
     hosts = ansible_zos_module
-    results = hosts.all.zos_job_submit(src=tmp_file.name, location="LOCAL")
+    results = hosts.all.zos_job_submit(src=tmp_file.name,
+                                       location="LOCAL",
+                                       wait_time_s=20,
+                                       encoding={
+                                            "from": "UTF-8",
+                                            "to": "IBM-1047"
+                                        },)
     for result in results.contacted.values():
-        # Expecting: The job completion code (CC) was not in the job log....."
         assert result.get("changed") is False
-        assert re.search(r'return code was not available', repr(result.get("msg")))
-        assert re.search(r'error ? ?', repr(result.get("msg")))
         assert result.get("jobs")[0].get("job_id") is not None
-        assert result.get("jobs")[0].get("ret_code").get("msg_text") == "?"
+        assert re.search(r'run with special job processing TYPRUN=SCAN', repr(result.get("jobs")[0].get("ret_code").get("msg_txt")))
+        assert result.get("jobs")[0].get("ret_code").get("code") is None
+        assert result.get("jobs")[0].get("ret_code").get("msg") == "TYPRUN=SCAN"
+        assert result.get("jobs")[0].get("ret_code").get("msg_code") is None
+
+
+def test_job_submit_local_jcl_typrun_copy(ansible_zos_module):
+    tmp_file = tempfile.NamedTemporaryFile(delete=True)
+    with open(tmp_file.name, "w") as f:
+        f.write(JCL_FILE_CONTENTS_TYPRUN_COPY)
+    hosts = ansible_zos_module
+    results = hosts.all.zos_job_submit(src=tmp_file.name,
+                                       location="LOCAL",
+                                       wait_time_s=20,
+                                       encoding={
+                                            "from": "UTF-8",
+                                            "to": "IBM-1047"
+                                        },)
+    import pprint
+    for result in results.contacted.values():
+        pprint.pprint(result)
+        assert result.get("changed") is False
+        assert result.get("jobs")[0].get("job_id") is not None
+        assert re.search(r'appears to be a long running job', repr(result.get("jobs")[0].get("ret_code").get("msg_txt")))
+        assert result.get("jobs")[0].get("ret_code").get("code") is None
+        assert result.get("jobs")[0].get("ret_code").get("msg") == "?"
+        assert result.get("jobs")[0].get("ret_code").get("msg_code") == "?"
+
+
+def test_job_submit_local_jcl_typrun_hold(ansible_zos_module):
+    tmp_file = tempfile.NamedTemporaryFile(delete=True)
+    with open(tmp_file.name, "w") as f:
+        f.write(JCL_FILE_CONTENTS_TYPRUN_HOLD)
+    hosts = ansible_zos_module
+    results = hosts.all.zos_job_submit(src=tmp_file.name,
+                                       location="LOCAL",
+                                       wait_time_s=20,
+                                       encoding={
+                                            "from": "UTF-8",
+                                            "to": "IBM-1047"
+                                        },)
+    for result in results.contacted.values():
+        assert result.get("changed") is False
+        assert result.get("jobs")[0].get("job_id") is not None
+        assert re.search(r'appears to be a long running job', repr(result.get("jobs")[0].get("ret_code").get("msg_txt")))
+        assert result.get("jobs")[0].get("ret_code").get("code") is None
+        assert result.get("jobs")[0].get("ret_code").get("msg") == "AC"
+        assert result.get("jobs")[0].get("ret_code").get("msg_code") == "?"
+
+
+def test_job_submit_local_jcl_typrun_jclhold(ansible_zos_module):
+    tmp_file = tempfile.NamedTemporaryFile(delete=True)
+    with open(tmp_file.name, "w") as f:
+        f.write(JCL_FILE_CONTENTS_TYPRUN_JCLHOLD)
+    hosts = ansible_zos_module
+    results = hosts.all.zos_job_submit(src=tmp_file.name,
+                                       location="LOCAL",
+                                       wait_time_s=20,
+                                       encoding={
+                                            "from": "UTF-8",
+                                            "to": "IBM-1047"
+                                        },)
+    for result in results.contacted.values():
+        assert result.get("changed") is False
+        assert result.get("jobs")[0].get("job_id") is not None
+        assert re.search(r'appears to be a long running job', repr(result.get("jobs")[0].get("ret_code").get("msg_txt")))
+        assert result.get("jobs")[0].get("ret_code").get("code") is None
+        assert result.get("jobs")[0].get("ret_code").get("msg") == "AC"
+        assert result.get("jobs")[0].get("ret_code").get("msg_code") == "?"

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -811,7 +811,7 @@ def test_job_submit_local_jcl_typrun_copy(ansible_zos_module):
         pprint.pprint(result)
         assert result.get("changed") is False
         assert result.get("jobs")[0].get("job_id") is not None
-        assert re.search(r'appears to be a long running job', repr(result.get("jobs")[0].get("ret_code").get("msg_txt")))
+        assert re.search(r'please review the job log', repr(result.get("jobs")[0].get("ret_code").get("msg_txt")))
         assert result.get("jobs")[0].get("ret_code").get("code") is None
         assert result.get("jobs")[0].get("ret_code").get("msg") == "?"
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "?"
@@ -832,7 +832,7 @@ def test_job_submit_local_jcl_typrun_hold(ansible_zos_module):
     for result in results.contacted.values():
         assert result.get("changed") is False
         assert result.get("jobs")[0].get("job_id") is not None
-        assert re.search(r'appears to be a long running job', repr(result.get("jobs")[0].get("ret_code").get("msg_txt")))
+        assert re.search(r'long running job', repr(result.get("jobs")[0].get("ret_code").get("msg_txt")))
         assert result.get("jobs")[0].get("ret_code").get("code") is None
         assert result.get("jobs")[0].get("ret_code").get("msg") == "AC"
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "?"
@@ -853,7 +853,7 @@ def test_job_submit_local_jcl_typrun_jclhold(ansible_zos_module):
     for result in results.contacted.values():
         assert result.get("changed") is False
         assert result.get("jobs")[0].get("job_id") is not None
-        assert re.search(r'appears to be a long running job', repr(result.get("jobs")[0].get("ret_code").get("msg_txt")))
+        assert re.search(r'long running job', repr(result.get("jobs")[0].get("ret_code").get("msg_txt")))
         assert result.get("jobs")[0].get("ret_code").get("code") is None
         assert result.get("jobs")[0].get("ret_code").get("msg") == "AC"
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == "?"


### PR DESCRIPTION
##### SUMMARY
Address issues:
 -  #1246 
 - #1278 
 

When JCL is submitted with a job card indicating the job should only be validated with TYPRUN=SCAN the message that is returned is in this format:

> "msg":"The JCL submitted with job id JOB00406 but there was an error, please review the error for further details: The job return code was not available in the job log, please review the job log and error ? ?."

This PR adds support to such that typrun=scan does not trigger a job submission failure with updated `ret_code` values:
```
"ret_code": {
                    "code": null,
                    "msg": "TYPRUN=SCAN",
                    "msg_code": null,
                    "msg_txt": "The job JOB00283 was run with special job processing TYPRUN=SCAN. This will result in no completion, return code or job steps and changed will be false.",
                    "steps": []
                },
```

##### ISSUE TYPE
Collaboration

##### COMPONENT NAME
IBM z/OS core zos_job_submit

##### ADDITIONAL INFORMATION
See git issue for more details