### PR TITLE
[Enhancement] [zos_operator] Case sensitivity in zos_operator commands

### DIFF
--- a/changelogs/fragments/1641-case-sensitivity-zos_operator.yml
+++ b/changelogs/fragments/1641-case-sensitivity-zos_operator.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - zos_operator - add new option case_sensitive to module, allowing users
+  - zos_operator - Added new option ``case_sensitive`` to module, allowing users
     to control how case in a command is handled by it.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1641)

--- a/changelogs/fragments/1641-case-sensitivity-zos_operator.yml
+++ b/changelogs/fragments/1641-case-sensitivity-zos_operator.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - zos_operator - add new option case_sensitive to module, allowing users
+    to control how case in a command is handled by it.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1641)

--- a/docs/source/modules/zos_operator.rst
+++ b/docs/source/modules/zos_operator.rst
@@ -33,9 +33,11 @@ cmd
 
   For example, change the command "...,P='DSN3EPX,-DBC1,S'" to "...,P=''DSN3EPX,-DBC1,S'' ".
 
-  If the command contains any special characters ($, &, etc), they must be escaped using double backslashes like \\\\\\$.
+  If the command contains any special characters ($, &, etc), they must be escaped using double backslashes like \\\\$.
 
   For example, to display job by job name the command would be ``cmd:"\\$dj''HELLO''"``
+
+  By default, the command will be converted to uppercase before execution, to control this behavior, see the \ :emphasis:`case\_sensitive`\  option below.
 
   | **required**: True
   | **type**: str
@@ -61,6 +63,14 @@ wait_time_s
   | **required**: False
   | **type**: int
   | **default**: 1
+
+
+case_sensitive
+  If \ :literal:`true`\ , the command will not be converted to uppercase before execution. Instead, the casing will be preserved just as it was written in a task.
+
+  | **required**: False
+  | **type**: bool
+  | **default**: False
 
 
 

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -29,6 +29,7 @@ author:
   - "Demetrios Dimatos (@ddimatos)"
   - "Rich Parker (@richp405)"
   - "Oscar Fernando Flores (@fernandofloresg)"
+  - "Ivan Moreno (@rexemin)"
 options:
   cmd:
     description:
@@ -38,6 +39,8 @@ options:
       - If the command contains any special characters ($, &, etc), they must be escaped using
         double backslashes like \\\\\\$.
       - For example, to display job by job name the command would be C(cmd:"\\$dj''HELLO''")
+      - By default, the command will be converted to uppercase before execution, to control this
+        behavior, see the I(case_sensitive) option below.
     type: str
     required: true
   verbose:
@@ -58,6 +61,14 @@ options:
     type: int
     required: false
     default: 1
+  case_sensitive:
+    description:
+      - If C(true), the command will not be converted to uppercase before
+        execution. Instead, the casing will be preserved just as it was
+        written in a task.
+    type: bool
+    required: false
+    default: false
 notes:
     - Commands may need to use specific prefixes like $, they can be discovered by
       issuing the following command C(D OPDATA,PREFIX).

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2023
+# Copyright (c) IBM Corporation 2019, 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -171,6 +171,24 @@ def test_zos_operator_positive_verbose_blocking(ansible_zos_module):
             assert result.get('elapsed') >= wait_time_s
 
 
+def test_zos_operator_positive_path_preserve_case(ansible_zos_module):
+    hosts = ansible_zos_module
+    command = "d u,all"
+    results = hosts.all.zos_operator(
+        cmd=command,
+        verbose=False,
+        case_sensitive=True
+    )
+
+    for result in results.contacted.values():
+        assert result["rc"] == 0
+        assert result.get("changed") is True
+        assert result.get("content") is not None
+        # Making sure the output from opercmd logged the command
+        # exactly as it was written.
+        assert len(result.get("content")) > 1
+        assert command in result.get("content")[1]
+
 
 def test_response_come_back_complete(ansible_zos_module):
     hosts = ansible_zos_module

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -173,7 +173,7 @@ def test_zos_operator_positive_verbose_blocking(ansible_zos_module):
 
 def test_zos_operator_positive_path_preserve_case(ansible_zos_module):
     hosts = ansible_zos_module
-    command = "d u,all"
+    command = "D U,all"
     results = hosts.all.zos_operator(
         cmd=command,
         verbose=False,


### PR DESCRIPTION
##### SUMMARY
Fixes #1155.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zos_operator

##### ADDITIONAL INFORMATION
Added a new option to the module, called `case_sensitive`, which is a boolean telling the module that the command is case sensitive and therefore not change the casing. Can change the name of the option, though.
