### PR TITLE
Update code to share exception types UnicodeDecodeError, JSONDecodeError, TypeError, KeyError

### DIFF
--- a/changelogs/fragments/1512-bugfix-zos_job_submit-error-type.yml
+++ b/changelogs/fragments/1512-bugfix-zos_job_submit-error-type.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_job_submit - Was not propagating any error types UnicodeDecodeError,
+    JSONDecodeError, TypeError, KeyError when encountered, now the error
+    message shares the type error.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1560).

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -463,10 +463,11 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
                                     single_dd["step_name"],
                                     single_dd["dd_name"]
                                 )
-                            except (UnicodeDecodeError, JSONDecodeError, TypeError, KeyError):
+                            except (UnicodeDecodeError, JSONDecodeError, TypeError, KeyError) as e:
+                                error_type = e.__class__.__name__
                                 tmpcont = (
-                                    "Non-printable UTF-8 characters were present in this output. "
-                                    "Please access it from the job log."
+                                    f"Non-printable UTF-8 characters were present in this output, a {error_type} error has occurred."
+                                    "Please access the content from the job log."
                                 )
 
                     dd["content"] = tmpcont.split("\n")

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -710,7 +710,6 @@ def submit_src_jcl(module, src, src_name=None, timeout=0, is_unix=True, start_ti
         "fetch_max_retries": timeout,
     }
 
-    present = False
     duration = 0
     job_submitted = None
     result = {}


### PR DESCRIPTION
##### SUMMARY
When a unicode or json decode error occur in a module its difficult to diagnose which occurred as each has a different solution. This will share the error type so development can better handle the diagnosis. 
#1512 

Note: there is no direct way to test this code because ZOAU has fixed the JSON decode and Unicode error thus we can not mock JCL to create a unicode or json error so I did locally mock some of these errors and caught the exception to ensure the code is working as planned. See issue #1512 attachment for more details on localized testing, the result of that testing showed the types were captured. 

> /tmp $: python3 json-test.py
> Non-printable UTF-8 characters were present in this output, a JSONDecodeError error has occurred.Please access the content from the job log.
> Non-printable UTF-8 characters were present in this output, a TypeError error has occurred.Please access the content from the job log.
> Non-printable UTF-8 characters were present in this output, a KeyError error has occurred.Please access the content from the job log.
> Non-printable UTF-8 characters were present in this output, a UnicodeDecodeError error has occurred.Please access the content from the job log.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
