### PR TITLE
[v1.10.0-beta.1][port forward] Add chained command example to zos_tso_command

### DIFF
--- a/changelogs/fragments/1292-doc-zos_tso_command-example.yml
+++ b/changelogs/fragments/1292-doc-zos_tso_command-example.yml
@@ -1,0 +1,4 @@
+trivial:
+  - zos_tso_command - Added an example on how to chain multiple TSO commands such
+    that they are invoked together when dependent on each other.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1292).

--- a/changelogs/fragments/1292-doc-zos_tso_command-example.yml
+++ b/changelogs/fragments/1292-doc-zos_tso_command-example.yml
@@ -1,4 +1,4 @@
 trivial:
   - zos_tso_command - Added an example on how to chain multiple TSO commands such
     that they are invoked together when dependent on each other.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1292).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1293).

--- a/docs/source/modules/zos_tso_command.rst
+++ b/docs/source/modules/zos_tso_command.rst
@@ -55,27 +55,34 @@ Examples
 .. code-block:: yaml+jinja
 
    
-   - name: Execute TSO commands to allocate a new dataset
+   - name: Execute TSO commands to allocate a new dataset.
      zos_tso_command:
-         commands:
-             - alloc da('TEST.HILL3.TEST') like('TEST.HILL3')
-             - delete 'TEST.HILL3.TEST'
+       commands:
+         - alloc da('TEST.HILL3.TEST') like('TEST.HILL3')
+         - delete 'TEST.HILL3.TEST'
 
-   - name: Execute TSO command list user TESTUSER to obtain TSO information
+   - name: Execute TSO command List User (LU) for TESTUSER to obtain TSO information.
      zos_tso_command:
-         commands:
-              - LU TESTUSER
+       commands:
+         - LU TESTUSER
 
-   - name: Execute TSO command to list dataset data (allow 4 for no dataset listed or cert found)
+   - name: Execute TSO command List Dataset (LISTDSD) and allow for maximum return code of 4.
      zos_tso_command:
-         commands:
-              - LISTDSD DATASET('HLQ.DATA.SET') ALL GENERIC
-         max_rc: 4
+       commands:
+         - LISTDSD DATASET('HLQ.DATA.SET') ALL GENERIC
+       max_rc: 4
 
    - name: Execute TSO command to run explicitly a REXX script from a data set.
      zos_tso_command:
-         commands:
-              - EXEC HLQ.DATASET.REXX exec
+       commands:
+         - EXEC HLQ.DATASET.REXX exec
+
+   - name: Chain multiple TSO commands into one invocation using semicolons.
+     zos_tso_command:
+       commands: >-
+         ALLOCATE DDNAME(IN1) DSNAME('HLQ.PDSE.DATA.SRC(INPUT)') SHR;
+         ALLOCATE DDNAME(OUT1) DSNAME('HLQ.PDSE.DATA.DEST(OUTPUT)') SHR;
+         OCOPY INDD(IN1) OUTDD(OUT1) BINARY;
 
 
 

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -94,27 +94,34 @@ output:
 """
 
 EXAMPLES = r"""
-- name: Execute TSO commands to allocate a new dataset
+- name: Execute TSO commands to allocate a new dataset.
   zos_tso_command:
-      commands:
-          - alloc da('TEST.HILL3.TEST') like('TEST.HILL3')
-          - delete 'TEST.HILL3.TEST'
+    commands:
+      - alloc da('TEST.HILL3.TEST') like('TEST.HILL3')
+      - delete 'TEST.HILL3.TEST'
 
-- name: Execute TSO command list user TESTUSER to obtain TSO information
+- name: Execute TSO command List User (LU) for TESTUSER to obtain TSO information.
   zos_tso_command:
-      commands:
-           - LU TESTUSER
+    commands:
+      - LU TESTUSER
 
-- name: Execute TSO command to list dataset data (allow 4 for no dataset listed or cert found)
+- name: Execute TSO command List Dataset (LISTDSD) and allow for maximum return code of 4.
   zos_tso_command:
-      commands:
-           - LISTDSD DATASET('HLQ.DATA.SET') ALL GENERIC
-      max_rc: 4
+    commands:
+      - LISTDSD DATASET('HLQ.DATA.SET') ALL GENERIC
+    max_rc: 4
 
 - name: Execute TSO command to run a REXX script explicitly from a data set.
   zos_tso_command:
-      commands:
-           - EXEC HLQ.DATASET.REXX exec
+    commands:
+      - EXEC HLQ.DATASET.REXX exec
+
+- name: Chain multiple TSO commands into one invocation using semicolons.
+  zos_tso_command:
+    commands: >-
+      ALLOCATE DDNAME(IN1) DSNAME('HLQ.PDSE.DATA.SRC(INPUT)') SHR;
+      ALLOCATE DDNAME(OUT1) DSNAME('HLQ.PDSE.DATA.DEST(OUTPUT)') SHR;
+      OCOPY INDD(IN1) OUTDD(OUT1) BINARY;
 """
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/zos_tso_command.py
+++ b/plugins/modules/zos_tso_command.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019 - 2023
+# Copyright (c) IBM Corporation 2019 - 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -26,6 +26,7 @@ description:
 author:
     - "Xiao Yuan Ma (@bjmaxy)"
     - "Rich Parker (@richp405)"
+    - "Demetrios Dimatos (@ddimatos)"
 options:
   commands:
     description:


### PR DESCRIPTION
SUMMARY
Addresses issue https://github.com/ansible-collections/ibm_zos_core/issues/777 which is only to add a chained TSO command example.

Fixes #777 

ISSUE TYPE
Docs Pull Request
COMPONENT NAME
zos_tso_command