### PR TITLE
Update module with RACF authority doc

### DIFF
--- a/changelogs/fragments/1647-doc-backup-restore-racf-class.yml
+++ b/changelogs/fragments/1647-doc-backup-restore-racf-class.yml
@@ -1,0 +1,5 @@
+trivial:
+  - zos_backup_restore - Added supplemental documentation explaining the RACF class
+    requirement when using module option restore. 
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1647).
+

--- a/docs/source/modules/zos_backup_restore.rst
+++ b/docs/source/modules/zos_backup_restore.rst
@@ -47,34 +47,38 @@ data_sets
 
 
   include
-    When \ :emphasis:`operation=backup`\ , specifies a list of data sets or data set patterns to include in the backup.
+    When *operation=backup*, specifies a list of data sets or data set patterns to include in the backup.
 
-    When \ :emphasis:`operation=restore`\ , specifies a list of data sets or data set patterns to include when restoring from a backup.
+    When *operation=backup* GDS relative names are supported.
 
-    The single asterisk, \ :literal:`\*`\ , is used in place of exactly one qualifier. In addition, it can be used to indicate to DFSMSdss that only part of a qualifier has been specified.
+    When *operation=restore*, specifies a list of data sets or data set patterns to include when restoring from a backup.
 
-    When used with other qualifiers, the double asterisk, \ :literal:`\*\*`\ , indicates either the nonexistence of leading, trailing, or middle qualifiers, or the fact that they play no role in the selection process.
+    The single asterisk, ``*``, is used in place of exactly one qualifier. In addition, it can be used to indicate to DFSMSdss that only part of a qualifier has been specified.
+
+    When used with other qualifiers, the double asterisk, ``**``, indicates either the nonexistence of leading, trailing, or middle qualifiers, or the fact that they play no role in the selection process.
 
     Two asterisks are the maximum permissible in a qualifier. If there are two asterisks in a qualifier, they must be the first and last characters.
 
-    A question mark \ :literal:`?`\  or percent sign \ :literal:`%`\  matches a single character.
+    A question mark ``?`` or percent sign ``%`` matches a single character.
 
     | **required**: False
     | **type**: raw
 
 
   exclude
-    When \ :emphasis:`operation=backup`\ , specifies a list of data sets or data set patterns to exclude from the backup.
+    When *operation=backup*, specifies a list of data sets or data set patterns to exclude from the backup.
 
-    When \ :emphasis:`operation=restore`\ , specifies a list of data sets or data set patterns to exclude when restoring from a backup.
+    When *operation=backup* GDS relative names are supported.
 
-    The single asterisk, \ :literal:`\*`\ , is used in place of exactly one qualifier. In addition, it can be used to indicate that only part of a qualifier has been specified."
+    When *operation=restore*, specifies a list of data sets or data set patterns to exclude when restoring from a backup.
 
-    When used with other qualifiers, the double asterisk, \ :literal:`\*\*`\ , indicates either the nonexistence of leading, trailing, or middle qualifiers, or the fact that they play no role in the selection process.
+    The single asterisk, ``*``, is used in place of exactly one qualifier. In addition, it can be used to indicate that only part of a qualifier has been specified."
+
+    When used with other qualifiers, the double asterisk, ``**``, indicates either the nonexistence of leading, trailing, or middle qualifiers, or the fact that they play no role in the selection process.
 
     Two asterisks are the maximum permissible in a qualifier. If there are two asterisks in a qualifier, they must be the first and last characters.
 
-    A question mark \ :literal:`?`\  or percent sign \ :literal:`%`\  matches a single character.
+    A question mark ``?`` or percent sign ``%`` matches a single character.
 
     | **required**: False
     | **type**: raw
@@ -84,22 +88,22 @@ data_sets
 volume
   This applies to both data set restores and volume restores.
 
-  When \ :emphasis:`operation=backup`\  and \ :emphasis:`data\_sets`\  are provided, specifies the volume that contains the data sets to backup.
+  When *operation=backup* and *data_sets* are provided, specifies the volume that contains the data sets to backup.
 
-  When \ :emphasis:`operation=restore`\ , specifies the volume the backup should be restored to.
+  When *operation=restore*, specifies the volume the backup should be restored to.
 
-  \ :emphasis:`volume`\  is required when restoring a full volume backup.
+  *volume* is required when restoring a full volume backup.
 
   | **required**: False
   | **type**: str
 
 
 full_volume
-  When \ :emphasis:`operation=backup`\  and \ :emphasis:`full\_volume=True`\ , specifies that the entire volume provided to \ :emphasis:`volume`\  should be backed up.
+  When *operation=backup* and *full_volume=True*, specifies that the entire volume provided to *volume* should be backed up.
 
-  When \ :emphasis:`operation=restore`\  and \ :emphasis:`full\_volume=True`\ , specifies that the volume should be restored (default is dataset).
+  When *operation=restore* and *full_volume=True*, specifies that the volume should be restored (default is dataset).
 
