### PR TITLE
[Enabler] [Various modules] Remove use of deprecated pipes library

### DIFF
--- a/changelogs/fragments/1565-remove-deprecated-pipes-library.yml
+++ b/changelogs/fragments/1565-remove-deprecated-pipes-library.yml
@@ -1,0 +1,11 @@
+trivial:
+  - zos_find - remove deprecated library pipes in favor of shlex.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1565).
+  - zos_mvs_raw - remove deprecated library pipes in favor of shlex.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1565).
+  - module_utils/backup.py - remove deprecated library pipes in favor of shlex.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1565).
+  - module_utils/copy.py - remove deprecated library pipes in favor of shlex.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1565).
+  - module_utils/encode.py - remove deprecated library pipes in favor of shlex.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1565).

--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import os
-from ansible.module_utils.six import PY3
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
     AnsibleModuleHelper,
 )

--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -44,10 +44,8 @@ try:
 except Exception:
     datasets = ZOAUImportError(traceback.format_exc())
     exceptions = ZOAUImportError(traceback.format_exc())
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
+
+from shlex import quote
 
 
 def _validate_data_set_name(ds):

--- a/plugins/module_utils/copy.py
+++ b/plugins/module_utils/copy.py
@@ -26,10 +26,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.mvs_cmd import (
     ikjeft01
 )
 
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
+from shlex import quote
 
 
 REPRO = """  REPRO INDATASET({}) -

--- a/plugins/module_utils/copy.py
+++ b/plugins/module_utils/copy.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-from ansible.module_utils.six import PY3
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
     AnsibleModuleHelper,
 )

--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -17,7 +17,6 @@ __metaclass__ = type
 from tempfile import NamedTemporaryFile, mkstemp, mkdtemp
 from math import floor, ceil
 from os import path, walk, makedirs, unlink
-from ansible.module_utils.six import PY3
 
 import shutil
 import errno

--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -42,11 +42,7 @@ try:
 except Exception:
     datasets = ZOAUImportError(traceback.format_exc())
 
-
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
+from shlex import quote
 
 
 class Defaults:

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -620,6 +620,10 @@ def main():
     result['stderr'] = operErr
     result['rc'] = operRc
     result['stdout'] = operOut
+
+    if operation != 'list' and operRc == 0:
+        result['changed'] = True
+
     if operation == 'list':
         try:
             data = json.loads(operOut)

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -612,7 +612,7 @@ def main():
             # ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent)
             apf_command = make_apf_command(library, opt, volume=volume, sms=sms, force_dynamic=force_dynamic, persistent=persistent)
             rc, out, err = module.run_command(apf_command)
-            ret = ztypes.ZOAUResponse(rc, out, err, apf_command)
+            ret = ztypes.ZOAUResponse(rc, out, err, apf_command, 'utf-8')
 
     operOut = ret.stdout_response
     operErr = ret.stderr_response

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -361,14 +361,7 @@ def backupOper(module, src, backup, tmphlq=None):
     return backup_name
 
 
-def make_apf_command(
-        library,
-        opt,
-        volume=None,
-        sms=None,
-        force_dynamic=None,
-        persistent=None
-    ):
+def make_apf_command(library, opt, volume=None, sms=None, force_dynamic=None, persistent=None):
     """Returns a string that can run an APF command in a shell.
 
     Parameters

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -305,8 +305,10 @@ import traceback
 
 try:
     from zoautil_py import zsystem
+    from zoautil_py import ztypes
 except Exception:
     zsystem = ZOAUImportError(traceback.format_exc())
+    ztypes = ZOAUImportError(traceback.format_exc())
 
 
 # supported data set types
@@ -609,7 +611,8 @@ def main():
             # release a fix soon so we can uncomment this Python API call.
             # ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent)
             apf_command = make_apf_command(library, opt, volume=volume, sms=sms, force_dynamic=force_dynamic, persistent=persistent)
-            ret = module.run_command(apf_command)
+            rc, out, err = module.run_command(apf_command)
+            ret = ztypes.ZOAUResponse(rc, out, err, apf_command)
 
     operOut = ret.stdout_response
     operErr = ret.stderr_response

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -611,6 +611,7 @@ def main():
             # release a fix soon so we can uncomment this Python API call.
             # ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent)
             apf_command = make_apf_command(library, opt, volume=volume, sms=sms, force_dynamic=force_dynamic, persistent=persistent)
