### PR TITLE
[bugfix][1520]mvs_raw_fix_verbose_and_first_character

### DIFF
--- a/changelogs/fragments/1543-mvs_raw_fix_verbose_and_first_character.yml
+++ b/changelogs/fragments/1543-mvs_raw_fix_verbose_and_first_character.yml
@@ -1,0 +1,4 @@
+bugfix:
+  - zos_mvs_raw - DD_output first character from each line was missing. Change now includes the first character
+    of each line.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1543).

--- a/changelogs/fragments/1543-mvs_raw_fix_verbose_and_first_character.yml
+++ b/changelogs/fragments/1543-mvs_raw_fix_verbose_and_first_character.yml
@@ -1,4 +1,4 @@
-bugfix:
+bugfixes:
   - zos_mvs_raw - DD_output first character from each line was missing. Change now includes the first character
     of each line.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1543).

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -819,7 +819,7 @@ class OutputDefinition(DataDefinition):
     def __init__(
         self,
         tmphlq="",
-        record_format="FBA",
+        record_format="FB",
         space_primary=100,
         space_secondary=50,
         space_type="trk",

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -60,6 +60,8 @@ class MVSCmd(object):
             MVSCmd._build_command(pgm, dds, parm),
         )
         rc, out, err = module.run_command(command)
+        if rc == 0 and verbose:
+            out = err
         return MVSCmdResponse(rc, out, err)
 
     @staticmethod
@@ -90,6 +92,8 @@ class MVSCmd(object):
             MVSCmd._build_command(pgm, dds, parm),
         )
         rc, out, err = module.run_command(command)
+        if rc == 0 and verbose:
+            out = err
         return MVSCmdResponse(rc, out, err)
 
     @staticmethod


### PR DESCRIPTION
##### SUMMARY
The dd_output by default use configuration of control that's why the first character was ignore, change now allows to be a regular dataset.

Fixes #1520 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### ADDITIONAL INFORMATION

new output
```
ok: [zvm] => {
    "output": {
        "backups": [],
        "changed": true,
        "dd_names": [
            {
                "byte_count": 5,
                "content": [
                    "abcd",
                    ""
                ],
                "dd_name": "stdout",
                "name": "OMVSADM.P6777740.T0791028.C0000000",
                "record_count": 2
            }
        ],
        "failed": false,
        "ret_code": {
            "code": 0
        },
        "stdout": "BGYSC0307I Program: <bpxbatch> Arguments: <SH echo abcd>\nBGYSC0308I DDNames:\nBGYSC0312I   STDOUT=OMVSADM.P6777740.T0791028.C0000000\nBGYSC0303I Dataset allocation succeeded for STDOUT=OMVSADM.P6777740.T0791028.C0000000\nBGYSC0328I OS Load program BPXBATCH\nBGYSC0320I Addressing mode: AMODE31\nBGYSC0327I Attach Exit code: 0 from BPXBATCH\nBGYSC0338I Dataset free succeeded for STDOUT=OMVSADM.P6777740.T0791028.C0000000\n",
        "stdout_lines": [
            "BGYSC0307I Program: <bpxbatch> Arguments: <SH echo abcd>",
            "BGYSC0308I DDNames:",
            "BGYSC0312I   STDOUT=OMVSADM.P6777740.T0791028.C0000000",
            "BGYSC0303I Dataset allocation succeeded for STDOUT=OMVSADM.P6777740.T0791028.C0000000",
            "BGYSC0328I OS Load program BPXBATCH",
            "BGYSC0320I Addressing mode: AMODE31",
            "BGYSC0327I Attach Exit code: 0 from BPXBATCH",
            "BGYSC0338I Dataset free succeeded for STDOUT=OMVSADM.P6777740.T0791028.C0000000"
        ]
    }
}
```

<img width="1540" alt="Captura de pantalla 2024-06-12 a la(s) 11 43 20 a m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/60ef2df5-c406-4ee2-8967-e5d1a821c670">
<img width="571" alt="Captura de pantalla 2024-06-12 a la(s) 11 43 49 a m" src="https://github.com/ansible-collections/ibm_zos_core/assets/68956970/6f229396-6c20-426c-8afd-e1c3b3da2139">