-  \ :emphasis:`volume`\  must be provided when \ :emphasis:`full\_volume=True`\ .
+  *volume* must be provided when *full_volume=True*.
 
   | **required**: False
   | **type**: bool
@@ -109,18 +113,20 @@ full_volume
 temp_volume
   Specifies a particular volume on which the temporary data sets should be created during the backup and restore process.
 
-  When \ :emphasis:`operation=backup`\  and \ :emphasis:`backup\_name`\  is a data set, specifies the volume the backup should be placed in.
+  When *operation=backup* and *backup_name* is a data set, specifies the volume the backup should be placed in.
 
   | **required**: False
   | **type**: str
 
 
 backup_name
-  When \ :emphasis:`operation=backup`\ , the destination data set or UNIX file to hold the backup.
+  When *operation=backup*, the destination data set or UNIX file to hold the backup.
 
-  When \ :emphasis:`operation=restore`\ , the destination data set or UNIX file backup to restore.
+  When *operation=restore*, the destination data set or UNIX file backup to restore.
 
-  There are no enforced conventions for backup names. However, using a common extension like \ :literal:`.dzp`\  for UNIX files and \ :literal:`.DZP`\  for data sets will improve readability.
+  There are no enforced conventions for backup names. However, using a common extension like ``.dzp`` for UNIX files and ``.DZP`` for data sets will improve readability.
+
+  GDS relative names are supported when *operation=restore*.
 
   | **required**: True
   | **type**: str
@@ -135,9 +141,9 @@ recover
 
 
 overwrite
-  When \ :emphasis:`operation=backup`\ , specifies if an existing data set or UNIX file matching \ :emphasis:`backup\_name`\  should be deleted.
+  When *operation=backup*, specifies if an existing data set or UNIX file matching *backup_name* should be deleted.
 
-  When \ :emphasis:`operation=restore`\ , specifies if the module should overwrite existing data sets with matching name on the target device.
+  When *operation=restore*, specifies if the module should overwrite existing data sets with matching name on the target device.
 
   | **required**: False
   | **type**: bool
@@ -145,35 +151,35 @@ overwrite
 
 
 sms_storage_class
-  When \ :emphasis:`operation=restore`\ , specifies the storage class to use. The storage class will also be used for temporary data sets created during restore process.
+  When *operation=restore*, specifies the storage class to use. The storage class will also be used for temporary data sets created during restore process.
 
-  When \ :emphasis:`operation=backup`\ , specifies the storage class to use for temporary data sets created during backup process.
+  When *operation=backup*, specifies the storage class to use for temporary data sets created during backup process.
 
-  If neither of \ :emphasis:`sms\_storage\_class`\  or \ :emphasis:`sms\_management\_class`\  are specified, the z/OS system's Automatic Class Selection (ACS) routines will be used.
+  If neither of *sms_storage_class* or *sms_management_class* are specified, the z/OS system's Automatic Class Selection (ACS) routines will be used.
 
   | **required**: False
   | **type**: str
 
 
 sms_management_class
-  When \ :emphasis:`operation=restore`\ , specifies the management class to use. The management class will also be used for temporary data sets created during restore process.
+  When *operation=restore*, specifies the management class to use. The management class will also be used for temporary data sets created during restore process.
 
-  When \ :emphasis:`operation=backup`\ , specifies the management class to use for temporary data sets created during backup process.
+  When *operation=backup*, specifies the management class to use for temporary data sets created during backup process.
 
-  If neither of \ :emphasis:`sms\_storage\_class`\  or \ :emphasis:`sms\_management\_class`\  are specified, the z/OS system's Automatic Class Selection (ACS) routines will be used.
+  If neither of *sms_storage_class* or *sms_management_class* are specified, the z/OS system's Automatic Class Selection (ACS) routines will be used.
 
   | **required**: False
   | **type**: str
 
 
 space
-  If \ :emphasis:`operation=backup`\ , specifies the amount of space to allocate for the backup. Please note that even when backing up to a UNIX file, backup contents will be temporarily held in a data set.
+  If *operation=backup*, specifies the amount of space to allocate for the backup. Please note that even when backing up to a UNIX file, backup contents will be temporarily held in a data set.
 
-  If \ :emphasis:`operation=restore`\ , specifies the amount of space to allocate for data sets temporarily created during the restore process.
+  If *operation=restore*, specifies the amount of space to allocate for data sets temporarily created during the restore process.
 
-  The unit of space used is set using \ :emphasis:`space\_type`\ .
+  The unit of space used is set using *space_type*.
 
-  When \ :emphasis:`full\_volume=True`\ , \ :emphasis:`space`\  defaults to \ :literal:`1`\ , otherwise default is \ :literal:`25`\ 
+  When *full_volume=True*, *space* defaults to ``1``, otherwise default is ``25``
 
   | **required**: False
   | **type**: int
