### PR TITLE
Create bandit github action using the ac command

### DIFF
--- a/.github/workflows/ac-bandit.yml
+++ b/.github/workflows/ac-bandit.yml
@@ -1,0 +1,38 @@
+name: AC Bandit
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - staging*
+    
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+
+    - name: Set up venv
+      run: |
+        python -m pip install --upgrade pip
+        pip install virtualenv
+        mkdir venv
+        virtualenv venv/venv-2.16
+
+    - name: Install dependencies
+      run: |
+        source venv/venv-2.16/bin/activate
+        python -m pip install --upgrade pip
+        pip install bandit
+
+    - name: Run ac-bandit
+      run: |
+        source venv/venv-2.16/bin/activate
+        ./ac --ac-bandit --level l


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added new github action that will run bandit upon a new pull request with base branch dev or any branch that starts with staging. By default, it will run on three triggers:

open
synchronize (every time the branch, with its PR in draft mode or ready for review gets a new push into remote).
reopen

You can see this Github Action in the following PR https://github.com/fernandofloresg/ibm_zos_core/pull/18
And look at the run details here https://github.com/fernandofloresg/ibm_zos_core/actions/runs/8363170326/job/22895488508?pr=18

It averages 26s of execution time
<img width="386" alt="image" src="https://github.com/ansible-collections/ibm_zos_core/assets/162612450/7d0efac0-3f39-4f28-bf59-591be8abfebf">

And looking at billable details we get 0s,
<img width="616" alt="image" src="https://github.com/ansible-collections/ibm_zos_core/assets/162612450/45a66324-a5c4-4be0-8625-7b64d6a19c19">

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ac-bandit
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
