### PR TITLE
[v1.10.0-beta.1][port forward] Documentation to update zos_ping about the deprecated scp in OpenSSH 9 or later.

### DIFF
--- a/changelogs/fragments/1294-doc-zos_ping-scp.yml
+++ b/changelogs/fragments/1294-doc-zos_ping-scp.yml
@@ -1,0 +1,7 @@
+trivial:
+  - zos_ping - Update zos_ping documentation to instruct users how
+    to fall back to legacy SCP when using OpenSSH 9.0 or later.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1294).
+  - zos_ping - Update zos_ping REXX source to check for python
+    version 3.10 or later.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1294).

--- a/changelogs/fragments/1295-doc-zos_ping-scp.yml
+++ b/changelogs/fragments/1295-doc-zos_ping-scp.yml
@@ -1,7 +1,7 @@
 trivial:
   - zos_ping - Update zos_ping documentation to instruct users how
     to fall back to legacy SCP when using OpenSSH 9.0 or later.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1294).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1295).
   - zos_ping - Update zos_ping REXX source to check for python
     version 3.10 or later.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1294).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1295).

--- a/docs/source/modules/zos_ping.rst
+++ b/docs/source/modules/zos_ping.rst
@@ -40,8 +40,20 @@ Examples
 
 
 
+Notes
+-----
+
+.. note::
+   This module is written in REXX and relies on the SCP protocol to transfer the source to the managed z/OS node and encode it in the managed nodes default encoding, eg IBM-1047. Starting with OpenSSH 9.0, it switches from SCP to use SFTP by default, meaning transfers are no longer treated as text and are transferred as binary preserving the source files encoding resulting in a module failure. If you are using OpenSSH 9.0 (ssh -V) or later, you can instruct SSH to use SCP by adding the entry ``scp_extra_args="-O"`` into the ini file named ``ansible.cfg``.
 
 
+
+See Also
+--------
+
+.. seealso::
+
+   - :ref:`ansible.builtin.ssh_module`
 
 
 

--- a/plugins/modules/zos_ping.py
+++ b/plugins/modules/zos_ping.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2020, 2023
+# Copyright (c) IBM Corporation 2019 - 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -31,6 +31,16 @@ author:
   - "Blake Becker (@blakeinate)"
   - "Demetrios Dimatos (@ddimatos)"
 options: {}
+notes:
+    - This module is written in REXX and relies on the SCP protocol to transfer the source to
+      the managed z/OS node and encode it in the managed nodes default encoding, eg IBM-1047.
+      Starting with OpenSSH 9.0, it switches from SCP to use SFTP by default, meaning transfers
+      are no longer treated as text and are transferred as binary preserving the source files
+      encoding resulting in a module failure. If you are using OpenSSH 9.0 (ssh -V) or later,
+      you can instruct SSH to use SCP by adding the entry C(scp_extra_args="-O") into the ini
+      file named C(ansible.cfg).
+seealso:
+- module: ansible.builtin.ssh
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/zos_ping.rexx
+++ b/plugins/modules/zos_ping.rexx
@@ -62,7 +62,7 @@ Parse Arg argFile .
 
 pythonName       = 'Python'
 majVersionPython = 3
-minVersionPython = 8
+minVersionPython = 10
 warningJsonList = ''
 
 If (argFile = '') Then Do
@@ -85,7 +85,7 @@ If (rc <> 0 | returnCode <> HWTJ_OK) Then Do
     failModule(errmsg, "", retC)
 End
 
-/* Check for Python version >= 3.8 eg: 'Python 3.8.2' */
+/* Check for Python version >= 3.8 eg: 'Python 3.10.0' */
 retC = bpxwunix('python3 --version', out., err.)
 If (err.0 > 0) Then Do
     Do index=1 To err.0


### PR DESCRIPTION
##### SUMMARY
Addresses issue #1281 and also updates the REXX to check for Python 3.10 or later since 1.9.0 will support only 3.10 or later. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zos_ping

<img width="782" alt="image" src="https://github.com/ansible-collections/ibm_zos_core/assets/25803172/38e3688f-4f4e-4e10-9824-fb6747f0ceea">
