### PR TITLE
[Documentation][zoau_version_checker] Standarize docstrings on module_utils/zoau_version_checker.py

### DIFF
--- a/changelogs/fragments/1338-update-docstring-zoau_version_checker.yml
+++ b/changelogs/fragments/1338-update-docstring-zoau_version_checker.yml
@@ -1,3 +1,3 @@
 trivial:
-  - zoau_version_checker - Updated docstrings to google style for visual aid to developers.
+  - zoau_version_checker - Updated docstrings to numpy style for visual aid to developers.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1338).

--- a/changelogs/fragments/1338-update-docstring-zoau_version_checker.yml
+++ b/changelogs/fragments/1338-update-docstring-zoau_version_checker.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zoau_version_checker - Updated docstrings to google style for visual aid to developers.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1338).

--- a/plugins/module_utils/zoau_version_checker.py
+++ b/plugins/module_utils/zoau_version_checker.py
@@ -25,8 +25,10 @@ __metaclass__ = type
 
 def is_zoau_version_higher_than(min_version_str):
     """Reports back if ZOAU version is high enough.
+
     Arguments:
         min_version_str {str} -- The minimal desired ZOAU version '#.#.#'.
+
     Returns:
         bool -- Whether ZOAU version found was high enough.
     """
@@ -78,8 +80,10 @@ def is_valid_version_string(version_str):
         series of numbers (minor) followed by another dot(.) followed by a
         series of numbers (patch) i.e. "#.#.#" where '#' can be any integer.
         There is a provision for a 4th level to this eg "v1.2.0.1".
+
     Arguments:
         min_version_str {str} -- String to be verified is in correct format.
+
     Returns:
         bool -- Whether provided str is in correct format.
     """
@@ -97,10 +101,10 @@ def is_valid_version_string(version_str):
 
 def get_zoau_version_str():
     """Attempts to call zoaversion on target and parses out version string.
-    Returns:
-        { [int, int, int] } -- ZOAU version found in format [#,#,#]. There is a
-                               provision for a 4th level eg "v1.2.0.1".
 
+    Returns:
+        list[int, int, int] -- ZOAU version found in format [#,#,#]. There is a
+                               provision for a 4th level eg "v1.2.0.1".
     """
     version_list = (
         ZOAU_API_VERSION.split('.')

--- a/plugins/module_utils/zoau_version_checker.py
+++ b/plugins/module_utils/zoau_version_checker.py
@@ -28,13 +28,13 @@ def is_zoau_version_higher_than(min_version_str):
 
     Parameters
     ----------
-        min_version_str : str
-            The minimal desired ZOAU version '#.#.#'.
+    min_version_str : str
+        The minimal desired ZOAU version '#.#.#'.
 
     Returns
     -------
-        bool
-            Whether ZOAU version found was high enough.
+    bool
+        Whether ZOAU version found was high enough.
     """
     if is_valid_version_string(min_version_str):
         # check zoau version on system (already a list)
@@ -87,13 +87,13 @@ def is_valid_version_string(version_str):
 
     Parameters
     ----------
-        min_version_str : str
-            String to be verified is in correct format.
+    min_version_str : str
+        String to be verified is in correct format.
 
     Returns
     -------
-        bool
-            Whether provided str is in correct format.
+    bool
+        Whether provided str is in correct format.
     """
 
     # split string into [major, minor, patch]
@@ -112,9 +112,9 @@ def get_zoau_version_str():
 
     Returns
     -------
-        list[int, int, int]
-            ZOAU version found in format [#,#,#]. There is a
-            provision for a 4th level eg "v1.2.0.1".
+    Union[int, int, int]
+        ZOAU version found in format [#,#,#]. There is a
+        provision for a 4th level eg "v1.2.0.1".
     """
     version_list = (
         ZOAU_API_VERSION.split('.')

--- a/plugins/module_utils/zoau_version_checker.py
+++ b/plugins/module_utils/zoau_version_checker.py
@@ -26,11 +26,15 @@ __metaclass__ = type
 def is_zoau_version_higher_than(min_version_str):
     """Reports back if ZOAU version is high enough.
 
-    Arguments:
-        min_version_str {str} -- The minimal desired ZOAU version '#.#.#'.
+    Parameters
+    ----------
+        min_version_str : str
+            The minimal desired ZOAU version '#.#.#'.
 
-    Returns:
-        bool -- Whether ZOAU version found was high enough.
+    Returns
+    -------
+        bool
+            Whether ZOAU version found was high enough.
     """
     if is_valid_version_string(min_version_str):
         # check zoau version on system (already a list)
@@ -81,11 +85,15 @@ def is_valid_version_string(version_str):
         series of numbers (patch) i.e. "#.#.#" where '#' can be any integer.
         There is a provision for a 4th level to this eg "v1.2.0.1".
 
-    Arguments:
-        min_version_str {str} -- String to be verified is in correct format.
+    Parameters
+    ----------
+        min_version_str : str
+            String to be verified is in correct format.
 
-    Returns:
-        bool -- Whether provided str is in correct format.
+    Returns
+    -------
+        bool
+            Whether provided str is in correct format.
     """
 
     # split string into [major, minor, patch]
@@ -102,9 +110,11 @@ def is_valid_version_string(version_str):
 def get_zoau_version_str():
     """Attempts to call zoaversion on target and parses out version string.
 
-    Returns:
-        list[int, int, int] -- ZOAU version found in format [#,#,#]. There is a
-                               provision for a 4th level eg "v1.2.0.1".
+    Returns
+    -------
+        list[int, int, int]
+            ZOAU version found in format [#,#,#]. There is a
+            provision for a 4th level eg "v1.2.0.1".
     """
     version_list = (
         ZOAU_API_VERSION.split('.')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update docstrings on zoau_version_checker to the numpy standard
This addresses part of #1311 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zoau_version_checker.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
