### PR TITLE
Fix modules failing with verbosity with ansible-core:2.17

### DIFF
--- a/changelogs/fragments/1640-quick-fix-ansible-core:2.17-verbosity-issue
+++ b/changelogs/fragments/1640-quick-fix-ansible-core:2.17-verbosity-issue
@@ -1,0 +1,7 @@
+bugfixes:
+  - zos_copy - module would fail when an internal SFTP command wrote output to
+    stderr. Fix sets default value of existing module option `ignore_sftp_error` to True 
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1640).
+  - zos_fetch - module would fail when an internal SFTP command wrote output to
+    stderr. Fix sets default value of existing module option `ignore_sftp_error` to True 
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1640).

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -61,7 +61,7 @@ class ActionModule(ActionBase):
         force_lock = _process_boolean(task_args.get('force_lock'), default=False)
         executable = _process_boolean(task_args.get('executable'), default=False)
         asa_text = _process_boolean(task_args.get('asa_text'), default=False)
-        ignore_sftp_stderr = _process_boolean(task_args.get("ignore_sftp_stderr"), default=False)
+        ignore_sftp_stderr = _process_boolean(task_args.get("ignore_sftp_stderr"), default=True)
         backup_name = task_args.get("backup_name", None)
         encoding = task_args.get("encoding", None)
         mode = task_args.get("mode", None)

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -123,7 +123,7 @@ class ActionModule(ActionBase):
         flat = _process_boolean(self._task.args.get('flat'), default=False)
         is_binary = _process_boolean(self._task.args.get('is_binary'))
         ignore_sftp_stderr = _process_boolean(
-            self._task.args.get("ignore_sftp_stderr"), default=False
+            self._task.args.get("ignore_sftp_stderr"), default=True
         )
         validate_checksum = _process_boolean(
             self._task.args.get("validate_checksum"), default=True

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -207,6 +207,10 @@ options:
         this behavior by setting this parameter to C(false). By doing so, any
         content written to stderr is considered an error by Ansible and will
         have module fail.
+      - When Ansible verbosity is set to greater than 3, either through the
+        command line interface (CLI) using B(-vvvv) or through environment
+        variables such as B(verbosity = 4), then this parameter will
+        automatically be set to C(true).
     type: bool
     required: false
     default: true

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -201,18 +201,15 @@ options:
     required: false
   ignore_sftp_stderr:
     description:
-      - During data transfer through SFTP, the module fails if the SFTP command
-        directs any content to stderr. The user is able to override this
-        behavior by setting this parameter to C(true). By doing so, the module
-        would essentially ignore the stderr stream produced by SFTP and continue
-        execution.
-      - When Ansible verbosity is set to greater than 3, either through the
-        command line interface (CLI) using B(-vvvv) or through environment
-        variables such as B(verbosity = 4), then this parameter will
-        automatically be set to C(true).
+      - During data transfer through SFTP, the SFTP command directs content to
+        stderr. By default, the module essentially ignores the stderr stream
+        produced by SFTP and continues execution. The user is able to override
+        this behavior by setting this parameter to C(false). By doing so, any
+        content written to stderr is considered an error by Ansible and will
+        have module fail.
     type: bool
     required: false
-    default: false
+    default: true
     version_added: "1.4.0"
   is_binary:
     description:
@@ -3822,7 +3819,7 @@ def main():
             backup_name=dict(type='str'),
             local_follow=dict(type='bool', default=True),
             remote_src=dict(type='bool', default=False),
-            ignore_sftp_stderr=dict(type='bool', default=False),
+            ignore_sftp_stderr=dict(type='bool', default=True),
             validate=dict(type='bool', default=False),
             volume=dict(type='str', required=False),
             dest_data_set=dict(

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -128,6 +128,10 @@ options:
         this behavior by setting this parameter to C(false). By doing so, any
         content written to stderr is considered an error by Ansible and will
         have module fail.
+      - When Ansible verbosity is set to greater than 3, either through the
+        command line interface (CLI) using B(-vvvv) or through environment
+        variables such as B(verbosity = 4), then this parameter will
+        automatically be set to C(true).
     type: bool
     required: false
     default: true

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -122,18 +122,15 @@ options:
     type: str
   ignore_sftp_stderr:
     description:
-      - During data transfer through sftp, the module fails if the sftp command
-        directs any content to stderr. The user is able to override this
-        behavior by setting this parameter to C(true). By doing so, the module
-        would essentially ignore the stderr stream produced by sftp and continue
-        execution.
-      - When Ansible verbosity is set to greater than 3, either through the
-        command line interface (CLI) using B(-vvvv) or through environment
-        variables such as B(verbosity = 4), then this parameter will
-        automatically be set to C(true).
+      - During data transfer through SFTP, the SFTP command directs content to
+        stderr. By default, the module essentially ignores the stderr stream
+        produced by SFTP and continues execution. The user is able to override
+        this behavior by setting this parameter to C(false). By doing so, any
+        content written to stderr is considered an error by Ansible and will
+        have module fail.
     type: bool
     required: false
-    default: false
+    default: true
 notes:
     - When fetching PDSE and VSAM data sets, temporary storage will be used
       on the remote z/OS system. After the PDSE or VSAM data set is
@@ -821,7 +818,7 @@ def run_module():
             use_qualifier=dict(required=False, default=False, type="bool"),
             validate_checksum=dict(required=False, default=True, type="bool"),
             encoding=dict(required=False, type="dict"),
-            ignore_sftp_stderr=dict(type="bool", default=False, required=False),
+            ignore_sftp_stderr=dict(type="bool", default=True, required=False),
             tmp_hlq=dict(required=False, type="str", default=None),
         )
     )


### PR DESCRIPTION
Primarily affects modules:
- zos_copy
- zos_fetch
- zos_script

possibly affects:
- zos_archive/zos_unarchive
- zos_encode

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ansible-core:2.17 changed the way the SFTP command is constructed, which resulted in SFTP output getting written to stderr, which triggers module failure,

An existing option, ignore_sftp_error, alleviates the issue. This PR merely changes the default value so that the module option is set to True by default.

- Fixes #1574 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

#### Testing Strategy

Beyond passing regression based on dependencyfinder to ensure no previous functionality has been lost, as is standard, I've elected to run the pipelines using ansible-core:2.17 with "verbose" mode enabled against the standard dev branch and then again against this branch to prove that "verbose" mode was indeed broken and has been fixed.

See the comment(s) below for pipeline results.

