### PR TITLE
[v1.10.0] [Documentation] Replaced path to src in zos_archive and zos_unarchive documentation

### DIFF
--- a/plugins/modules/zos_archive.py
+++ b/plugins/modules/zos_archive.py
@@ -325,7 +325,7 @@ EXAMPLES = r'''
 # Simple archive
 - name: Archive file into a tar
   zos_archive:
-    path: /tmp/archive/foo.txt
+    src: /tmp/archive/foo.txt
     dest: /tmp/archive/foo_archive_test.tar
     format:
       name: tar
@@ -333,7 +333,7 @@ EXAMPLES = r'''
 # Archive multiple files
 - name: Compress list of files into a zip
   zos_archive:
-    path:
+    src:
       - /tmp/archive/foo.txt
       - /tmp/archive/bar.txt
     dest: /tmp/archive/foo_bar_archive_test.zip
@@ -343,7 +343,7 @@ EXAMPLES = r'''
 # Archive one data set into terse
 - name: Compress data set into a terse
   zos_archive:
-    path: "USER.ARCHIVE.TEST"
+    src: "USER.ARCHIVE.TEST"
     dest: "USER.ARCHIVE.RESULT.TRS"
     format:
       name: terse
@@ -351,7 +351,7 @@ EXAMPLES = r'''
 # Use terse with different options
 - name: Compress data set into a terse, specify pack algorithm and use adrdssu
   zos_archive:
-    path: "USER.ARCHIVE.TEST"
+    src: "USER.ARCHIVE.TEST"
     dest: "USER.ARCHIVE.RESULT.TRS"
     format:
       name: terse
@@ -362,7 +362,7 @@ EXAMPLES = r'''
 # Use a pattern to store
 - name: Compress data set pattern using xmit
   zos_archive:
-    path: "USER.ARCHIVE.*"
+    src: "USER.ARCHIVE.*"
     exclude_sources: "USER.ARCHIVE.EXCLUDE.*"
     dest: "USER.ARCHIVE.RESULT.XMIT"
     format:

--- a/plugins/modules/zos_unarchive.py
+++ b/plugins/modules/zos_unarchive.py
@@ -323,14 +323,14 @@ EXAMPLES = r'''
 # Simple extract
 - name: Copy local tar file and unpack it on the managed z/OS node.
   zos_unarchive:
-    path: "./files/archive_folder_test.tar"
+    src: "./files/archive_folder_test.tar"
     format:
       name: tar
 
 # use include
 - name: Unarchive a bzip file selecting only a file to unpack.
   zos_unarchive:
-    path: "/tmp/test.bz2"
+    src: "/tmp/test.bz2"
     format:
       name: bz2
     include:
@@ -339,7 +339,7 @@ EXAMPLES = r'''
 # Use exclude
 - name: Unarchive a terse data set and excluding data sets from unpacking.
   zos_unarchive:
-    path: "USER.ARCHIVE.RESULT.TRS"
+    src: "USER.ARCHIVE.RESULT.TRS"
     format:
       name: terse
     exclude:
@@ -349,7 +349,7 @@ EXAMPLES = r'''
 # List option
 - name: List content from XMIT
   zos_unarchive:
-    path: "USER.ARCHIVE.RESULT.XMIT"
+    src: "USER.ARCHIVE.RESULT.XMIT"
     format:
       name: xmit
       format_options:
@@ -358,14 +358,14 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-path:
+src:
   description:
-    File path or data set name unarchived.
+    File path or data set name unpacked.
   type: str
   returned: always
 dest_path:
   description:
-    - Destination path where archive was extracted.
+    - Destination path where archive was unpacked.
   type: str
   returned: always
 targets:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
zos_archive and zos_unarchive had path as an option but it was replaced before going to GA but examples were not updated with the newest option `src`.

This PR updates the examples as well as the return dictionary for zos_unarchive.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1267 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_unarchive
zos_archive
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
