### PR TITLE
[Bugfix][1377]output_mvs_raw_gds_positive_was_false_positive

### DIFF
--- a/changelogs/fragments/1541-output_mvs_raw_gds_positive_was_false_positive.yml
+++ b/changelogs/fragments/1541-output_mvs_raw_gds_positive_was_false_positive.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zos_mvs_raw - Added support for GDG and GDS relative positive name notation to use a data set.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1541).

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1634,12 +1634,14 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.zos_mvs_raw impor
     RawInputDefinition,
     RawOutputDefinition,
 )
+from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import ZOAUImportError
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import data_set
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
     AnsibleModuleHelper,
 )
 import re
+import traceback
 from ansible.module_utils.six import PY3
 
 if PY3:

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2654,13 +2654,13 @@ def resolve_data_set_names(dataset, disposition, type):
           The disposition base on the system
     """
     if disposition:
-        disposition = disposition
+        disp = disposition
     else:
-        disposition = "shr"
+        disp = "shr"
 
     if data_set.DataSet.is_gds_relative_name(dataset):
         if data_set.DataSet.is_gds_positive_relative_name(dataset):
-            if disposition == "new":
+            if disp == "new":
                 if type:
                     return str(datasets.create(dataset, type).name), "shr"
                 else:
@@ -2673,15 +2673,14 @@ def resolve_data_set_names(dataset, disposition, type):
             )
             src = data.name
             if data.is_gds_active:
-                if disposition and disposition == "new":
+                if disposition and disp == "new":
                     raise ("GDS {0} already created, incorrect parameters for disposition and data_set_name".format(src))
                 else:
                     return src, disposition
             else:
                 raise ("{0} does not exist".format(src))
     else:
-        return dataset, disposition
-        return dataset
+        return dataset, disp
 
 
 def build_data_definition(dd):

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1596,6 +1596,7 @@ EXAMPLES = r"""
       - dd_data_set:
           dd_name: sysprint
           data_set_name: TEST.CREATION(+1)
+          disposition: new
           return_content:
             type: text
       - dd_input:

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2587,8 +2587,8 @@ def get_dd_name_and_key(dd):
     if dd.get("dd_data_set"):
         dd_name = dd.get("dd_data_set").get("dd_name")
         data_set_name, disposition = resolve_data_set_names(dd.get("dd_data_set").get("data_set_name"),
-                                               dd.get("dd_data_set").get("disposition"),
-                                               dd.get("dd_data_set").get("type"))
+                                                            dd.get("dd_data_set").get("disposition"),
+                                                            dd.get("dd_data_set").get("type"))
         dd.get("dd_data_set")["data_set_name"] = data_set_name
         dd.get("dd_data_set")["disposition"] = disposition
         key = "dd_data_set"

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2662,9 +2662,9 @@ def resolve_data_set_names(dataset, disposition, type):
         if data_set.DataSet.is_gds_positive_relative_name(dataset):
             if disposition == "new":
                 if type:
-                    return str(datasets.create(dataset, type).name), disposition
+                    return str(datasets.create(dataset, type).name), "shr"
                 else:
-                    return str(datasets.create(dataset, "seq").name), disposition
+                    return str(datasets.create(dataset, "seq").name), "shr"
             else:
                 raise ("To generate a new GDS as {0} disposition 'new' is required.".format(dataset))
         else:

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2930,6 +2930,12 @@ def get_data_set_output(dd_statement):
     """
     contents = ""
     if dd_statement.definition.return_content.type == "text":
+        if data_set.DataSet.is_gds_positive_relative_name(dd_statement.definition.name):
+            src = dd_statement.definition.name
+            data = data_set.MVSDataSet(
+                name=src.replace('(+1)', '(0)')
+            )
+            dd_statement.definition.name = data.name
         contents = get_data_set_content(
             name=dd_statement.definition.name,
             binary=False,

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2582,7 +2582,8 @@ def get_dd_name_and_key(dd):
     if dd.get("dd_data_set"):
         dd_name = dd.get("dd_data_set").get("dd_name")
         data_set_name = resolve_data_set_names(dd.get("dd_data_set").get("data_set_name"),
-                                               dd.get("dd_data_set").get("disposition"))
+                                               dd.get("dd_data_set").get("disposition"),
+                                               dd.get("dd_data_set").get("type"))
         dd.get("dd_data_set")["data_set_name"] = data_set_name
         key = "dd_data_set"
     elif dd.get("dd_unix"):
@@ -2628,7 +2629,7 @@ def set_extra_attributes_in_dd(dd, tmphlq, key):
     return dd
 
 
-def resolve_data_set_names(dataset, disposition):
+def resolve_data_set_names(dataset, disposition, type):
     """Resolve cases for data set names as relative gds or positive
       that could be accepted if disposition is new.
       Parameters
@@ -2637,6 +2638,8 @@ def resolve_data_set_names(dataset, disposition):
           Data set name to determine if is a GDS relative name or regular name.
       disposition : str
           Disposition of data set for it creation.
+      type : str
+          Type of dataset
       Returns
       -------
       str
@@ -2644,7 +2647,10 @@ def resolve_data_set_names(dataset, disposition):
     """
     if data_set.DataSet.is_gds_relative_name(dataset):
         if data_set.DataSet.is_gds_positive_relative_name(dataset):
-            return datasets.create(dataset)
+            if type:
+                return str(datasets.create(dataset, type).name)
+            else:
+                return str(datasets.create(dataset, "seq").name)
         else:
             data = data_set.MVSDataSet(
                 name=dataset

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -719,7 +719,6 @@ def test_data_set_name_gdgs(ansible_zos_module):
                     dd_data_set=dict(
                         dd_name=SYSPRINT_DD,
                         data_set_name=default_data_set + "(+1)",
-                        disposition="new",
                         return_content=dict(type="text"),
                     ),
                 ),

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -814,6 +814,7 @@ def test_data_set_name_gdgs(ansible_zos_module):
                     dd_data_set=dict(
                         dd_name=SYSPRINT_DD,
                         data_set_name=default_data_set + "(+1)",
+                        disposition="new",
                         return_content=dict(type="text"),
                     ),
                 ),


### PR DESCRIPTION
##### SUMMARY
First solution of adding gds name into the module generate a false positive using positive relative name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Create the dataset if the name is a positive relative name.

##### ADDITIONAL INFORMATION
First iteration did not generate a new gds, only was syntactically correct for the system.

<img width="1368" alt="Captura de pantalla 2024-06-11 a la(s) 10 46 06 a m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/491309e1-b001-41c9-b4bf-1a82fddb0cc7">
<img width="680" alt="Captura de pantalla 2024-06-11 a la(s) 10 46 18 a m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/3206a1e9-e2e3-4501-ab2e-959cab463368">
