### PR TITLE
[zos_find] Fix filter PDSE by size

### DIFF
--- a/changelogs/fragments/1450-zos_find-filter-size-pdse.yml
+++ b/changelogs/fragments/1450-zos_find-filter-size-pdse.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zos_find - Filter size failed if a PDS/E matched the pattern. Fix now gets the correct size
+    for PDS/Es.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1450).

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -479,7 +479,7 @@ def data_set_attribute_filter(
                 age and not size and _age_filter(ds_age, now, age)
             ) or
             (
-                size and not age and _size_filter(int(out[5]), size)
+                size and not age and _size_filter(int(out[6]), size)
             )
         ):
             filtered_data_sets.add(ds)

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import pytest
 from ibm_zos_core.tests.helpers.volumes import Volume_Handler
 
 SEQ_NAMES = [
@@ -32,6 +33,7 @@ VSAM_NAMES = [
     "TEST.FIND.VSAM.FUNCTEST.FIRST"
 ]
 
+DATASET_TYPES = ['seq', 'pds', 'pdse']
 
 def create_vsam_ksds(ds_name, ansible_zos_module, volume="000000"):
     hosts = ansible_zos_module
@@ -216,13 +218,14 @@ def test_find_data_sets_older_than_age(ansible_zos_module):
         assert val.get('matched') == 2
 
 
-def test_find_data_sets_larger_than_size(ansible_zos_module):
+@pytest.mark.parametrize("ds_type", DATASET_TYPES)
+def test_find_data_sets_larger_than_size(ansible_zos_module, ds_type):
     hosts = ansible_zos_module
     TEST_PS1 = 'TEST.PS.ONE'
     TEST_PS2 = 'TEST.PS.TWO'
     try:
-        res = hosts.all.zos_data_set(name=TEST_PS1, state="present", size="5m")
-        res = hosts.all.zos_data_set(name=TEST_PS2, state="present", size="5m")
+        res = hosts.all.zos_data_set(name=TEST_PS1, state="present", size="5m", type=ds_type)
+        res = hosts.all.zos_data_set(name=TEST_PS2, state="present", size="5m", type=ds_type)
         find_res = hosts.all.zos_find(patterns=['TEST.PS.*'], size="1k")
         for val in find_res.contacted.values():
             assert len(val.get('data_sets')) == 2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated how we check the size to be consistent. We check allocated space instead of utilized space because we can not get that value for PDS/E. Essentially, added support for PDS/e datasets.

Fixes #1062 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_find

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