+            result['cmd'] = apf_command
             rc, out, err = module.run_command(apf_command)
             ret = ztypes.ZOAUResponse(rc, out, err, apf_command, 'utf-8')
 

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -431,7 +431,7 @@ def make_apf_batch_command(batch, force_dynamic=None, persistent=None):
     str
         APF command.
     """
-    command = f"apfadm"
+    command = "apfadm"
 
     for item in batch:
         operation = "-A" if item["opt"] == "add" else "-D"

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -413,6 +413,57 @@ def make_apf_command(library, opt, volume=None, sms=None, force_dynamic=None, pe
     return command
 
 
+def make_apf_batch_command(batch, force_dynamic=None, persistent=None):
+    """Returns a string that can run an APF command for multiple operations
+    in a shell.
+
+    Parameters
+    ----------
+    batch : list
+        List of dicts containing different APF add/del operations.
+    force_dynamic : bool
+        Whether the APF list format should be dynamic.
+    persistent : dict
+        Options for persistent entries that should be modified by APF.
+
+    Returns
+    -------
+    str
+        APF command.
+    """
+    command = f"apfadm"
+
+    for item in batch:
+        operation = "-A" if item["opt"] == "add" else "-D"
+        operation_args = item["dsname"]
+
+        volume = item.get("volume")
+        sms = item.get("sms")
+
+        if volume:
+            operation_args = f"{operation_args},{volume}"
+        elif sms:
+            operation_args = f"{operation_args},SMS"
+
+        command = f"{command} {operation} '{operation_args}'"
+
+    if force_dynamic:
+        command = f"{command} -f"
+
+    if persistent:
+        if persistent.get("addDataset"):
+            persistent_args = f""" -P '{persistent.get("addDataset")}' """
+        else:
+            persistent_args = f""" -R '{persistent.get("delDataset")}' """
+
+        if persistent.get("marker"):
+            persistent_args = f""" {persistent_args} -M '{persistent.get("marker")}' """
+
+        command = f"{command} {persistent_args}"
+
+    return command
+
+
 def main():
     """Initialize the module.
 
@@ -603,7 +654,12 @@ def main():
                 item['opt'] = opt
                 item['dsname'] = item.get('library')
                 del item['library']
-            ret = zsystem.apf(batch=batch, forceDynamic=force_dynamic, persistent=persistent)
+            # Commenting this line to implement a workaround for names with '$'. ZOAU should
+            # release a fix soon so we can uncomment this Python API call.
+            # ret = zsystem.apf(batch=batch, forceDynamic=force_dynamic, persistent=persistent)
+            apf_command = make_apf_batch_command(batch, force_dynamic=force_dynamic, persistent=persistent)
+            rc, out, err = module.run_command(apf_command)
+            ret = ztypes.ZOAUResponse(rc, out, err, apf_command, 'utf-8')
         else:
             if not library:
                 module.fail_json(msg='library is required')
@@ -611,7 +667,6 @@ def main():
             # release a fix soon so we can uncomment this Python API call.
             # ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent)
             apf_command = make_apf_command(library, opt, volume=volume, sms=sms, force_dynamic=force_dynamic, persistent=persistent)
-            result['cmd'] = apf_command
             rc, out, err = module.run_command(apf_command)
             ret = ztypes.ZOAUResponse(rc, out, err, apf_command, 'utf-8')
 

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -406,12 +406,12 @@ def make_apf_command(
 
     if persistent:
         if opt == "add":
-            persistent_args = f"""-P '{persistent.get("addDataset")}' """
+            persistent_args = f""" -P '{persistent.get("addDataset")}' """
         else:
-            persistent_args = f"""-R '{persistent.get("delDataset")}' """
+            persistent_args = f""" -R '{persistent.get("delDataset")}' """
 
         if persistent.get("marker"):
-            persistent_args = f"{persistent_args} -M '{persistent.get("marker")}'"
+            persistent_args = f""" {persistent_args} -M '{persistent.get("marker")}' """
 
         command = f"{command} {persistent_args}"
 

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -406,9 +406,9 @@ def make_apf_command(
 
     if persistent:
         if opt == "add":
-            persistent_args = f"-P '{persistent.get("addDataset")}'"
+            persistent_args = f"""-P '{persistent.get("addDataset")}' """
         else:
-            persistent_args = f"-R '{persistent.get("delDataset")}'"
+            persistent_args = f"""-R '{persistent.get("delDataset")}' """
 
         if persistent.get("marker"):
             persistent_args = f"{persistent_args} -M '{persistent.get("marker")}'"

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -254,7 +254,6 @@ from copy import deepcopy
 from re import match as fullmatch
 
 
-from ansible.module_utils.six import PY3
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -269,10 +269,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module im
     AnsibleModuleHelper
 )
 
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
+from shlex import quote
 
 
 def content_filter(module, patterns, content):

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1645,7 +1645,6 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module im
 )
 import re
 import traceback
