### PR TITLE
Updated actions to only run when PR is not draft

### DIFF
--- a/.github/workflows/ac-ansible-test-sanity.yml
+++ b/.github/workflows/ac-ansible-test-sanity.yml
@@ -2,6 +2,7 @@ name: AC Ansible sanity
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - dev
       - staging*
@@ -38,6 +39,7 @@ on:
 
 jobs:
   ansible-sanity:
+    if: ! github.event.pull_request.draft
     runs-on: ubuntu-latest
     env:
       branch: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/ac-ansible-test-sanity.yml
+++ b/.github/workflows/ac-ansible-test-sanity.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   ansible-sanity:
-    if: ! github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
       branch: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/ac-bandit.yml
+++ b/.github/workflows/ac-bandit.yml
@@ -2,12 +2,14 @@ name: AC Bandit
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - dev
       - staging*
     
 jobs:
   bandit:
+    if: ! github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ac-bandit.yml
+++ b/.github/workflows/ac-bandit.yml
@@ -6,7 +6,9 @@ on:
     branches:
       - dev
       - staging*
-    
+    paths:
+      - 'plugins/**'
+
 jobs:
   bandit:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ac-bandit.yml
+++ b/.github/workflows/ac-bandit.yml
@@ -9,7 +9,7 @@ on:
     
 jobs:
   bandit:
-    if: ! github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ac-galaxy-importer.yml
+++ b/.github/workflows/ac-galaxy-importer.yml
@@ -2,12 +2,14 @@ name: AC Galaxy Importer
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - dev
       - staging*
     
 jobs:
   galaxy-importer:
+    if: ! github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ac-galaxy-importer.yml
+++ b/.github/workflows/ac-galaxy-importer.yml
@@ -9,7 +9,7 @@ on:
     
 jobs:
   galaxy-importer:
-    if: ! github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ac-galaxy-importer.yml
+++ b/.github/workflows/ac-galaxy-importer.yml
@@ -6,7 +6,37 @@ on:
     branches:
       - dev
       - staging*
-    
+    paths-ignore:
+      - '**.tar.gz'
+      - 'pycache/**'
+      - '.ansible-lint'
+      - 'cache/**'
+      - '.DS_Store'
+      - '.git/**'
+      - '.github/**'
+      - '.gitignore'
+      - '.python-version'
+      - '.pytest_cache/**'
+      - '.vscode/**'
+      - 'Jenkinsfile'
+      - 'ac'
+      - 'ansible.cfg'
+      - 'changelogs/**'
+      - 'collections/**'
+      - 'docs/**'
+      - 'scripts/**'
+      - 'test_config.yml'
+      - 'tests/*.ini'
+      - 'tests/*.py'
+      - 'tests/.pytest_cache'
+      - 'tests/pycache'
+      - 'tests/functional'
+      - 'tests/helpers'
+      - 'tests/requirements.txt'
+      - 'tests/unit'
+      - 'tests/sanity/ignore-*'
+      - 'venv*'
+
 jobs:
   galaxy-importer:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ac_changelog.yml
+++ b/.github/workflows/ac_changelog.yml
@@ -2,6 +2,7 @@ name: AC Changelog Lint
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'changelogs/fragments/*'
     branches:
@@ -10,6 +11,7 @@ on:
 
 jobs:
   lint:
+    if: ! github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ac_changelog.yml
+++ b/.github/workflows/ac_changelog.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   lint:
-    if: ! github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -18,7 +18,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: zos_apf
+module: zos_apf.
 version_added: '1.3.0'
 author:
   - "Behnam (@balkajbaf)"

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -214,7 +214,7 @@ notes:
 
 
 EXAMPLES = r'''
-- name: Add a library to the APF list
+- name: Add a library to the APF list.
   zos_apf:
     library: SOME.SEQUENTIAL.DATASET
     volume: T12345

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -18,7 +18,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 ---
-module: zos_apf.
+module: zos_apf
 version_added: '1.3.0'
 author:
   - "Behnam (@balkajbaf)"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated the Github Action in the repository so that when PRs are in draft mode no action will be run, saving us some execution time.

Also updated the paths for when to run bandit and when to run the galaxy importer, basically bandit should only be executed when something under `plugins` changed, and galaxy importer when something that is included in the release tar is changed.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