@@ -182,9 +188,9 @@ space
 space_type
   The unit of measurement to use when defining data set space.
 
-  Valid units of size are \ :literal:`k`\ , \ :literal:`m`\ , \ :literal:`g`\ , \ :literal:`cyl`\ , and \ :literal:`trk`\ .
+  Valid units of size are ``k``, ``m``, ``g``, ``cyl``, and ``trk``.
 
-  When \ :emphasis:`full\_volume=True`\ , \ :emphasis:`space\_type`\  defaults to \ :literal:`g`\ , otherwise default is \ :literal:`m`\ 
+  When *full_volume=True*, *space_type* defaults to ``g``, otherwise default is ``m``
 
   | **required**: False
   | **type**: str
@@ -203,7 +209,7 @@ hlq
 tmp_hlq
   Override the default high level qualifier (HLQ) for temporary and backup data sets.
 
-  The default HLQ is the Ansible user that executes the module and if that is not available, then the value of \ :literal:`TMPHLQ`\  is used.
+  The default HLQ is the Ansible user that executes the module and if that is not available, then the value of ``TMPHLQ`` is used.
 
   | **required**: False
   | **type**: str
@@ -234,6 +240,15 @@ Examples
            - private.test.*
          exclude: user.private.*
        backup_name: MY.BACKUP.DZP
+
+   - name: Backup a list of GDDs to data set my.backup.dzp
+     zos_backup_restore:
+       operation: backup
+       data_sets:
+         include:
+           - user.gdg(-1)
+           - user.gdg(0)
+       backup_name: my.backup.dzp
 
    - name: Backup all datasets matching the pattern USER.** to UNIX file /tmp/temp_backup.dzp, ignore recoverable errors.
      zos_backup_restore:
@@ -331,6 +346,16 @@ Examples
 
 
 
+
+Notes
+-----
+
+.. note::
+   It is the playbook author or user's responsibility to ensure they have appropriate authority to the RACF FACILITY resource class. A user is described as the remote user, configured to run either the playbook or playbook tasks, who can also obtain escalated privileges to execute as root or another user.
+
+   When using this module, if the RACF FACILITY class profile **STGADMIN.ADR.DUMP.TOLERATE.ENQF** is active, you must have READ access authority to use the module option *recover=true*. If the RACF FACILITY class checking is not set up, any user can use the module option without access to the class.
+
+   If your system uses a different security product, consult that product's documentation to configure the required security classes.
 
 
 

--- a/plugins/modules/zos_backup_restore.py
+++ b/plugins/modules/zos_backup_restore.py
@@ -197,6 +197,19 @@ options:
         that is not available, then the value of C(TMPHLQ) is used.
     required: false
     type: str
+notes:
+    - It is the playbook author or user's responsibility to ensure they have
+      appropriate authority to the RACF FACILITY resource class. A user is
+      described as the remote user, configured to run either the playbook or
+      playbook tasks, who can also obtain escalated privileges to execute as
+      root or another user.
+    - When using this module, if the RACF FACILITY class
+      profile B(STGADMIN.ADR.DUMP.TOLERATE.ENQF) is active, you must
+      have READ access authority to use the module option I(recover=true).
+      If the RACF FACILITY class checking is not set up, any user can use
+      the module option without access to the class.
+    - If your system uses a different security product, consult that product's
+      documentation to configure the required security classes.
 """
 
 RETURN = r""""""

--- a/tests/functional/modules/test_zos_backup_restore.py
+++ b/tests/functional/modules/test_zos_backup_restore.py
@@ -769,7 +769,7 @@ def test_backup_into_gds(ansible_zos_module, dstype):
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
         ds_to_write = f"{ds_name}(MEM)" if dstype in ['pds', 'pdse'] else ds_name
-        results = hosts.all.shell(cmd=f"decho 'test line' \"{ds_to_write}\"")
+        results = hosts.all.shell(cmd=f"decho 'test line' '{ds_to_write}'")
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None


### PR DESCRIPTION
##### SUMMARY
Addresses issue #1540 

Adds documentation explaining the RACF class requirement for use with the modules restore option. 

```
notes:
    - It is the playbook author or user's responsibility to ensure they have
      appropriate authority to the RACF FACILITY resource class. A user is
      described as the remote user, configured to run either the playbook or
      playbook tasks, who can also obtain escalated privileges to execute as
      root or another user.
    - When using this module, if the RACF FACILITY class
      profile B(STGADMIN.ADR.DUMP.TOLERATE.ENQF) is active, you must
      have READ access authority to use the module option I(recover=true).
      If the RACF FACILITY class checking is not set up, any user can use
      the module option without access to the class.
    - If your system uses a different security product, consult that product's
      documentation to configure the required security classes.
```

##### ISSUE TYPE
- Docs Pull Request


