### PR TITLE
[Documentation][zos_mvs_raw] Standarize docstrings on module_utils/zos_mvs_raw.py

### DIFF
--- a/changelogs/fragments/1341-update-docstring-zos_mvs_raw.yml
+++ b/changelogs/fragments/1341-update-docstring-zos_mvs_raw.yml
@@ -1,3 +1,3 @@
 trivial:
-  - zos_mvs_raw - Updated docstrings to google style for visual aid to developers.
+  - zos_mvs_raw - Updated docstrings to numpy style for visual aid to developers.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1341).

--- a/changelogs/fragments/1341-update-docstring-zos_mvs_raw.yml
+++ b/changelogs/fragments/1341-update-docstring-zos_mvs_raw.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_mvs_raw - Updated docstrings to google style for visual aid to developers.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1341).

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -27,13 +27,13 @@ class MVSCmd(object):
     def execute(pgm, dds, parm="", debug=False, verbose=False):
         """Execute an unauthorized MVS command.
 
-        Args:
-            pgm (str): The name of the program to execute.
-            dds (list[DDStatement]): A list of DDStatement objects.
-            parm (str, optional): Argument string if required by the program. Defaults to "".
+        Arguments:
+            pgm {str} -- The name of the program to execute.
+            dds {list[DDStatement]} -- A list of DDStatement objects.
+            parm {str, optional} -- Argument string if required by the program. Defaults to "".
 
         Returns:
-            MVSCmdResponse: The response of the command.
+            MVSCmdResponse -- The response of the command.
         """
         module = AnsibleModuleHelper(argument_spec={})
         command = "mvscmd {0} {1} {2} ".format(
@@ -48,14 +48,14 @@ class MVSCmd(object):
     def execute_authorized(pgm, dds, parm="", debug=False, verbose=False, tmp_hlq=None):
         """Execute an authorized MVS command.
 
-        Args:
-            pgm (str): The name of the program to execute.
-            dds (list[DDStatement]): A list of DDStatement objects.
-            parm (str, optional): Argument string if required by the program. Defaults to "".
-            tmp_hlq (str): The name of the temporary high level qualifier to use for temp data sets.
+        Arguments:
+            pgm {str} -- The name of the program to execute.
+            dds {list[DDStatement]} -- A list of DDStatement objects.
+            parm {str, optional} -- Argument string if required by the program. Defaults to "".
+            tmp_hlq {str} -- The name of the temporary high level qualifier to use for temp data sets.
 
         Returns:
-            MVSCmdResponse: The response of the command.
+            MVSCmdResponse -- The response of the command.
         """
         module = AnsibleModuleHelper(argument_spec={})
         command = "mvscmdauth {0} {1} {2} {3} ".format(
@@ -72,13 +72,13 @@ class MVSCmd(object):
     def _build_command(pgm, dds, parm):
         """Build the command string to be used by ZOAU mvscmd/mvscmdauth.
 
-        Args:
-            pgm (str): [description]
-            dds (list[DDStatement]): A list of DDStatement objects.
-            parm (str, optional): Argument string if required by the program. Defaults to "".
+        Arguments:
+            pgm {str} -- The name of the program to execute.
+            dds {list[DDStatement]} -- A list of DDStatement objects.
+            parm {str, optional} -- Argument string if required by the program. Defaults to "".
 
         Returns:
-            str: Command string formatted as expected by mvscmd/mvscmdauth.
+            str -- Command string formatted as expected by mvscmd/mvscmdauth.
         """
         args_string = ""
         if parm:
@@ -93,6 +93,16 @@ class MVSCmd(object):
 
 class MVSCmdResponse(object):
     """Holds response information for MVSCmd call.
+
+    Arguments:
+        rc {int} -- Return code
+        stdout {str} -- Standard output 
+        stderr {str} -- Standard error
+
+    Attributes:
+        rc {int} -- Return code
+        stdout {str} -- Standard output 
+        stderr {str} -- Standard error
     """
 
     def __init__(self, rc, stdout, stderr):

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -27,13 +27,19 @@ class MVSCmd(object):
     def execute(pgm, dds, parm="", debug=False, verbose=False):
         """Execute an unauthorized MVS command.
 
-        Arguments:
-            pgm {str} -- The name of the program to execute.
-            dds {list[DDStatement]} -- A list of DDStatement objects.
-            parm {str, optional} -- Argument string if required by the program. Defaults to "".
+        Parameters
+        ----------
+            pgm : str
+                The name of the program to execute.
+            dds : list[DDStatement]
+                A list of DDStatement objects.
+            parm : str, optional
+                Argument string if required by the program. Defaults to "".
 
-        Returns:
-            MVSCmdResponse -- The response of the command.
+        Returns
+        -------
+            MVSCmdResponse
+                The response of the command.
         """
         module = AnsibleModuleHelper(argument_spec={})
         command = "mvscmd {0} {1} {2} ".format(
@@ -48,14 +54,21 @@ class MVSCmd(object):
     def execute_authorized(pgm, dds, parm="", debug=False, verbose=False, tmp_hlq=None):
         """Execute an authorized MVS command.
 
-        Arguments:
-            pgm {str} -- The name of the program to execute.
-            dds {list[DDStatement]} -- A list of DDStatement objects.
-            parm {str, optional} -- Argument string if required by the program. Defaults to "".
-            tmp_hlq {str} -- The name of the temporary high level qualifier to use for temp data sets.
+        Parameters
+        ----------
+            pgm : str
+                The name of the program to execute.
+            dds : list[DDStatement]
+                A list of DDStatement objects.
+            parm : str, optional
+                Argument string if required by the program. Defaults to "".
+            tmp_hlq : str
+                The name of the temporary high level qualifier to use for temp data sets.
 
-        Returns:
-            MVSCmdResponse -- The response of the command.
+        Returns
+        -------
+            MVSCmdResponse
+                The response of the command.
         """
         module = AnsibleModuleHelper(argument_spec={})
         command = "mvscmdauth {0} {1} {2} {3} ".format(
@@ -72,13 +85,19 @@ class MVSCmd(object):
     def _build_command(pgm, dds, parm):
         """Build the command string to be used by ZOAU mvscmd/mvscmdauth.
 
-        Arguments:
-            pgm {str} -- The name of the program to execute.
-            dds {list[DDStatement]} -- A list of DDStatement objects.
-            parm {str, optional} -- Argument string if required by the program. Defaults to "".
+        Parameters
+        ----------
+            pgm : str
+                The name of the program to execute.
+            dds : list[DDStatement]
+                A list of DDStatement objects.
+            parm : str, optional
+                Argument string if required by the program. Defaults to "".
 
-        Returns:
-            str -- Command string formatted as expected by mvscmd/mvscmdauth.
+        Returns
+        -------
+            str
+                Command string formatted as expected by mvscmd/mvscmdauth.
         """
         args_string = ""
         if parm:
@@ -94,15 +113,23 @@ class MVSCmd(object):
 class MVSCmdResponse(object):
     """Holds response information for MVSCmd call.
 
-    Arguments:
-        rc {int} -- Return code
-        stdout {str} -- Standard output 
-        stderr {str} -- Standard error
+    Parameters
+    ----------
+        rc : int
+            Return code
+        stdout : str
+            Standard output
+        stderr : str
+            Standard error
 
-    Attributes:
-        rc {int} -- Return code
-        stdout {str} -- Standard output 
-        stderr {str} -- Standard error
+    Attributes
+    ----------
+        rc : int
+            Return code
+        stdout : str
+            Standard output
+        stderr : str
+            Standard error
     """
 
     def __init__(self, rc, stdout, stderr):

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -29,17 +29,17 @@ class MVSCmd(object):
 
         Parameters
         ----------
-            pgm : str
-                The name of the program to execute.
-            dds : list[DDStatement]
-                A list of DDStatement objects.
-            parm : str, optional
-                Argument string if required by the program. Defaults to "".
+        pgm : str
+            The name of the program to execute.
+        dds : list[DDStatement]
+            A list of DDStatement objects.
+        parm : str, optional
+            Argument string if required by the program. Defaults to "".
 
         Returns
         -------
-            MVSCmdResponse
-                The response of the command.
+        MVSCmdResponse
+            The response of the command.
         """
         module = AnsibleModuleHelper(argument_spec={})
         command = "mvscmd {0} {1} {2} ".format(
@@ -56,19 +56,19 @@ class MVSCmd(object):
 
         Parameters
         ----------
-            pgm : str
-                The name of the program to execute.
-            dds : list[DDStatement]
-                A list of DDStatement objects.
-            parm : str, optional
-                Argument string if required by the program. Defaults to "".
-            tmp_hlq : str
-                The name of the temporary high level qualifier to use for temp data sets.
+        pgm : str
+            The name of the program to execute.
+        dds : list[DDStatement]
+            A list of DDStatement objects.
+        parm : str, optional
+            Argument string if required by the program. Defaults to "".
+        tmp_hlq : str
+            The name of the temporary high level qualifier to use for temp data sets.
 
         Returns
         -------
-            MVSCmdResponse
-                The response of the command.
+        MVSCmdResponse
+            The response of the command.
         """
         module = AnsibleModuleHelper(argument_spec={})
         command = "mvscmdauth {0} {1} {2} {3} ".format(
@@ -87,17 +87,17 @@ class MVSCmd(object):
 
         Parameters
         ----------
-            pgm : str
-                The name of the program to execute.
-            dds : list[DDStatement]
-                A list of DDStatement objects.
-            parm : str, optional
-                Argument string if required by the program. Defaults to "".
+        pgm : str
+            The name of the program to execute.
+        dds : list[DDStatement]
+            A list of DDStatement objects.
+        parm : str, optional
+            Argument string if required by the program. Defaults to "".
 
         Returns
         -------
-            str
-                Command string formatted as expected by mvscmd/mvscmdauth.
+        str
+            Command string formatted as expected by mvscmd/mvscmdauth.
         """
         args_string = ""
         if parm:
@@ -111,28 +111,27 @@ class MVSCmd(object):
 
 
 class MVSCmdResponse(object):
-    """Holds response information for MVSCmd call.
-
-    Parameters
-    ----------
-        rc : int
-            Return code
-        stdout : str
-            Standard output
-        stderr : str
-            Standard error
-
-    Attributes
-    ----------
-        rc : int
-            Return code
-        stdout : str
-            Standard output
-        stderr : str
-            Standard error
-    """
-
     def __init__(self, rc, stdout, stderr):
+        """Holds response information for MVSCmd call.
+
+        Parameters
+        ----------
+        rc : int
+            Return code.
+        stdout : str
+            Standard output.
+        stderr : str
+            Standard error.
+
+        Attributes
+        ----------
+        rc : int
+            Return code.
+        stdout : str
+            Standard output.
+        stderr : str
+            Standard error.
+        """
         self.rc = rc
         self.stdout = stdout
         self.stderr = stderr


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update docstrings on zos_mvs_raw to the numpy standard
This addresses part of #1311 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zos_mvs_raw.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
