### PR TITLE
[Enabler] Fix resolve GDS function to return a string with the gds name instead of zoau dataset object

### DIFF
--- a/changelogs/fragments/1490-fix-gds-resolve.yml
+++ b/changelogs/fragments/1490-fix-gds-resolve.yml
@@ -1,0 +1,4 @@
+trivial:
+  - module_utils/data_set.py - resolve_gds_absolute_name was returning a ZOAU dataset type instead
+    of string.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1484).

--- a/changelogs/fragments/1496-fix-gds-resolve.yml
+++ b/changelogs/fragments/1496-fix-gds-resolve.yml
@@ -1,4 +1,4 @@
 trivial:
   - module_utils/data_set.py - resolve_gds_absolute_name was returning a ZOAU dataset type instead
     of string.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1484).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1496).

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -1374,11 +1374,11 @@ class DataSet(object):
                 raise Exception
             gdg = gdgs.GenerationDataGroupView(name=gdg_base)
             generations = gdg.generations()
-            absolute_name = generations[rel_generation - 1]
-        except Exception as e:
+            gds = generations[rel_generation - 1]
+        except Exception:
             raise GDSNameResolveError(relative_name)
 
-        return absolute_name
+        return gds.name
 
     @staticmethod
     def escape_data_set_name(name):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix resolve GDS function to return a string with the gds name instead of zoau dataset object, this is the original design but was overlooked previously.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/data_set.py
