### PR TITLE
[Enabler][995 996]Remove_local_charset_from_zos_fetch

### DIFF
--- a/changelogs/fragments/1298-Remove_local_charset_from_zos_fetch.yml
+++ b/changelogs/fragments/1298-Remove_local_charset_from_zos_fetch.yml
@@ -1,3 +1,3 @@
 trivial:
-  - zos_fetch - Remove type of argument and argument not documented.
+  - zos_fetch - Remove argument not documented.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1298).

--- a/changelogs/fragments/1298-Remove_local_charset_from_zos_fetch.yml
+++ b/changelogs/fragments/1298-Remove_local_charset_from_zos_fetch.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_fetch - Remove type of argument and argument not documented.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1298).

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -219,7 +219,7 @@ class ActionModule(ActionBase):
         #                Execute module on remote host               #
         # ********************************************************** #
         new_module_args = self._task.args.copy()
-        encoding_to=None
+        encoding_to = None
         if encoding:
             encoding_to = encoding.get("to", None)
         if encoding is None or encoding_to is None:

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2019-2023
+# Copyright (c) IBM Corporation 2019 - 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -107,7 +107,7 @@ class ActionModule(ActionBase):
 
         src = self._task.args.get('src')
         dest = self._task.args.get('dest')
-        encoding = self._task.args.get('encoding')
+        encoding = self._task.args.get('encoding', None)
         flat = _process_boolean(self._task.args.get('flat'), default=False)
         is_binary = _process_boolean(self._task.args.get('is_binary'))
         ignore_sftp_stderr = _process_boolean(
@@ -219,9 +219,13 @@ class ActionModule(ActionBase):
         #                Execute module on remote host               #
         # ********************************************************** #
         new_module_args = self._task.args.copy()
-        new_module_args.update(
-            dict(local_charset=encode.Defaults.get_default_system_charset())
-        )
+        encoding_to=None
+        if encoding:
+            encoding_to = encoding.get("to", None)
+        if encoding is None or encoding_to is None:
+            new_module_args.update(
+                dict(encoding=dict(to=encode.Defaults.get_default_system_charset()))
+            )
         remote_path = None
         try:
             fetch_res = self._execute_module(

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -616,6 +616,9 @@ def run_module():
             "to": module.params.get("encoding").get("to"),
         }
 
+    # We check encoding 'from' and 'to' because if the user pass both arguments of encoding,
+    # we honor those but encoding 'to' is an argument that the code obtain any time.
+    # Encoding will not be null and will generate problems as encoding 'from' could came empty.
     if module.params.get("encoding").get("from") and module.params.get("encoding").get("to"):
         module.params.update(
             dict(

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -584,7 +584,6 @@ def run_module():
             validate_checksum=dict(required=False, default=True, type="bool"),
             encoding=dict(required=False, type="dict"),
             ignore_sftp_stderr=dict(type="bool", default=False, required=False),
-            local_charset=dict(type="str"),
             tmp_hlq=dict(required=False, type="str", default=None),
         )
     )

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -606,7 +606,7 @@ def run_module():
         tmp_hlq=dict(type='qualifier_or_empty', required=False, default=None),
     )
 
-    if not module.params.get("encoding") and not module.params.get("is_binary"):
+    if not module.params.get("encoding").get("from") and not module.params.get("is_binary"):
         mvs_src = data_set.is_data_set(src)
         remote_charset = encode.Defaults.get_default_system_charset()
 
@@ -614,10 +614,10 @@ def run_module():
             "from": encode.Defaults.DEFAULT_EBCDIC_MVS_CHARSET
             if mvs_src
             else remote_charset,
-            "to": module.params.get("local_charset"),
+            "to": module.params.get("encoding").get("to"),
         }
 
-    if module.params.get("encoding"):
+    if module.params.get("encoding").get("from") and module.params.get("encoding").get("to"):
         module.params.update(
             dict(
                 from_encoding=module.params.get("encoding").get("from"),

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -10,8 +10,6 @@ plugins/modules/zos_data_set.py validate-modules:missing-gplv3-license # License
 plugins/modules/zos_data_set.py validate-modules:undocumented-parameter # Keep aliases to match behavior of old module spec, but some aliases were functionally inaccurate, and detailing in docs would only confuse user.
 plugins/modules/zos_encode.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_fetch.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/zos_fetch.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
-plugins/modules/zos_fetch.py validate-modules:undocumented-parameter # Passing args from action plugin
 plugins/modules/zos_find.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_output.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_query.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -10,8 +10,6 @@ plugins/modules/zos_data_set.py validate-modules:missing-gplv3-license # License
 plugins/modules/zos_data_set.py validate-modules:undocumented-parameter # Keep aliases to match behavior of old module spec, but some aliases were functionally inaccurate, and detailing in docs would only confuse user.
 plugins/modules/zos_encode.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_fetch.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/zos_fetch.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
-plugins/modules/zos_fetch.py validate-modules:undocumented-parameter # Passing args from action plugin
 plugins/modules/zos_find.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_output.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_query.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -10,8 +10,6 @@ plugins/modules/zos_data_set.py validate-modules:missing-gplv3-license # License
 plugins/modules/zos_data_set.py validate-modules:undocumented-parameter # Keep aliases to match behavior of old module spec, but some aliases were functionally inaccurate, and detailing in docs would only confuse user.
 plugins/modules/zos_encode.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_fetch.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-plugins/modules/zos_fetch.py validate-modules:parameter-type-not-in-doc # Passing args from action plugin
-plugins/modules/zos_fetch.py validate-modules:undocumented-parameter # Passing args from action plugin
 plugins/modules/zos_find.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_output.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zos_job_query.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0


### PR DESCRIPTION
##### SUMMARY
Fix sanity issue about local charset by pass the value in the encoding parameter

Fixes #995 and fixes #996

##### ISSUE TYPE
- Enabler Pull Request

##### COMPONENT NAME
Add a value of the to parameter of the parameter encoding to get the value for the controller machine.

##### ADDITIONAL INFORMATION
<img width="1253" alt="Captura de pantalla 2024-03-11 a la(s) 1 28 49 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/8cdc6383-474c-4642-8e85-84a655ff53bd">
<img width="596" alt="Captura de pantalla 2024-03-11 a la(s) 1 29 07 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/f5e07d14-b179-4250-a763-ed9115098dae">
<img width="1258" alt="Captura de pantalla 2024-03-11 a la(s) 1 29 21 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/bb16df6e-57aa-453d-a1cd-e44c6a07d4f0">
<img width="652" alt="Captura de pantalla 2024-03-11 a la(s) 1 30 05 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/14ae1795-5d28-41d3-9105-bb4f87888c5e">
