### PR TITLE
[v1.9.2][Bugfix] [zos_copy] Only issue opercmd to check for a locked data set if dest exists

### DIFF
--- a/changelogs/fragments/1549-zos_copy-opercmd.yml
+++ b/changelogs/fragments/1549-zos_copy-opercmd.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_copy - module would use opercmd to check if a non existent
+    destination data set is locked. Fix now only checks if the destination
+    is already present.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1549).

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2856,7 +2856,7 @@ def run_module(module, arg_def):
     # the machine and not generate a false positive check the disposition
     # for try to write in dest and if both src and dest are in lock.
     # ********************************************************************
-    if dest_ds_type != "USS":
+    if dest_exists and dest_ds_type != "USS":
         if not force_lock:
             is_dest_lock = data_set_locked(dest_name)
             if is_dest_lock:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 `zos_copy` was issuing an opercmd to see if the destination data set is locked even if it does not exist. Fix only issues the command if destination exists.

This is the fix meant for 1.9.2 release, did not add a test case for this scenario since automating a test to validate the command was not issued would take me some time, basically that would need to check the syslog to make sure the command was not issued for that specific data set name, I can add it if requested.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1544 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