-from ansible.module_utils.six import PY3
 
 from shlex import quote
 

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1647,10 +1647,7 @@ import re
 import traceback
 from ansible.module_utils.six import PY3
 
-if PY3:
-    from shlex import quote
-else:
-    from pipes import quote
+from shlex import quote
 
 try:
     from zoautil_py import datasets

--- a/tests/functional/modules/test_module_security.py
+++ b/tests/functional/modules/test_module_security.py
@@ -17,7 +17,7 @@ __metaclass__ = type
 
 import pytest
 from pprint import pprint
-from pipes import quote
+from shlex import quote
 import unittest
 
 # TODO: remove some of the logic from tests and make pytest fixtures

--- a/tests/functional/modules/test_zos_apf_func.py
+++ b/tests/functional/modules/test_zos_apf_func.py
@@ -42,10 +42,10 @@ DEL_EXPECTED = """/*BEGINAPFLIST*/
 /*ENDAPFLIST*/"""
 
 def clean_test_env(hosts, test_info):
-    cmd_str = f"drm {test_info['library']}"
+    cmd_str = f"drm '{test_info['library']}' "
     hosts.all.shell(cmd=cmd_str)
     if test_info.get('persistent'):
-        cmd_str = f"drm {test_info['persistent']['data_set_name']}"
+        cmd_str = f"drm '{test_info['persistent']['data_set_name']}' "
         hosts.all.shell(cmd=cmd_str)
 
 
@@ -60,10 +60,10 @@ def test_add_del(ansible_zos_module, volumes_with_vvds):
             "force_dynamic":True
         }
         ds = get_tmp_ds_name(3,2)
-        hosts.all.shell(f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -74,7 +74,7 @@ def test_add_del(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         results = hosts.all.zos_apf(**test_info)
@@ -106,10 +106,10 @@ def test_add_del_with_tmp_hlq_option(ansible_zos_module, volumes_with_vvds):
         }
         test_info['tmp_hlq'] = tmphlq
         ds = get_tmp_ds_name(3,2,True)
-        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -120,7 +120,7 @@ def test_add_del_with_tmp_hlq_option(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         results = hosts.all.zos_apf(**test_info)
@@ -148,10 +148,10 @@ def test_add_del_volume(ansible_zos_module, volumes_with_vvds):
         }
         ds = get_tmp_ds_name(1,1,True)
 
-        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -162,7 +162,7 @@ def test_add_del_volume(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         results = hosts.all.zos_apf(**test_info)
@@ -221,10 +221,10 @@ def test_add_del_volume_persist(ansible_zos_module, volumes_with_vvds):
             "force_dynamic":True
         }
         ds = get_tmp_ds_name(1,1,True)
-        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -235,7 +235,7 @@ def test_add_del_volume_persist(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         results = hosts.all.zos_apf(**test_info)
@@ -298,15 +298,15 @@ def test_batch_add_del(ansible_zos_module, volumes_with_vvds):
         }
         for item in test_info['batch']:
             ds = get_tmp_ds_name(1,1,True)
-            hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+            hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
             item['library'] = ds
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
             item['volume'] = vol
         prstds = get_tmp_ds_name(5,5,True)
-        cmd_str = f"dtouch -tseq {prstds}"
+        cmd_str = f"dtouch -tseq '{prstds}' "
         hosts.all.shell(cmd=cmd_str)
 
         test_info['persistent']['data_set_name'] = prstds
@@ -342,7 +342,7 @@ def test_batch_add_del(ansible_zos_module, volumes_with_vvds):
     finally:
         for item in test_info['batch']:
             clean_test_env(hosts, item)
-        hosts.all.shell(cmd=f"drm {test_info['persistent']['data_set_name']}")
+        hosts.all.shell(cmd=f"drm '{test_info['persistent']['data_set_name']}' ")
 
 
 def test_operation_list(ansible_zos_module):
@@ -371,10 +371,10 @@ def test_operation_list_with_filter(ansible_zos_module, volumes_with_vvds):
         }
         test_info['state'] = 'present'
         ds = get_tmp_ds_name(3,2,True)
-        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -385,7 +385,7 @@ def test_operation_list_with_filter(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         hosts.all.zos_apf(**test_info)
@@ -420,10 +420,10 @@ def test_add_already_present(ansible_zos_module, volumes_with_vvds):
         }
         test_info['state'] = 'present'
         ds = get_tmp_ds_name(3,2,True)
