### PR TITLE
[Bugfix] [zos_script] Fix missing args when splitting command

### DIFF
--- a/changelogs/fragments/1698-multiple-args-zos_script.yml
+++ b/changelogs/fragments/1698-multiple-args-zos_script.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_script - The module would discard command line arguments in a command,
+    except for the first one. Fix now makes sure that all arguments are
+    passed to the remote command that gets executed.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1698).

--- a/plugins/action/zos_script.py
+++ b/plugins/action/zos_script.py
@@ -46,7 +46,7 @@ class ActionModule(ActionBase):
             return result
 
         script_path = cmd_parts[0]
-        script_args = cmd_parts[1] if len(cmd_parts) > 1 else ""
+        script_args = ' '.join(cmd_parts[1:]) if len(cmd_parts) > 1 else ""
         remote_src = self._process_boolean(module_args.get('remote_src'))
         user_cmd = tempfile_path = None
 


### PR DESCRIPTION
##### SUMMARY
Fixes #1669.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zos_script
