### PR TITLE
Enabler/1319/redesign mvs raw

### DIFF
--- a/changelogs/fragments/1470-redesign_mvs_raw.yml
+++ b/changelogs/fragments/1470-redesign_mvs_raw.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zos_mvs_raw - Redesign the wrappers of dd clases to use properly the arguments.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1470).

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -38,13 +38,19 @@ class MVSCmd(object):
     def execute(pgm, dds, parm="", debug=False, verbose=False, tmp_hlq=None):
         """Execute an unauthorized MVS command.
 
-        Args:
-            pgm (str): The name of the program to execute.
-            dds (list[DDStatement]): A list of DDStatement objects.
-            parm (str, optional): Argument string if required by the program. Defaults to "".
+        Parameters
+        ----------
+            pgm : str
+                The name of the program to execute.
+            dds : list[DDStatement]
+                A list of DDStatement objects.
+            parm : str, optional)
+                 Argument string if required by the program. Defaults to "".
 
-        Returns:
-            MVSCmdResponse: The response of the command.
+        Returns
+        -------
+            MVSCmdResponse : object
+                           The response of the command.
         """
         module = AnsibleModuleHelper(argument_spec={})
         command = "mvscmd {0} {1} {2} {3}".format(
@@ -60,14 +66,21 @@ class MVSCmd(object):
     def execute_authorized(pgm, dds, parm="", debug=False, verbose=False, tmp_hlq=None):
         """Execute an authorized MVS command.
 
-        Args:
-            pgm (str): The name of the program to execute.
-            dds (list[DDStatement]): A list of DDStatement objects.
-            parm (str, optional): Argument string if required by the program. Defaults to "".
-            tmp_hlq (str): The name of the temporary high level qualifier to use for temp data sets.
+        Parameters
+        ----------
+            pgm : str
+                The name of the program to execute.
+            dds : list[DDStatement]
+                A list of DDStatement objects.
+            parm : str, optional
+                 Argument string if required by the program. Defaults to "".
+            tmp_hlq : str
+                    The name of the temporary high level qualifier to use for temp data sets.
 
-        Returns:
-            MVSCmdResponse: The response of the command.
+        Returns
+        -------
+            MVSCmdResponse : object
+                           The response of the command.
         """
         module = AnsibleModuleHelper(argument_spec={})
         command = "mvscmdauth {0} {1} {2} {3} ".format(
@@ -83,13 +96,19 @@ class MVSCmd(object):
     def _build_command(pgm, dds, parm):
         """Build the command string to be used by ZOAU mvscmd/mvscmdauth.
 
-        Args:
-            pgm (str): [description]
-            dds (list[DDStatement]): A list of DDStatement objects.
-            parm (str, optional): Argument string if required by the program. Defaults to "".
+        Parameters
+        ----------
+            pgm : str
+                [description]
+            dds : list[DDStatement]
+                A list of DDStatement objects.
+            parm : str, optional
+                 Argument string if required by the program. Defaults to "".
 
-        Returns:
-            str: Command string formatted as expected by mvscmd/mvscmdauth.
+        Returns
+        -------
+            command : str
+                    Command string formatted as expected by mvscmd/mvscmdauth.
         """
         args_string = ""
         if parm:
@@ -115,9 +134,6 @@ class MVSCmdResponse(object):
 class RawDatasetDefinition(DatasetDefinition):
     """Wrapper around DatasetDefinition to contain information about
     desired return contents.
-
-    Args:
-        DatasetDefinition (DatasetDefinition): Dataset DD data type to be used in a DDStatement.
     """
 
     def __init__(
@@ -150,37 +166,66 @@ class RawDatasetDefinition(DatasetDefinition):
         tmphlq=None,
         **kwargs
     ):
-        """Initialize RawDatasetDefinition
-
+        """
+        DatasetDefinition (DatasetDefinition): Dataset DD data type to be used in a DDStatement.
+        Parameters
+        ----------
         Args:
-            data_set_name (str): The name of the data set.
-            disposition (str, optional): The disposition of the data set. Defaults to "".
-            type (str, optional): The type of the data set. Defaults to None.
-            space_primary (int, optional): The primary amount of space of the data set. Defaults to None.
-            space_secondary (int, optional): The secondary amount of space of the data set. Defaults to None.
-            space_type (str, optional): The unit of space to use for primary and secondary space. Defaults to None.
-            disposition_normal (str, optional): What to do with the data set after normal termination of the program. Defaults to None.
-            disposition_abnormal (str, optional): What to do with the data set after abnormal termination of the program. Defaults to None.
-            block_size (int, optional): The block size of the data set. Defaults to None.
-            directory_blocks (int, optional): The number of directory blocks to allocate for the data set. Defaults to None.
-            record_format (str, optional): The record format of the data set. Defaults to None.
-            record_length (int, optional): The length, in bytes, of each record in the data set. Defaults to None.
-            sms_storage_class (str, optional): The storage class for an SMS-managed dataset. Defaults to None.
-            sms_data_class (str, optional): The data class for an SMS-managed dataset. Defaults to None.
-            sms_management_class (str, optional): The management class for an SMS-managed dataset. Defaults to None.
-            key_length (int, optional): The key length of a record. Defaults to None.
-            key_offset (int, optional): The key offset is the position of the first byte of the key
-                in each logical record of a the specified VSAM data set. Defaults to None.
-            volumes (list, optional): A list of volume serials.. Defaults to None.
-            key_label (str, optional): The label for the encryption key used by the system to encrypt the data set. Defaults to None.
-            encryption_key_1 (dict, optional): [description]. Defaults to None.
-            encryption_key_2 (dict, optional): [description]. Defaults to None.
-            reuse (bool, optional): Determines if data set should be reused. Defaults to None.
-            replace (bool, optional): Determines if data set should be replaced. Defaults to None.
-            backup (bool, optional): Determines if a backup should be made of existing data set when disposition=NEW, replace=true,
-                and a data set with the desired name is found.. Defaults to None.
-            return_content (dict, optional): Determines how content should be returned to the user. Defaults to None.
-            tmphlq (str, optional): HLQ to be used for temporary datasets. Defaults to None.
+            data_set_name : str
+                          The name of the data set.
+            disposition : str, optional
+                        The disposition of the data set. Defaults to "".
+            type : str, optional
+                 The type of the data set. Defaults to None.
+            space_primary : int, optional
+                          The primary amount of space of the data set. Defaults to None.
+            space_secondary : int, optional
+                            The secondary amount of space of the data set. Defaults to None.
+            space_type : str, optional
+                       The unit of space to use for primary and secondary space. Defaults to None.
+            disposition_normal : str, optional
+                               What to do with the data set after normal termination of the program. Defaults to None.
+            disposition_abnormal : str, optional
+                                 What to do with the data set after abnormal termination of the program. Defaults to None.
+            block_size : int, optional
+                       The block size of the data set. Defaults to None.
+            directory_blocks : int, optional
+                             The number of directory blocks to allocate for the data set. Defaults to None.
+            record_format : str, optional
+                          The record format of the data set. Defaults to None.
+            record_length : int, optional
+                          The length, in bytes, of each record in the data set. Defaults to None.
+            sms_storage_class : str, optional
+                              The storage class for an SMS-managed dataset. Defaults to None.
+            sms_data_class : str, optional
+                           The data class for an SMS-managed dataset. Defaults to None.
+            sms_management_class : str, optional
+                                 The management class for an SMS-managed dataset. Defaults to None.
+            key_length : int, optional
+                       The key length of a record. Defaults to None.
+            key_offset : int, optional
+                       The key offset is the position of the first byte of the key
+                       in each logical record of a the specified VSAM data set. Defaults to None.
+            volumes : list, optional
+                    A list of volume serials.. Defaults to None.
+            key_label : str, optional
+                      The label for the encryption key used by the system to encrypt the data set. Defaults to None.
+            encryption_key_1 : dict, optional
+                             [description]. Defaults to None.
+            encryption_key_2 : dict, optional
+                             [description]. Defaults to None.
+            reuse : bool, optional
+                  Determines if data set should be reused. Defaults to None.
+            replace : bool, optional
+                    Determines if data set should be replaced. Defaults to None.
+            backup : bool, optional
+                   Determines if a backup should be made of existing data set when disposition=NEW, replace=true,
+                   and a data set with the desired name is found.. Defaults to None.
+            return_content : dict, optional
+                           Determines how content should be returned to the user. Defaults to None.
+            tmphlq : str, optional
+                   HLQ to be used for temporary datasets. Defaults to None.
+        ----------
         """
         self.backup = None
         self.return_content = ReturnContent(**(return_content or {}))
@@ -258,9 +303,6 @@ class RawDatasetDefinition(DatasetDefinition):
 class RawFileDefinition(FileDefinition):
     """Wrapper around FileDefinition to contain information about
     desired return contents.
-
-    Args:
-        FileDefinition (FileDefinition): File DD data type to be used in a DDStatement.
     """
 
     def __init__(
@@ -278,20 +320,32 @@ class RawFileDefinition(FileDefinition):
         return_content=None,
         **kwargs
     ):
-        """Initialize RawFileDefinition
-
-        Args:
-            path (str): An absolute UNIX file path.
-            disposition_normal (str, optional): What to do with path after normal program termination. Defaults to None.
-            disposition_abnormal (str, optional): What to do with path after abnormal program termination. Defaults to None.
-            mode (int, optional): The file access attributes for the UNIX file being allocated. Defaults to None.
-            access_group (str, optional): the access mode for UNIX file. Defaults to None.
-            status_group (list[str], optional): The status for UNIX file being allocated. Defaults to None.
-            file_data_type (str, optional): The type of data that is (or will be) stored in the UNIX file. Defaults to None.
-            record_length (int, optional): The specified logical record length for the UNIX file. Defaults to None.
-            block_size (int, optional): the specified block size for the UNIX file being allocated. Defaults to None.
-            record_format (str, optional): The specified record format for the UNIX file. Defaults to None.
-            return_content (dict, optional): Determines how content should be returned to the user. Defaults to None.
+        """
+        FileDefinition (FileDefinition): File DD data type to be used in a DDStatement.
+        Parameters
+        ----------
+            path : str
+                 An absolute UNIX file path.
+            disposition_normal : str, optional
+                               What to do with path after normal program termination. Defaults to None.
+            disposition_abnormal : str, optional
+                                 What to do with path after abnormal program termination. Defaults to None.
+            mode : int, optional
+                 The file access attributes for the UNIX file being allocated. Defaults to None.
+            access_group : str, optional
+                         The access mode for UNIX file. Defaults to None.
+            status_group : list[str], optional
+                         The status for UNIX file being allocated. Defaults to None.
+            file_data_type : str, optional
+                           The type of data that is (or will be) stored in the UNIX file. Defaults to None.
+            record_length : int, optional
+                          The specified logical record length for the UNIX file. Defaults to None.
+            block_size : int, optional
+                       The specified block size for the UNIX file being allocated. Defaults to None.
+            record_format : str, optional
+                          The specified record format for the UNIX file. Defaults to None.
+            return_content : dict, optional
+                           Determines how content should be returned to the user. Defaults to None.
         """
         self.return_content = ReturnContent(**(return_content or {}))
         super().__init__(
@@ -311,9 +365,6 @@ class RawFileDefinition(FileDefinition):
 class RawInputDefinition(InputDefinition):
     """Wrapper around InputDefinition to contain information about
     desired return contents.
-
-    Args:
-        InputDefinition (InputDefinition): Input DD data type to be used in a DDStatement.
     """
 
     def __init__(
@@ -323,11 +374,14 @@ class RawInputDefinition(InputDefinition):
             tmphlq="",
             **kwargs
     ):
-        """Initialize RawInputDefinition
-
-        Args:
-            content (str): The content to write to temporary data set / stdin.
-            return_content (dict, optional): Determines how content should be returned to the user. Defaults to {}.
+        """
+        InputDefinition (InputDefinition): Input DD data type to be used in a DDStatement.
+        Parameters
+        ----------
+            content : str
+                    The content to write to temporary data set / stdin.
+            return_content : dict, optional
+                           Determines how content should be returned to the user. Defaults to {}.
         """
         self.return_content = ReturnContent(**(return_content or {}))
         super().__init__(
@@ -338,9 +392,6 @@ class RawInputDefinition(InputDefinition):
 class RawOutputDefinition(OutputDefinition):
     """Wrapper around OutputDefinition to contain information about
     desired return contents.
-
-    Args:
-        OutputDefinition (OutputDefinition): Output DD data type to be used in a DDStatement.
     """
 
     def __init__(
@@ -349,11 +400,14 @@ class RawOutputDefinition(OutputDefinition):
             tmphlq="",
             **kwargs
     ):
-        """Initialize RawOutputDefinition
-
-        Args:
-            content (str): The content to write to temporary data set / stdin.
-            return_content (dict, optional): Determines how content should be returned to the user. Defaults to {}.
+        """
+        OutputDefinition (OutputDefinition): Output DD data type to be used in a DDStatement.
+        Parameters
+        ----------
+            content : str
+                    The content to write to temporary data set / stdin.
+            return_content : dict, optional
+                           Determines how content should be returned to the user. Defaults to {}.
         """
         self.return_content = ReturnContent(**(return_content or {}))
         super().__init__(
@@ -364,21 +418,18 @@ class RawOutputDefinition(OutputDefinition):
 class ReturnContent(object):
     """Holds information about what type of content
     should be returned for a particular DD, if any.
-
-    Args:
-        object (object): The most base type.
     """
 
     def __init__(self, type=None, src_encoding=None, response_encoding=None):
-        """Initialize ReturnContent
-
-        Args:
-            type (str, optional): The type of content to return.
-                    Defaults to None.
-            src_encoding (str, optional): The encoding of the data set or file on the z/OS system.
-                    Defaults to None.
-            response_encoding (str, optional): The encoding to use when returning the contents of the data set or file.
-                    Defaults to None.
+        """
+        Parameters
+        ----------
+            type : str, optional
+                 The type of content to return.
+            src_encoding : str, optional
+                         The encoding of the data set or file on the z/OS system.
+            response_encoding : str, optional
+                              The encoding to use when returning the contents of the data set or file.
         """
         self.type = type
         self.src_encoding = src_encoding

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -348,7 +348,7 @@ class RawOutputDefinition(OutputDefinition):
             return_content=None,
             tmphlq="",
             **kwargs
-            ):
+        ):
         """Initialize RawOutputDefinition
 
         Args:

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -123,7 +123,6 @@ class RawDatasetDefinition(DatasetDefinition):
     def __init__(
         self,
         data_set_name,
-        backups,
         disposition="",
         disposition_normal=None,
         disposition_abnormal=None,
@@ -149,6 +148,7 @@ class RawDatasetDefinition(DatasetDefinition):
         backup=None,
         return_content=None,
         tmphlq=None,
+        **kwargs
     ):
         """Initialize RawDatasetDefinition
 
@@ -209,9 +209,6 @@ class RawDatasetDefinition(DatasetDefinition):
             elif replace:
                 if backup:
                     self.backup = zos_backup.mvs_file_backup(data_set_name, None, tmphlq)
-                    backups.append(
-                        {"original_name": data_set_name, "backup_name": self.backup}
-                    )
                 DataSet.delete(data_set_name)
 
         if not should_reuse:
@@ -279,6 +276,7 @@ class RawFileDefinition(FileDefinition):
         record_length=None,
         record_format=None,
         return_content=None,
+        **kwargs
     ):
         """Initialize RawFileDefinition
 
@@ -322,7 +320,8 @@ class RawInputDefinition(InputDefinition):
             self,
             content="",
             return_content=None,
-            tmphlq=""
+            tmphlq="",
+            **kwargs
     ):
         """Initialize RawInputDefinition
 
@@ -344,10 +343,12 @@ class RawOutputDefinition(OutputDefinition):
         OutputDefinition (OutputDefinition): Output DD data type to be used in a DDStatement.
     """
 
-    def __init__(self,
-                 return_content=None,
-                 tmphlq="",
-                 ):
+    def __init__(
+            self,
+            return_content=None,
+            tmphlq="",
+            **kwargs
+            ):
         """Initialize RawOutputDefinition
 
         Args:

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -203,7 +203,7 @@ class RawDatasetDefinition(DatasetDefinition):
                 key_encoding2 = encryption_key_2.get("encoding")
 
         should_reuse = False
-        if (reuse or replace) and data_set_exists(data_set_name, volumes):
+        if (reuse or replace) and DataSet.data_set_exists(data_set_name, volumes):
             if reuse:
                 should_reuse = True
             elif replace:
@@ -383,26 +383,3 @@ class ReturnContent(object):
         self.type = type
         self.src_encoding = src_encoding
         self.response_encoding = response_encoding
-
-
-def data_set_exists(name, volumes=None):
-    """Is used to determine if a data set exists.
-    In addition, if a data set does exist and is uncataloged,
-    the data set will be cataloged.
-
-    Args:
-        name (str): The name of the data set.
-        volumes (list[str], optional): A list of volume serials. Defaults to None.
-
-    Returns:
-        bool: Whether the data set exists or not.
-    """
-    exists = False
-    try:
-        present, changed = DataSet.attempt_catalog_if_necessary(name, volumes)
-        exists = present
-    except Exception:
-        # Failure locating or cataloging the data set. Go ahead assumming it does not exist.
-        # exists = False to avoid using pass clause which results in bandit warning.
-        exists = False
-    return exists

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -348,7 +348,7 @@ class RawOutputDefinition(OutputDefinition):
             return_content=None,
             tmphlq="",
             **kwargs
-        ):
+    ):
         """Initialize RawOutputDefinition
 
         Args:

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -19,18 +19,16 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module im
 )
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.dd_statement import (
-    DDStatement,
     FileDefinition,
     DatasetDefinition,
     InputDefinition,
     OutputDefinition,
-    DummyDefinition,
-    VIODefinition,
 )
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.data_set import DataSet
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     backup as zos_backup,
 )
+
 
 class MVSCmd(object):
     """Provides an interface to execute authorized and unauthorized MVS commands.
@@ -114,10 +112,6 @@ class MVSCmdResponse(object):
         self.stderr = stderr
 
 
-class backups():
-    def __init__():
-        backups = []
-
 class RawDatasetDefinition(DatasetDefinition):
     """Wrapper around DatasetDefinition to contain information about
     desired return contents.
@@ -129,32 +123,32 @@ class RawDatasetDefinition(DatasetDefinition):
     def __init__(
         self,
         data_set_name,
+        backups,
         disposition="",
-        type=None,
-        space_primary=None,
-        space_secondary=None,
-        space_type=None,
         disposition_normal=None,
         disposition_abnormal=None,
-        block_size=None,
-        directory_blocks=None,
-        record_format=None,
-        record_length=None,
+        space_type=None,
+        space_primary=None,
+        space_secondary=None,
+        volumes=None,
+        sms_management_class=None,
         sms_storage_class=None,
         sms_data_class=None,
-        sms_management_class=None,
-        key_length=None,
-        key_offset=None,
-        volumes=None,
+        block_size=None,
+        directory_blocks=None,
         key_label=None,
+        type=None,
         encryption_key_1=None,
         encryption_key_2=None,
+        key_length=None,
+        key_offset=None,
+        record_length=None,
+        record_format=None,
         reuse=None,
         replace=None,
         backup=None,
         return_content=None,
         tmphlq=None,
-        **kwargs
     ):
         """Initialize RawDatasetDefinition
 
@@ -264,6 +258,108 @@ class RawDatasetDefinition(DatasetDefinition):
             )
 
 
+class RawFileDefinition(FileDefinition):
+    """Wrapper around FileDefinition to contain information about
+    desired return contents.
+
+    Args:
+        FileDefinition (FileDefinition): File DD data type to be used in a DDStatement.
+    """
+
+    def __init__(
+        self,
+        path,
+        disposition_normal=None,
+        disposition_abnormal=None,
+        mode=None,
+        status_group=None,
+        access_group=None,
+        file_data_type=None,
+        block_size=None,
+        record_length=None,
+        record_format=None,
+        return_content=None,
+    ):
+        """Initialize RawFileDefinition
+
+        Args:
+            path (str): An absolute UNIX file path.
+            disposition_normal (str, optional): What to do with path after normal program termination. Defaults to None.
+            disposition_abnormal (str, optional): What to do with path after abnormal program termination. Defaults to None.
+            mode (int, optional): The file access attributes for the UNIX file being allocated. Defaults to None.
+            access_group (str, optional): the access mode for UNIX file. Defaults to None.
+            status_group (list[str], optional): The status for UNIX file being allocated. Defaults to None.
+            file_data_type (str, optional): The type of data that is (or will be) stored in the UNIX file. Defaults to None.
+            record_length (int, optional): The specified logical record length for the UNIX file. Defaults to None.
+            block_size (int, optional): the specified block size for the UNIX file being allocated. Defaults to None.
+            record_format (str, optional): The specified record format for the UNIX file. Defaults to None.
+            return_content (dict, optional): Determines how content should be returned to the user. Defaults to None.
+        """
+        self.return_content = ReturnContent(**(return_content or {}))
+        super().__init__(
+            path_name=path,
+            normal_disposition=disposition_normal,
+            conditional_disposition=disposition_abnormal,
+            path_mode=mode,
+            access_group=access_group,
+            status_group=status_group,
+            file_data=file_data_type,
+            record_length=record_length,
+            block_size=block_size,
+            record_format=record_format,
+        )
+
+
+class RawInputDefinition(InputDefinition):
+    """Wrapper around InputDefinition to contain information about
+    desired return contents.
+
+    Args:
+        InputDefinition (InputDefinition): Input DD data type to be used in a DDStatement.
+    """
+
+    def __init__(
+            self,
+            content="",
+            return_content=None,
+            tmphlq=""
+    ):
+        """Initialize RawInputDefinition
+
+        Args:
+            content (str): The content to write to temporary data set / stdin.
+            return_content (dict, optional): Determines how content should be returned to the user. Defaults to {}.
+        """
+        self.return_content = ReturnContent(**(return_content or {}))
+        super().__init__(
+            content=content,
+            tmphlq=tmphlq)
+
+
+class RawOutputDefinition(OutputDefinition):
+    """Wrapper around OutputDefinition to contain information about
+    desired return contents.
+
+    Args:
+        OutputDefinition (OutputDefinition): Output DD data type to be used in a DDStatement.
+    """
+
+    def __init__(self,
+                 return_content=None,
+                 tmphlq="",
+                 ):
+        """Initialize RawOutputDefinition
+
+        Args:
+            content (str): The content to write to temporary data set / stdin.
+            return_content (dict, optional): Determines how content should be returned to the user. Defaults to {}.
+        """
+        self.return_content = ReturnContent(**(return_content or {}))
+        super().__init__(
+            tmphlq=tmphlq
+        )
+
+
 class ReturnContent(object):
     """Holds information about what type of content
     should be returned for a particular DD, if any.
@@ -286,6 +382,7 @@ class ReturnContent(object):
         self.type = type
         self.src_encoding = src_encoding
         self.response_encoding = response_encoding
+
 
 def data_set_exists(name, volumes=None):
     """Is used to determine if a data set exists.

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -211,9 +211,11 @@ class RawDatasetDefinition(DatasetDefinition):
             key_label : str, optional
                       The label for the encryption key used by the system to encrypt the data set. Defaults to None.
             encryption_key_1 : dict, optional
-                             [description]. Defaults to None.
+                             The label for the key encrypting key used by the Encryption Key Manager and how the label
+                             for the key encrypting key specified.
             encryption_key_2 : dict, optional
-                             [description]. Defaults to None.
+                             The label for the key encrypting key used by the Encryption Key Manager and how the label
+                             for the key encrypting key specified
             reuse : bool, optional
                   Determines if data set should be reused. Defaults to None.
             replace : bool, optional

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1278,6 +1278,16 @@ backups:
     backup_name:
       description: The name of the data set containing the backup of content from data set in original_name.
       type: str
+stdout:
+  The stdout from a USS command or MVS command, if applicable.
+  returned: always
+  type: str
+  sample:
+stderr:
+  The stderr of a USS command or MVS command, if applicable.
+  returned: failure
+  type: str
+  sample:
 """
 
 EXAMPLES = r"""
@@ -2500,9 +2510,9 @@ def build_response(rc, dd_statements, stdout):
         dict: Response dictionary in format expected for response on module completion.
     """
     response = {"ret_code": {"code": rc}}
-    response["stdout"] = stdout
     response["backups"] = gather_backups(dd_statements)
     response["dd_names"] = gather_output(dd_statements)
+    response["stdout"] = stdout
     return response
 
 
@@ -2562,7 +2572,7 @@ def gather_output(dd_statements):
     """
     output = []
     for dd_statement in dd_statements:
-        output += get_dd_output(dd_statement)
+        output.append(get_dd_output(dd_statement))
     return output
 
 

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1879,11 +1879,15 @@ def run_module():
 def parse_and_validate_args(params):
     """Perform additional argument validation to validate and update input content,
 
-    Args:
-        params (dict): The raw module parameters as provided by AnsibleModule.
+    Parameters
+    ----------
+        params : dict
+               The raw module parameters as provided by AnsibleModule.
 
-    Returns:
-        dict: The module parameters after validation and content updates.
+    Returns
+    -------
+        parsed_args : dict
+                    The module parameters after validation and content updates.
     """
     dd_name_base = dict(dd_name=dict(type="dd", required=True))
 
@@ -2067,12 +2071,17 @@ def combine_dicts(dict1, dict2):
     """Combine two dictionaries.
     Provides clean way to combine two dictionaries in python >= 2
 
-    Args:
-        dict1 (dict): The first dict to add to combine
-        dict2 (dict): The second dict to add to combine
+    Parameters
+    ----------
+        dict1 : dict
+              The first dict to add to combine
+        dict2 : dict
+              The second dict to add to combine
 
-    Returns:
-        dict: The combination of dict1 and dict2.
+    Returns
+    -------
+        merged_dict : dict
+                    The combination of dict1 and dict2.
     """
     merged_dict = dict1.copy()
     merged_dict.update(dict2)
@@ -2081,12 +2090,23 @@ def combine_dicts(dict1, dict2):
 
 def key_length(contents, dependencies):
     """Validates key length
-    Args:
-        contents (int): argument contents
-        dependencies (dict): Any dependent arguments
 
-    Returns:
-        int: provided key length
+    Parameters
+    ----------
+        contents : int
+                 Argument contents
+        dependencies : dict
+                     Any dependent arguments
+
+    Raises
+    -------
+        ValueError : str
+                   When invalid argument provided.
+
+    Returns
+    -------
+        contents : int
+                 Provided key length
     """
     if contents is None:
         return contents
@@ -2102,12 +2122,23 @@ def key_length(contents, dependencies):
 
 def key_offset(contents, dependencies):
     """Validates key offset
-    Args:
-        contents (int): argument contents
-        dependencies (dict): Any dependent arguments
 
-    Returns:
-        int: provided key offset
+    Parameters
+    ----------
+        contents : int
+                 Argument contents
+        dependencies : dict
+                     Any dependent arguments
+
+    Raises
+    -------
+        ValueError : str
+                   When invalid argument provided.
+
+    Returns
+    -------
+        contents : int
+                 Provided key offset
     """
     if contents is None:
         return contents
@@ -2124,12 +2155,18 @@ def key_offset(contents, dependencies):
 
 def key_length_default(contents, dependencies):
     """Determines default key length
-    Args:
-        contents (int): argument contents
-        dependencies (dict): Any dependent arguments
 
-    Returns:
-        int: default key length
+    Parameters
+    ----------
+        contents : int
+                 Argument contents
+        dependencies : dict
+                     Any dependent arguments
+
+    Returns
+    -------
+        length : int
+               Default key length
     """
     KEY_LENGTH = 5
     length = None
@@ -2142,12 +2179,18 @@ def key_length_default(contents, dependencies):
 
 def key_offset_default(contents, dependencies):
     """Determines default key offset
-    Args:
-        contents (int): argument contents
-        dependencies (dict): Any dependent arguments
 
-    Returns:
-        int: default key offset
+    Parameters
+    ----------
+        contents : int
+                 Argument contents
+        dependencies : dict
+                     Any dependent arguments
+
+    Returns
+    -------
+        offset : int
+               Default key offset
     """
     KEY_OFFSET = 0
     offset = None
@@ -2161,12 +2204,17 @@ def key_offset_default(contents, dependencies):
 def dd_content(contents, dependencies):
     """Reformats dd content arguments
 
-    Args:
-        contents (Union[str, list[str]]): argument contents
-        dependencies (dict): Any dependent arguments
+    Parameters
+    ----------
+        contents : Union[str, list[str]]
+                 Argument contents
+        dependencies : dict
+                     Any dependent arguments
 
-    Returns:
-        str: content string to save to data set
+    Returns
+    -------
+        contents : str
+                 Content string to save to data set
     """
     if contents is None:
         return None
@@ -2183,11 +2231,15 @@ def dd_content(contents, dependencies):
 def modify_contents(contents):
     """Return the content of dd_input to a valid form for a JCL program.
 
-    Args:
-        contents (str or list): The string or list with the program.
+    Parameters
+    ----------
+        contents : str or list
+                 The string or list with the program.
 
-    Returns:
-        contents: The content in a proper multi line str.
+    Returns
+    -------
+        contents : str
+                 The content in a proper multi line str.
     """
     if not isinstance(contents, list):
         contents = list(contents.split("\n"))
@@ -2199,11 +2251,20 @@ def modify_contents(contents):
 def prepend_spaces(lines):
     """Return the array with two spaces at the beggining.
 
-    Args:
-        lines (list): The list with a line of a program.
+    Parameters
+    ----------
+        lines : list
+              The list with a line of a program.
 
-    Returns:
-        new_lines: The list in a proper two spaces and the code.
+    Raises
+    -------
+        ValueError : str
+                   When invalid argument provided.
+
+    Returns
+    -------
+        new_lines : list[str]
+                  The list in a proper two spaces and the code.
     """
     module = AnsibleModuleHelper(argument_spec={})
     for index, line in enumerate(lines):
@@ -2226,12 +2287,17 @@ def prepend_spaces(lines):
 def sms_class(contents, dependencies):
     """Validates provided sms class is of valid length.
 
-    Args:
-        contents (str): argument contents
-        dependencies (dict): Any dependent arguments
+    Parameters
+    ----------
+        contents : str
+                 Argument contents
+        dependencies : dict
+                     Any dependent arguments
 
-    Returns:
-        str: the sms class
+    Returns
+    -------
+        contents : str
+                  the sms class
     """
     if not contents:
         return None
@@ -2248,15 +2314,22 @@ def sms_class(contents, dependencies):
 def volumes(contents, dependencies):
     """Validate volume arguments.
 
-    Args:
-        contents (Union[str, list[str]]): The contents provided for the volume argument.
-        dependencies (dict): Any arguments this argument is dependent on.
+    Parameters
+    ----------
+        contents : Union[str, list[str]]
+                 The contents provided for the volume argument.
+        dependencies : dict
+                     Any arguments this argument is dependent on.
 
-    Raises:
-        ValueError: When invalid argument provided.
+    Raises
+    -------
+        ValueError : str
+                   When invalid argument provided.
 
-    Returns:
-        list[str]: The contents returned as a list of volumes
+    Returns
+    -------
+        contents : list[str]
+                 The contents returned as a list of volumes
     """
     if not contents:
         return None
@@ -2276,15 +2349,22 @@ def volumes(contents, dependencies):
 def reuse(contents, dependencies):
     """Validate reuse argument.
 
-    Args:
-        contents (bool): The contents provided for the reuse argument.
-        dependencies (dict): Any arguments this argument is dependent on.
+    Parameters
+    ----------
+        contents : bool
+                 The contents provided for the reuse argument.
+        dependencies : dict
+                     Any arguments this argument is dependent on.
 
-    Raises:
-        ValueError: When invalid argument provided.
+    Raises
+    -------
+        ValueError : str
+                   When invalid argument provided.
 
-    Returns:
-        bool: The value of reuse.
+    Returns
+    -------
+        contents : bool
+                 The value of reuse.
     """
     if contents is True and dependencies.get("disposition") != "new":
         raise ValueError('Argument "reuse" is only valid when "disposition" is "new".')
@@ -2294,15 +2374,22 @@ def reuse(contents, dependencies):
 def replace(contents, dependencies):
     """Validate replace argument.
 
-    Args:
-        contents (bool): The contents provided for the replace argument.
-        dependencies (dict): Any arguments this argument is dependent on.
+    Parameters
+    ----------
+        contents : bool
+                 The contents provided for the replace argument.
+        dependencies : dict
+                     Any arguments this argument is dependent on.
 
-    Raises:
-        ValueError: When invalid argument provided.
+    Raises
+    -------
+        ValueError : str
+                   When invalid argument provided.
 
-    Returns:
-        bool: The value of replace.
+    Returns
+    -------
+        contents : bool
+                 The value of replace.
     """
     if contents is True and dependencies.get("reuse") is True:
         raise ValueError('Arguments "replace" and "reuse" are mutually exclusive.')
@@ -2316,15 +2403,22 @@ def replace(contents, dependencies):
 def backup(contents, dependencies):
     """Validate backup argument.
 
-    Args:
-        contents (bool): The contents provided for the backup argument.
-        dependencies (dict): Any arguments this argument is dependent on.
+    Parameters
+    ----------
+        contents : bool
+                 The contents provided for the backup argument.
+        dependencies : dict
+                     Any arguments this argument is dependent on.
 
-    Raises:
-        ValueError: When invalid argument provided.
+    Raises
+    -------
+        ValueError : str
+                   When invalid argument provided.
 
-    Returns:
-        bool: The value of backup.
+    Returns
+    -------
+        contents : bool
+                 The value of backup.
     """
     if contents is True and dependencies.get("replace") is False:
         raise ValueError('Argument "backup" is only valid when "replace" is True.')
@@ -2334,12 +2428,17 @@ def backup(contents, dependencies):
 def status_group(contents, dependencies):
     """Validate status group argument.
 
-    Args:
-        contents (list[str]): The contents provided for the status_group argument.
-        dependencies (dict): Any arguments this argument is dependent on.
+    Parameters
+    ----------
+        contents : list[str]
+                 The contents provided for the status_group argument.
+        dependencies : dict
+                     Any arguments this argument is dependent on.
 
-    Returns:
-        list[str]: The access group as expected by mvscmd.
+    Returns
+    -------
+        contents : list[str]
+                 The access group as expected by mvscmd.
     """
     if not contents:
         return None
@@ -2359,12 +2458,17 @@ def status_group(contents, dependencies):
 def access_group(contents, dependencies):
     """Validate access group argument.
 
-    Args:
-        contents (str): The contents provided for the access_group argument.
-        dependencies (dict): Any arguments this argument is dependent on.
+    Parameters
+    ----------
+        contents : str
+                 The contents provided for the access_group argument.
+        dependencies : dict
+                     Any arguments this argument is dependent on.
 
-    Returns:
-        str: The access group as expected by mvscmd.
+    Returns
+    -------
+        contents : str
+                 The access group as expected by mvscmd.
     """
     if contents and ACCESS_GROUP_NAME_MAP.get(contents):
         contents = ACCESS_GROUP_NAME_MAP.get(contents)
@@ -2374,14 +2478,20 @@ def access_group(contents, dependencies):
 def build_dd_statements(parms):
     """Build a list of DDStatement objects from provided module parms.
 
-    Args:
-        parms (dict): Module parms after formatting and validation.
+    Parameters
+    ----------
+        parms : dict
+              Module parms after formatting and validation.
 
-    Raises:
-        ValueError: If no data definition can be found matching provided DD type.
+    Raises
+    -------
+        ValueError : None
+             If no data definition can be found matching provided DD type.
 
-    Returns:
-        list[DDStatement]: List of DDStatement objects representing DD statements specified in module parms.
+    Returns
+    -------
+        dd_statements : list[DDStatement]
+                      List of DDStatement objects representing DD statements specified in module parms.
     """
     dd_statements = []
     tmphlq = parms.get("tmphlq")
@@ -2397,6 +2507,18 @@ def build_dd_statements(parms):
 
 
 def get_key(dd):
+    """
+    Get the key of the dd.
+    Parameters
+    ----------
+        dd : dict
+           A single DD parm as specified in module parms.
+
+    Returns
+    -------
+        key : str
+            Type of dd.
+    """
     dd_key = ""
     keys_list = list(dd.keys())
     for key in keys_list:
@@ -2406,6 +2528,20 @@ def get_key(dd):
 
 
 def get_dd_name_and_key(dd):
+    """
+    Get the key and dd_name of the dd.
+    Parameters
+    ----------
+        dd : dict
+           A single DD parm as specified in module parms.
+
+    Returns
+    -------
+        dd_name : str
+                Identifier of the dd.
+        key : str
+            Type of dd.
+    """
     dd_name = ""
     key = ""
     if dd.get("dd_data_set"):
@@ -2435,11 +2571,15 @@ def get_dd_name_and_key(dd):
 def set_extra_attributes_in_dd(dd, tmphlq, key):
     """
     Set any extra attributes in dds like in global tmp_hlq.
-    Args:
-        dd (dict): A single DD parm as specified in module parms.
+    Parameters
+    ----------
+        dd : dict
+           A single DD parm as specified in module parms.
 
-    Returns:
-        dd (dict): A single DD parm as specified in module parms.
+    Returns
+    -------
+        dd : dict
+            A single DD parm as specified in module parms.
     """
     if key == "dd_concat":
         for single_dd in dd.get("dd_concat").get("dds", []):
@@ -2453,14 +2593,16 @@ def set_extra_attributes_in_dd(dd, tmphlq, key):
 def build_data_definition(dd):
     """Build a DataDefinition object for a particular DD parameter.
 
-    Args:
-        dd (dict): A single DD parm as specified in module parms.
+    Parameters
+    ----------
+        dd : dict
+           A single DD parm as specified in module parms.
 
-    Returns:
-        Union[list[RawDatasetDefinition, RawFileDefinition,
-              RawInputDefinition],
-              RawDatasetDefinition, RawFileDefinition,
-              RawInputDefinition, DummyDefinition]: The DataDefinition object or a list of DataDefinition objects.
+    Returns
+    -------
+        data_definition : Union[list[RawDatasetDefinition, RawFileDefinition,vRawInputDefinition],
+                          RawDatasetDefinition, RawFileDefinition, RawInputDefinition, DummyDefinition]
+                        The DataDefinition object or a list of DataDefinition objects.
     """
     data_definition = None
     if dd.get("dd_data_set"):
@@ -2499,15 +2641,23 @@ def run_zos_program(
 ):
     """Run a program on z/OS.
 
-    Args:
-        program (str): The name of the program to run.
-        parm (str, optional): Additional argument string if required. Defaults to "".
-        dd_statements (list[DDStatement], optional): DD statements to allocate for the program. Defaults to [].
-        authorized (bool, optional): Determines if program will execute as an authorized user. Defaults to False.
-        tmphlq (str, optional): Arguments overwrite variable tmp_hlq
+    Parameters
+    ----------
+        program : str
+                The name of the program to run.
+        parm : str, optional
+             Additional argument string if required. Defaults to "".
+        dd_statements : list[DDStatement], optional
+                      DD statements to allocate for the program. Defaults to [].
+        authorized : bool, optional
+                   Determines if program will execute as an authorized user. Defaults to False.
+        tmphlq : str, optional
+               Arguments overwrite variable tmp_hlq
 
-    Returns:
-        MVSCmdResponse: Holds the response information for program execution.
+    Returns
+    -------
+        response : MVSCmdResponse
+                 Holds the response information for program execution.
     """
     if not dd_statements:
         dd_statements = []
@@ -2526,12 +2676,17 @@ def run_zos_program(
 def build_response(rc, dd_statements, stdout):
     """Build response dictionary to return at module completion.
 
-    Args:
-        rc (int): The return code of the program.
-        dd_statements (list[DDStatement]): The DD statements for the program.
+    Parameters
+    ----------
+        rc : int
+           The return code of the program.
+        dd_statements : list[DDStatement]
+                      The DD statements for the program.
 
-    Returns:
-        dict: Response dictionary in format expected for response on module completion.
+    Returns
+    -------
+        response : dict
+                 Response dictionary in format expected for response on module completion.
     """
     response = {"ret_code": {"code": rc}}
     response["backups"] = gather_backups(dd_statements)
@@ -2544,11 +2699,15 @@ def gather_backups(dd_statements):
     """Gather backup information for all data sets which had
     a backup made during module execution.
 
-    Args:
-        dd_statements (list[DDStatement]): The DD statements for the program.
+    Parameters
+    ----------
+        dd_statements : list[DDStatement]
+                      The DD statements for the program.
 
-    Returns:
-        list[dict]: List of backups in format expected for response on module completion.
+    Returns
+    -------
+        backups : list[dict]
+                List of backups in format expected for response on module completion.
     """
     backups = []
     for dd_statement in dd_statements:
@@ -2560,11 +2719,15 @@ def get_dd_backup(dd_statement):
     """Gather backup information for a single data set
     if the DD is a data set DD and a backup was made.
 
-    Args:
-        dd (DataDefinition): A single DD statement.
+    Parameters
+    ----------
+        dd : DataDefinition
+           A single DD statement.
 
-    Returns:
-        list[dict]: List of backups in format expected for response on module completion.
+    Returns
+    -------
+        dd_backup : list[dict]
+                  List of backups in format expected for response on module completion.
     """
     dd_backup = []
     if (
@@ -2580,11 +2743,15 @@ def get_dd_backup(dd_statement):
 def get_data_set_backup(dd_statement):
     """Get backup of a single data set DD statement.
 
-    Args:
-        dd_statement (DDStatement): A single DD statement.
+    Parameters
+    ----------
+        dd_statement : DDStatement
+                     A single DD statement.
 
-    Returns:
-        dict: Backup information in format expected for response on module completion.
+    Returns
+    -------
+        backup : dict
+               Backup information in format expected for response on module completion.
     """
     backup = {}
     backup["backup_name"] = dd_statement.definition.backup
@@ -2595,12 +2762,16 @@ def get_data_set_backup(dd_statement):
 def get_concatenation_backup(dd_statement):
     """Get the backup information for a single concatenation DD statement.
 
-    Args:
-        dd_statement (DDStatement): A single DD statement.
+    Parameters
+    ----------
+        dd_statement : DDStatement
+                     A single DD statement.
 
-    Returns:
-        list[dict]: The backup information of a single DD, in format expected for response on module completion.
-                Response can contain multiple backups.
+    Returns
+    -------
+        dd_backup : list[dict]
+                  The backup information of a single DD, in format expected for response on module completion.
+                  Response can contain multiple backups.
     """
     # create new DDStatement objects for each concat member
     # makes it easier to handle concat and non-concat DDs consistently
@@ -2616,11 +2787,15 @@ def gather_output(dd_statements):
     """Gather DD contents for all DD statements for which
     content was requested.
 
-    Args:
-        dd_statements (list[DDStatement]): The DD statements for the program.
+    Parameters
+    ----------
+        dd_statements : list[DDStatement]
+                      The DD statements for the program.
 
-    Returns:
-        list[dict]: The list of DD outputs, in format expected for response on module completion.
+    Returns
+    -------
+        output : list[dict]
+               The list of DD outputs, in format expected for response on module completion.
     """
     output = []
     for dd_statement in dd_statements:
@@ -2631,11 +2806,15 @@ def gather_output(dd_statements):
 def get_dd_output(dd_statement):
     """Get the output for a single DD statement.
 
-    Args:
-        dd_statement (DDStatement): A single DD statement.
+    Parameters
+    ----------
+        dd_statement : DDStatement
+                     A single DD statement.
 
-    Returns:
-        list[dict]: The output of a single DD, in format expected for response on module completion.
+    Returns
+    -------
+        dd_output : list[dict]
+                  The output of a single DD, in format expected for response on module completion.
     """
     dd_output = []
     if (
@@ -2666,11 +2845,15 @@ def get_dd_output(dd_statement):
 def get_data_set_output(dd_statement):
     """Get the output of a single data set DD statement.
 
-    Args:
-        dd_statement (DDStatement): A single DD statement.
+    Parameters
+    ----------
+        dd_statement : DDStatement
+                     A single DD statement.
 
-    Returns:
-        dict: The output of a single DD, in format expected for response on module completion.
+    Returns
+    -------
+        dd_response : dict
+                    The output of a single DD, in format expected for response on module completion.
     """
     contents = ""
     if dd_statement.definition.return_content.type == "text":
@@ -2688,11 +2871,15 @@ def get_data_set_output(dd_statement):
 def get_unix_file_output(dd_statement):
     """Get the output of a single UNIX file DD statement.
 
-    Args:
-        dd_statement (DDStatement): A single DD statement.
+    Parameters
+    ----------
+        dd_statement : DDStatement
+                     A single DD statement.
 
-    Returns:
-        dict: The output of a single DD, in format expected for response on module completion.
+    Returns
+    -------
+        dd_response : dict
+                    The output of a single DD, in format expected for response on module completion.
     """
     contents = ""
     if dd_statement.definition.return_content.type == "text":
@@ -2710,12 +2897,16 @@ def get_unix_file_output(dd_statement):
 def get_concatenation_output(dd_statement):
     """Get the output of a single concatenation DD statement.
 
-    Args:
-        dd_statement (DDStatement): A single DD statement.
+    Parameters
+    ----------
+        dd_statement : DDStatement
+                     A single DD statement.
 
-    Returns:
-        list[dict]: The output of a single DD, in the format expected for response on module completion.
-                Response can contain multiple outputs.
+    Returns
+    -------
+        dd_response : list[dict]
+                    The output of a single DD, in the format expected for response on module completion.
+                    Response can contain multiple outputs.
     """
     # create new DDStatement objects for each concat member
     # makes it easier to handle concat and non-concat DDs consistently
@@ -2731,13 +2922,19 @@ def build_dd_response(dd_name, name, contents):
     """Gather additional response metrics and format
     as expected for response on module completion.
 
-    Args:
-        dd_name (str): The DD name associated with this response.
-        name (str): The data set or UNIX file name associated with the response.
-        contents (str): The raw contents taken from the data set or UNIX file.
+    Parameters
+    ----------
+        dd_name : str
+                The DD name associated with this response.
+        name : str
+             The data set or UNIX file name associated with the response.
+        contents : str
+                 The raw contents taken from the data set or UNIX file.
 
-    Returns:
-        dict: Response content info of a single DD, in the format expected for response on module completion.
+    Returns
+    -------
+        dd_response : dict
+                    Response content info of a single DD, in the format expected for response on module completion.
     """
     dd_response = {}
     dd_response["dd_name"] = dd_name
@@ -2751,14 +2948,21 @@ def build_dd_response(dd_name, name, contents):
 def get_data_set_content(name, binary=False, from_encoding=None, to_encoding=None):
     """Retrieve the raw contents of a data set.
 
-    Args:
-        name (str): The name of the data set.
-        binary (bool, optional): Determines if contents are retrieved without encoding conversion. Defaults to False.
-        from_encoding (str, optional): The encoding of the data set on the z/OS system. Defaults to None.
-        to_encoding (str, optional): The encoding to receive the data back in. Defaults to None.
+    Parameters
+    ----------
+        name : str
+             The name of the data set.
+        binary : bool, optional
+               Determines if contents are retrieved without encoding conversion. Defaults to False.
+        from_encoding : str, optional
+                      The encoding of the data set on the z/OS system. Defaults to None.
+        to_encoding : str, optional
+                    The encoding to receive the data back in. Defaults to None.
 
-    Returns:
-        str: The raw content of the data set.
+    Returns
+    -------
+        quoted_name : str
+                    The raw content of the data set.
     """
     quoted_name = quote(name)
     if "'" not in quoted_name:
@@ -2771,14 +2975,21 @@ def get_data_set_content(name, binary=False, from_encoding=None, to_encoding=Non
 def get_unix_content(name, binary=False, from_encoding=None, to_encoding=None):
     """Retrieve the raw contents of a UNIX file.
 
-    Args:
-        name (str): The name of the UNIX file.
-        binary (bool, optional): Determines if contents are retrieved without encoding conversion. Defaults to False.
-        from_encoding (str, optional): The encoding of the UNIX file on the z/OS system. Defaults to None.
-        to_encoding (str, optional): The encoding to receive the data back in. Defaults to None.
+    Parameters
+    ----------
+        name : str
+             The name of the UNIX file.
+        binary : bool, optional
+               Determines if contents are retrieved without encoding conversion. Defaults to False.
+        from_encoding : str, optional
+                      The encoding of the UNIX file on the z/OS system. Defaults to None.
+        to_encoding : str, optional
+                    The encoding to receive the data back in. Defaults to None.
 
-    Returns:
-        str: The raw content of the UNIX file.
+    Returns
+    -------
+        stdout : str
+               The raw content of the UNIX file.
     """
     return get_content("{0}".format(quote(name)), binary, from_encoding, to_encoding)
 
@@ -2786,14 +2997,21 @@ def get_unix_content(name, binary=False, from_encoding=None, to_encoding=None):
 def get_content(formatted_name, binary=False, from_encoding=None, to_encoding=None):
     """Retrieve raw contents of a data set or UNIXfile.
 
-    Args:
-        name (str): The name of the data set or UNIX file, formatted and quoted for proper usage in command.
-        binary (bool, optional): Determines if contents are retrieved without encoding conversion. Defaults to False.
-        from_encoding (str, optional): The encoding of the data set or UNIX file on the z/OS system. Defaults to None.
-        to_encoding (str, optional): The encoding to receive the data back in. Defaults to None.
+    Parameters
+    ----------
+        name : str
+             The name of the data set or UNIX file, formatted and quoted for proper usage in command.
+        binary : bool, optional
+               Determines if contents are retrieved without encoding conversion. Defaults to False.
+        from_encoding : str, optional
+                      The encoding of the data set or UNIX file on the z/OS system. Defaults to None.
+        to_encoding : str, optional
+                    The encoding to receive the data back in. Defaults to None.
 
-    Returns:
-        str: The raw content of the data set or UNIX file. If unsuccessful in retrieving data, returns empty string.
+    Returns
+    -------
+        stdout : str
+               The raw content of the data set or UNIX file. If unsuccessful in retrieving data, returns empty string.
     """
     module = AnsibleModuleHelper(argument_spec={})
     conversion_command = ""

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1279,15 +1279,13 @@ backups:
       description: The name of the data set containing the backup of content from data set in original_name.
       type: str
 stdout:
-  The stdout from a USS command or MVS command, if applicable.
+  description: The stdout from a USS command or MVS command, if applicable.
   returned: always
   type: str
-  sample:
 stderr:
-  The stderr of a USS command or MVS command, if applicable.
+  description: The stderr of a USS command or MVS command, if applicable.
   returned: failure
   type: str
-  sample:
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Wrapper classes with the arguments not used are now included, delete parameters unnecessary types for arguments and logic of assign values as also the output.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1358 #1319 and #1359  
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Enabler Pull Request

##### COMPONENT NAME
Keys as a value to get the dd_type avoiding consult the name many times and types of arguments not used.

##### ADDITIONAL INFORMATION
The design of module work correctly now includes all parameters in arguments to be for the classes, to ensure a new property of dd's response required a braking change in arguments acceptance.

<img width="1540" alt="Captura de pantalla 2024-04-29 a la(s) 1 58 20 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/1ac824e1-28c6-4169-8095-9b2ee8987bac">
<img width="489" alt="Captura de pantalla 2024-04-29 a la(s) 1 58 58 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/02562de0-0c7b-420a-9912-b9303058a7c5">
<img width="1546" alt="Captura de pantalla 2024-04-29 a la(s) 2 13 09 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/52ca755f-2f48-4b6e-a28c-5a4c87922d69">
<img width="555" alt="Captura de pantalla 2024-04-29 a la(s) 2 13 17 p m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/ad9ce5ce-ba20-4b31-8881-d6928d0d9d07">

Outputs of playbooks with verbose true for cases 1358 and 1359

```

PLAY [zvm] *********************************************************************************************************************************************************************************************

TASK [create data set to LISTCAT] **********************************************************************************************************************************************************************
changed: [zvm]

TASK [mvs raw with verbose with rc=0] ******************************************************************************************************************************************************************
changed: [zvm]

TASK [print output] ************************************************************************************************************************************************************************************
ok: [zvm] => {
    "msg": [
        {
            "backups": [],
            "changed": true,
            "dd_names": [
                {
                    "byte_count": 1205,
                    "content": [
                        "\fIDCAMS  SYSTEM SERVICES                                           TIME: 12:30:20        04/29/24     PAGE      1",
                        "",
                        "        ",
                        " LISTCAT ENTRIES('USER.WHAT.EVER')",
                        "",
                        "NONVSAM ------- USER.WHAT.EVER",
                        "     IN-CAT --- SYS1.ECTEST.MASTER.CATALOG\fIDCAMS  SYSTEM SERVICES                                           TIME: 12:30:20        04/29/24     PAGE      2",
                        "",
                        "         THE NUMBER OF ENTRIES PROCESSED WAS:",
                        "                   AIX -------------------0",
                        "                   ALIAS -----------------0",
                        "                   CLUSTER ---------------0",
                        "                   DATA ------------------0",
                        "                   GDG -------------------0",
                        "                   INDEX -----------------0",
                        "                   NONVSAM ---------------1",
                        "                   PAGESPACE -------------0",
                        "                   PATH ------------------0",
                        "                   SPACE -----------------0",
                        "                   USERCATALOG -----------0",
                        "                   TAPELIBRARY -----------0",
                        "                   TAPEVOLUME ------------0",
                        "                   TOTAL -----------------1",
                        "",
                        "         THE NUMBER OF PROTECTED ENTRIES SUPPRESSED WAS 0",
                        "",
                        "IDC0001I FUNCTION COMPLETED, HIGHEST CONDITION CODE WAS 0",
                        "",
                        "        ",
                        "",
                        "IDC0002I IDCAMS PROCESSING COMPLETE. MAXIMUM CONDITION CODE WAS 0",
                        ""
                    ],
                    "dd_name": "SYSPRINT",
                    "name": "USER.WHAT.EVER.ONE",
                    "record_count": 32
                }
            ],
            "failed": false,
            "ret_code": {
                "code": 0
            },
            "stdout": "",
            "stdout_lines": []
        }
    ]
}

TASK [mvs raw with verbose with rc=0] ******************************************************************************************************************************************************************
changed: [zvm]

TASK [print output] ************************************************************************************************************************************************************************************
ok: [zvm] => {
    "msg": [
        {
            "backups": [],
            "changed": true,
            "dd_names": [
                {
                    "byte_count": 1205,
                    "content": [
                        "\fIDCAMS  SYSTEM SERVICES                                           TIME: 12:30:32        04/29/24     PAGE      1",
                        "",
                        "        ",
                        " LISTCAT ENTRIES('USER.WHAT.EVER')",
                        "",
                        "NONVSAM ------- USER.WHAT.EVER",
                        "     IN-CAT --- SYS1.ECTEST.MASTER.CATALOG\fIDCAMS  SYSTEM SERVICES                                           TIME: 12:30:32        04/29/24     PAGE      2",
                        "",
                        "         THE NUMBER OF ENTRIES PROCESSED WAS:",
                        "                   AIX -------------------0",
                        "                   ALIAS -----------------0",
                        "                   CLUSTER ---------------0",
                        "                   DATA ------------------0",
                        "                   GDG -------------------0",
                        "                   INDEX -----------------0",
                        "                   NONVSAM ---------------1",
                        "                   PAGESPACE -------------0",
                        "                   PATH ------------------0",
                        "                   SPACE -----------------0",
                        "                   USERCATALOG -----------0",
                        "                   TAPELIBRARY -----------0",
                        "                   TAPEVOLUME ------------0",
                        "                   TOTAL -----------------1",
                        "",
                        "         THE NUMBER OF PROTECTED ENTRIES SUPPRESSED WAS 0",
                        "",
                        "IDC0001I FUNCTION COMPLETED, HIGHEST CONDITION CODE WAS 0",
                        "",
                        "        ",
                        "",
                        "IDC0002I IDCAMS PROCESSING COMPLETE. MAXIMUM CONDITION CODE WAS 0",
                        ""
                    ],
                    "dd_name": "SYSPRINT",
                    "name": "USER.WHAT.EVER.ONE",
                    "record_count": 32
                }
            ],
            "failed": false,
            "ret_code": {
                "code": 0
            },
            "stdout": "",
            "stdout_lines": []
        }
    ]
}

TASK [delete data sets] ********************************************************************************************************************************************************************************
changed: [zvm] => (item=USER.WHAT.EVER)
changed: [zvm] => (item=USER.WHAT.EVER.ONE)

PLAY RECAP *********************************************************************************************************************************************************************************************
zvm                        : ok=6    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```

Playbook:
```
  vars:
    ZOAU: "/zoau/v1.3.0"
    PYZ: "/allpython/3.11/usr/lpp/IBM/cyp/v3r11/pyz"
    RC_0_DATA_SET_NAME: "USER.WHAT.EVER.ONE"
    DATA_SET_TO_LISTCAT: "USER.WHAT.EVER"
    IDCAMS_STDIN: " LISTCAT ENTRIES('{{ DATA_SET_TO_LISTCAT | upper }}')"
```

```
  tasks:

    - name: create some data set
      block:
        - name: create data set to LISTCAT
          zos_data_set:
            name: "{{ DATA_SET_TO_LISTCAT }}"
            type: seq
            state: present
            replace: yes

        - name: mvs raw with verbose with rc=0
          zos_mvs_raw:
            verbose: True
            program_name: idcams
            auth: True
            dds:
              - dd_data_set:
                  dd_name: SYSPRINT
                  data_set_name: "{{ RC_0_DATA_SET_NAME }}"
                  disposition: new
                  type: seq
                  return_content:
                    type: text
              - dd_input:
                  dd_name: SYSIN
                  content: "{{ IDCAMS_STDIN }}"
          register: output_rc_0

        - name: print output
          debug:
            msg:
              - "{{ output_rc_0 }}"

        - name: mvs raw with verbose with rc=0
          zos_mvs_raw:
            verbose: False
            program_name: idcams
            auth: True
            dds:
              - dd_data_set:
                  dd_name: SYSPRINT
                  data_set_name: "{{ RC_0_DATA_SET_NAME }}"
                  disposition: old
                  type: seq
                  return_content:
                    type: text
              - dd_input:
                  dd_name: SYSIN
                  content: "{{ IDCAMS_STDIN }}"
          register: output_rc_0

        - name: print output
          debug:
            msg:
              - "{{ output_rc_0 }}"

      always:
        - name: delete data sets
          zos_data_set:
            name: "{{ item }}"
            state: absent
          loop:
            - "{{ DATA_SET_TO_LISTCAT }}"
            - "{{ RC_0_DATA_SET_NAME }}"
```