### PR TITLE
[Bugfix] [v1.11.0 beta.1] [zos_apf] Backup when using special symbols

### DIFF
--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -139,7 +139,10 @@ def mvs_file_backup(dsn, bk_dsn=None, tmphlq=None):
             rc, out, err = _copy_pds(dsn, bk_dsn)
             if rc != 0:
                 raise BackupError(
-                    "Unable to backup data set {0} to {1}".format(dsn, bk_dsn)
+                    "Unable to backup data set {0} to {1}.".format(dsn, bk_dsn),
+                    rc=rc,
+                    stdout=out,
+                    stderr=err
                 )
     return bk_dsn
 

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -362,8 +362,17 @@ def backupOper(module, src, backup, tmphlq=None):
             backup_name = Backup.uss_file_backup(src, backup_name=backup, compress=False)
         else:
             backup_name = Backup.mvs_file_backup(dsn=src, bk_dsn=backup, tmphlq=tmphlq)
+    except Backup.BackupError as exc:
+        module.fail_json(
+            msg=exc.msg,
+            rc=exc.rc,
+            stdout=exc.stdout,
+            stderr=exc.stderr
+        )
     except Exception:
-        module.fail_json(msg="creating backup has failed")
+        module.fail_json(
+            msg="An error ocurred during backup."
+        )
 
     return backup_name
 

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -349,7 +349,7 @@ def backupOper(module, src, backup, tmphlq=None):
             file_type = 'USS'
 
     if file_type != 'USS' and file_type not in DS_TYPE:
-        message = "{0} data set type of {1} is NOT supported".format(str(file_type), src)
+        message = "Dataset {0} of type {1} is NOT supported".format(src, str(file_type))
         module.fail_json(msg=message)
 
     # backup can be True(bool) or none-zero length string. string indicates that backup_name was provided.

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -349,7 +349,7 @@ def backupOper(module, src, backup, tmphlq=None):
             file_type = 'USS'
 
     if file_type != 'USS' and file_type not in DS_TYPE:
-        message = "{0} data set type is NOT supported".format(str(file_type))
+        message = "{0} data set type of {1} is NOT supported".format(str(file_type), src)
         module.fail_json(msg=message)
 
     # backup can be True(bool) or none-zero length string. string indicates that backup_name was provided.


### PR DESCRIPTION
##### SUMMARY
Fixes a bug where the backup function would use outdated utilities to get the type of a dataset and fail when the name has a `$` in its name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zos_apf