-        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -434,7 +434,7 @@ def test_add_already_present(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         results = hosts.all.zos_apf(**test_info)
@@ -461,10 +461,10 @@ def test_del_not_present(ansible_zos_module, volumes_with_vvds):
             "force_dynamic":True
         }
         ds = get_tmp_ds_name(1,1,True)
-        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -475,7 +475,7 @@ def test_del_not_present(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         test_info['state'] = 'absent'
@@ -514,10 +514,10 @@ def test_add_with_wrong_volume(ansible_zos_module, volumes_with_vvds):
         }
         test_info['state'] = 'present'
         ds = get_tmp_ds_name(3,2,True)
-        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -528,7 +528,7 @@ def test_add_with_wrong_volume(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         test_info['volume'] = 'T12345'
@@ -556,10 +556,10 @@ def test_persist_invalid_ds_format(ansible_zos_module, volumes_with_vvds):
         }
         test_info['state'] = 'present'
         ds = get_tmp_ds_name(3,2,True)
-        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -570,7 +570,7 @@ def test_persist_invalid_ds_format(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         ds_name = test_info['persistent']['data_set_name']
@@ -599,10 +599,10 @@ def test_persist_invalid_marker(ansible_zos_module, volumes_with_vvds):
         }
         test_info['state'] = 'present'
         ds = get_tmp_ds_name(3,2,True)
-        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -613,7 +613,7 @@ def test_persist_invalid_marker(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         test_info['persistent']['marker'] = "# Invalid marker format"
@@ -640,10 +640,10 @@ def test_persist_invalid_marker_len(ansible_zos_module, volumes_with_vvds):
         }
         test_info['state'] = 'present'
         ds = get_tmp_ds_name(3,2,True)
-        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} {ds} ")
+        hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{ds}' ")
         test_info['library'] = ds
         if test_info.get('volume') is not None:
-            cmd_str = "dls -l " + ds + " | awk '{print $5}' "
+            cmd_str = "dls -l '" + ds + "' | awk '{print $5}' "
             results = hosts.all.shell(cmd=cmd_str)
             for result in results.contacted.values():
                 vol = result.get("stdout")
@@ -654,7 +654,7 @@ def test_persist_invalid_marker_len(ansible_zos_module, volumes_with_vvds):
             for result in results.contacted.values():
                 prstds = result.get("stdout")
             prstds = prstds[:30]
-            cmd_str = f"dtouch -tseq {prstds}"
+            cmd_str = f"dtouch -tseq '{prstds}' "
             hosts.all.shell(cmd=cmd_str)
             test_info['persistent']['data_set_name'] = prstds
         test_info['persistent']['marker'] = "/* {mark} This is a awfully lo%70sng marker */" % ("o")

--- a/tests/functional/modules/test_zos_apf_func.py
+++ b/tests/functional/modules/test_zos_apf_func.py
@@ -322,7 +322,7 @@ def test_batch_add_del(ansible_zos_module, volumes_with_vvds):
             test_info['batch'][2]['volume']
         )
         add_exptd = add_exptd.replace(" ", "")
-        cmd_str = f"cat \"//'{test_info['persistent']['data_set_name']}'\" "
+        cmd_str = f"""dcat '{test_info["persistent"]["data_set_name"]}' """
         results = hosts.all.shell(cmd=cmd_str)
         for result in results.contacted.values():
             actual = result.get("stdout")
@@ -333,7 +333,7 @@ def test_batch_add_del(ansible_zos_module, volumes_with_vvds):
         for result in results.contacted.values():
             assert result.get("rc") == 0
         del_exptd = DEL_EXPECTED.replace(" ", "")
-        cmd_str = f"cat \"//'{test_info['persistent']['data_set_name']}'\" "
+        cmd_str = f"""dcat '{test_info["persistent"]["data_set_name"]}' """
         results = hosts.all.shell(cmd=cmd_str)
         for result in results.contacted.values():
             actual = result.get("stdout")

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import time
-from pipes import quote
+from shlex import quote
 from pprint import pprint
 import pytest
 


### PR DESCRIPTION
##### SUMMARY
Fixes #1327.

##### ISSUE TYPE
- Enabler Pull Request

##### COMPONENT NAME
- module_utils/backup.py
- module_utils/copy.py
- module_utils/encode.py
- zos_find
- zos_mvs_raw
- tests for zos_data_set

##### ADDITIONAL INFORMATION
Not only does it remove the use of `pipes` in zos_data_set tests, but it also removes the use throughout the entire collection.
