### PR TITLE
[Documentation] Inform users the need to escape commands with special characters

### DIFF
--- a/changelogs/fragments/1507-zos_operator-docs.yml
+++ b/changelogs/fragments/1507-zos_operator-docs.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_operator - Added a doc entry to inform users they need to escape certain special chars.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1507).

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -58,6 +58,9 @@ options:
     type: int
     required: false
     default: 1
+notes:
+    - Commands may need to use specific prefixes like $, they can be discovered by
+      issuing the following command C(D OPDATA,PREFIX).
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019 - 2024
+# Copyright (c) IBM Corporation 2019, 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -35,6 +35,9 @@ options:
       - The command to execute.
       - If the command contains single-quotations, another set of single quotes must be added.
       - For example, change the command "...,P='DSN3EPX,-DBC1,S'" to "...,P=''DSN3EPX,-DBC1,S'' ".
+      - If the command contains any special characters ($, &, etc), they must be escaped using
+        double backslashes like \\\$.
+      - For example, to display job by job name the command would be C(cmd:"\\$dj''HELLO''")
     type: str
     required: true
   verbose:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated doc entry with escaping instructions when using special characters.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1471 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_operator
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
