### PR TITLE
Automatically add "Needs Triage" label on bug creation template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug_issue.yml
@@ -1,7 +1,7 @@
 name: Report a bug
 description: Request that a bug be reviewed. Complete all required fields.
 title: "[Bug] Enter description"
-labels: [Bug]
+labels: ["Bug", "Needs Triage" ]
 assignees:
   - IBMAnsibleHelper
 body:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We've been lately relying on manual addition of "Needs Triage" label for community raised issues, so better to have it automatically added when a bug is reported.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
