### PR TITLE
[Documentation][zos_volume_init] Add and standarize docstrings on modules/zos_volume_init.py

### DIFF
--- a/changelogs/fragments/1391-update-docstring-zos_volume_init.yml
+++ b/changelogs/fragments/1391-update-docstring-zos_volume_init.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_volume_init - Updated docstrings to numpy style for visual aid to developers.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1391).

--- a/changelogs/fragments/1392-update-docstring-zos_volume_init.yml
+++ b/changelogs/fragments/1392-update-docstring-zos_volume_init.yml
@@ -1,3 +1,3 @@
 trivial:
   - zos_volume_init - Updated docstrings to numpy style for visual aid to developers.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1391).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1392).

--- a/plugins/modules/zos_volume_init.py
+++ b/plugins/modules/zos_volume_init.py
@@ -230,7 +230,13 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import ickdsf  # 
 
 
 def run_module():
+    """Initialize the module.
 
+    Raises
+    ------
+    fail_json
+        'Index' cannot be False for SMS managed volumes.
+    """
     module_args = dict(
         address=dict(type="str", required=True),
         verify_volid=dict(type="str", required=False),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update docstrings on zos_volume_init to the numpy standard
This addresses part of #1316 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zos_volume_init.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
