### PR TITLE
[Documentation][zos_apf] Add and standarize docstrings on modules/zos_apf.py

### DIFF
--- a/changelogs/fragments/1392-update-docstring-zos_apf.yml
+++ b/changelogs/fragments/1392-update-docstring-zos_apf.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_apf - Updated docstrings to numpy style for visual aid to developers.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1392).

--- a/changelogs/fragments/1393-update-docstring-zos_apf.yml
+++ b/changelogs/fragments/1393-update-docstring-zos_apf.yml
@@ -1,3 +1,3 @@
 trivial:
   - zos_apf - Updated docstrings to numpy style for visual aid to developers.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1392).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1393).

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -312,6 +312,30 @@ DS_TYPE = ['PS', 'PO']
 
 
 def backupOper(module, src, backup, tmphlq=None):
+    """Backup operations
+
+    Parameters
+    ----------
+    module : AnsibleModule
+    src : str
+        Source of the file.
+    backup : str
+        Name for the backup file.
+    tmphlq : str
+        The name of the temporary high level qualifier to use.
+
+    Returns
+    -------
+    str
+        Backup name.
+
+    Raises
+    ------
+    fail_json
+        Data set type is NOT supported.
+    fail_json
+        Creating backup has failed.
+    """
     # analysis the file type
     ds_utils = data_set.DataSetUtils(src)
     file_type = ds_utils.ds_type()
@@ -336,6 +360,19 @@ def backupOper(module, src, backup, tmphlq=None):
 
 
 def main():
+    """Initialize the module.
+
+    Raises
+    ------
+    fail_json
+        Parameter verification failed.
+    fail_json
+        Marker length may not exceed 72 characters.
+    fail_json
+        library is required.
+    fail_json
+        An exception occurred.
+    """
     module = AnsibleModule(
         argument_spec=dict(
             library=dict(

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -312,15 +312,15 @@ DS_TYPE = ['PS', 'PO']
 
 
 def backupOper(module, src, backup, tmphlq=None):
-    """Backup operations
+    """Create a backup for a specified USS file or MVS data set.
 
     Parameters
     ----------
     module : AnsibleModule
     src : str
-        Source of the file.
+        Source USS file or data set to backup.
     backup : str
-        Name for the backup file.
+        Name for the backup.
     tmphlq : str
         The name of the temporary high level qualifier to use.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update docstrings on zos_apf to the numpy standard
This addresses part of #1316 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
zos_apf.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
