### PR TITLE
[v1.9.3][zos_job_query] Return system and subsystem values when querying a job.

### DIFF
--- a/changelogs/fragments/1723-zos_query-return-system-subsystem.yml
+++ b/changelogs/fragments/1723-zos_query-return-system-subsystem.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - zos_job_submit - Module was not returning values for system and subsystem. Fix now returns these values.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1723).

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -189,13 +189,13 @@ def job_status(job_id=None, owner=None, job_name=None, dd_name=None):
     job_name = parsed_args.get("job_name") or "*"
     owner = parsed_args.get("owner") or "*"
 
-    job_status_result = _get_job_status(job_id=job_id, owner=owner, job_name=job_name, dd_scan=False)
+    job_status_result = _get_job_status(job_id=job_id, owner=owner, job_name=job_name)
 
     if len(job_status_result) == 0:
         job_id = "" if job_id == "*" else job_id
         job_name = "" if job_name == "*" else job_name
         owner = "" if owner == "*" else owner
-        job_status_result = _get_job_status(job_id=job_id, owner=owner, job_name=job_name, dd_scan=False)
+        job_status_result = _get_job_status(job_id=job_id, owner=owner, job_name=job_name)
 
     return job_status_result
 

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -119,6 +119,16 @@ jobs:
          Unique job identifier assigned to the job by JES.
       type: str
       sample: JOB01427
+    system:
+      description:
+         The job entry system that MVS uses to do work.
+      type: str
+      sample: STL1
+    subsystem:
+      description:
+         The job entry subsystem that MVS uses to do work.
+      type: str
+      sample: STL1
     ret_code:
       description:
          Return code output collected from job log.
@@ -129,17 +139,6 @@ jobs:
             Return code or abend resulting from the job submission.
           type: str
           sample: CC 0000
-        msg_code:
-          description:
-            Return code extracted from the `msg` so that it can be evaluated.
-            For example, ABEND(S0C4) would yield "S0C4".
-          type: str
-          sample: S0C4
-        msg_txt:
-          description:
-             Returns additional information related to the job.
-          type: str
-          sample: "No job can be located with this job name: HELLO"
         code:
           description:
              Return code converted to integer value (when possible).

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -139,6 +139,17 @@ jobs:
             Return code or abend resulting from the job submission.
           type: str
           sample: CC 0000
+        msg_code:
+          description:
+            Return code extracted from the `msg` so that it can be evaluated.
+            For example, ABEND(S0C4) would yield "S0C4".
+          type: str
+          sample: S0C4
+        msg_txt:
+          description:
+             Returns additional information related to the job.
+          type: str
+          sample: "No job can be located with this job name: HELLO"
         code:
           description:
              Return code converted to integer value (when possible).

--- a/tests/functional/modules/test_zos_job_query_func.py
+++ b/tests/functional/modules/test_zos_job_query_func.py
@@ -74,6 +74,8 @@ def test_zos_job_id_query_multi_wildcards_func(ansible_zos_module):
             qresults = hosts.all.zos_job_query(job_id=jobmask)
             for qresult in qresults.contacted.values():
                 assert qresult.get("jobs") is not None
+                assert qresult.get("jobs")[0].get("system") is not None
+                assert qresult.get("jobs")[0].get("subsystem") is not None
 
     finally:
         hosts.all.file(path=TEMP_PATH, state="absent")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enabled the dd scan when fetching a job status, while this is less performant it enables us to fetch both SYSTEM and NODE values from JES output.

We know that this won't be the same final implementation that will go into `dev` branch since we have requested ZOAU to provide these values when fetching the job list instead of us parsing the JES output.




<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1681 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_query
