### PR TITLE
Staging v1.11.0 (#1726)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,13 +4,13 @@ ibm.ibm\_zos\_core Release Notes
 
 .. contents:: Topics
 
-v1.11.0-beta.1
-==============
+v1.11.0
+=======
 
 Release Summary
 ---------------
 
-Release Date: '2024-08-05'
+Release Date: '2024-10-01'
 This changelog describes all changes made to the modules and plugins included
 in this collection. The release date is the date the changelog is created.
 For additional details such as required dependencies and availability review
@@ -32,11 +32,11 @@ Minor Changes
 - zos_job_submit - add support for generation data groups and generation data sets as sources for jobs. (https://github.com/ansible-collections/ibm_zos_core/pull/1497)
 - zos_lineinfile - Added support for GDG and GDS relative name notation to use a data set. And backup in new generations. Added support for data set names with special characters like $, /#, /- and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1516).
 - zos_mount - Added support for data set names with special characters ($, /#, /- and @). This is for both src and backup data set names. (https://github.com/ansible-collections/ibm_zos_core/pull/1631).
-- zos_tso_command - Added support for GDG and GDS relative name notation to use a data set name. Added support for data set names with special characters like $, /#, /- and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1563).
 - zos_mvs_raw - Added support for GDG and GDS relative name notation to use a data set. Added support for data set names with special characters like $, /#, /- and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1525).
 - zos_mvs_raw - Added support for GDG and GDS relative positive name notation to use a data set. (https://github.com/ansible-collections/ibm_zos_core/pull/1541).
 - zos_mvs_raw - Redesign the wrappers of dd clases to use properly the arguments. (https://github.com/ansible-collections/ibm_zos_core/pull/1470).
 - zos_script - Improved the copy to remote mechanic to avoid using deepcopy that could result in failure for some systems. (https://github.com/ansible-collections/ibm_zos_core/pull/1561).
+- zos_tso_command - Added support for GDG and GDS relative name notation to use a data set name. Added support for data set names with special characters like $, /#, /- and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1563).
 - zos_unarchive - Added support for data set names with special characters like $, /#, /- and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1511).
 - zos_unarchive - Improved the copy to remote mechanic to avoid using deepcopy that could result in failure for some systems. (https://github.com/ansible-collections/ibm_zos_core/pull/1561).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ The **IBM z/OS core** collection enables Ansible to interact with z/OS Data Sets
 
 The **IBM z/OS core** collection is part of the **Red Hat® Ansible Certified Content for IBM Z®** offering that brings Ansible automation to IBM Z®. This collection brings forward the possibility to manage batch jobs, perform program authorizations, run operator operations, and execute both JES and MVS commands as well as execute shell, python, and REXX scripts. It supports data set creation, searching, copying, fetching, and encoding. It provides both archiving and unarchiving of data sets, initializing volumes, performing backups and supports Jinja templating.
 
-
 <br/>System programmers can enable pipelines to setup, tear down and deploy applications while system administrators can automate time consuming repetitive tasks inevitably freeing up their time. New z/OS users can find comfort in Ansible's familiarity and expedite their proficiency in record time.
 
 ## Requirements
@@ -64,7 +63,7 @@ after an update.
 ```sh
 PYZ: "path_to_python_installation_on_zos_target"
 ZOAU: "path_to_zoau_installation_on_zos_target"
-ZOAU_PYTHONPATH: "path_to_zoau_wheel_installation_directory"
+ZOAU_PYTHON_LIBRARY_PATH: "path_to_zoau_wheel_installation_directory"
 
 ansible_python_interpreter: "{{ PYZ }}/bin/python3"
 
@@ -135,11 +134,9 @@ All releases will meet the following test criteria.
 
 * ansible-core v2.15.x
 * Python 3.11.x
-* IBM Open Enterprise SDK for Python 3.11.x
+* IBM Open Enterprise SDK for Python 3.12.x
 * IBM Z Open Automation Utilities (ZOAU) 1.3.1.x
 * z/OS V2R5
-
-This release introduces case sensitivity for option values and includes a porting guide in the [release notes](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html) to assist with which option values will need to be updated.
 
 ## Contributing
 
@@ -154,7 +151,7 @@ If you would like to communicate with this community, you can do so through the 
 * GitHub [discussions](https://github.com/ansible-collections/ibm_zos_core/discussions).
 * GitHub [issues](https://github.com/ansible-collections/ibm_zos_core/issues/new/choose).
 * [Ansible Forum](https://forum.ansible.com/), please use the `zos` tag to ensure proper awareness.
-* Discord [System Z Enthusiasts](https://discord.gg/Kmy5QaUGbB) room [ansible](https://discord.gg/nHrDdRTC).
+* Discord [System Z Enthusiasts](https://discord.gg/sze) room `ansible`.
 * Matrix general usage questions [room](https://matrix.to/#/#users:ansible.com).
 
 ## Support
@@ -178,8 +175,8 @@ For Galaxy and GitHub users, to see the supported ansible-core versions, review 
 | Version  | Status         | Release notes | Changelogs |
 |----------|----------------|---------------|------------|
 | 1.12.x   | In development | unreleased    | unreleased |
-| 1.11.x   | In preview     | [Release notes](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html#version-1-11-0-beta.1) | [Changelogs](https://github.com/ansible-collections/ibm_zos_core/blob/v1.11.0-beta.1/CHANGELOG.rst) |
-| 1.10.x   | Current        | [Release notes](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html#version-1-10-0)   | [Changelogs](https://github.com/ansible-collections/ibm_zos_core/blob/v1.10.0/CHANGELOG.rst) |
+| 1.11.x   | Current        | [Release notes](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html#version-1-11-0)   | [Changelogs](https://github.com/ansible-collections/ibm_zos_core/blob/v1.11.0/CHANGELOG.rst) |
+| 1.10.x   | Released       | [Release notes](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html#version-1-10-0)   | [Changelogs](https://github.com/ansible-collections/ibm_zos_core/blob/v1.10.0/CHANGELOG.rst) |
 | 1.9.x    | Released       | [Release notes](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html#version-1-9-2)    | [Changelogs](https://github.com/ansible-collections/ibm_zos_core/blob/v1.9.2/CHANGELOG.rst)  |
 | 1.8.x    | Released       | [Release notes](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html#version-1-8-0)    | [Changelogs](https://github.com/ansible-collections/ibm_zos_core/blob/v1.8.0/CHANGELOG.rst)  |
 | 1.7.x    | Released       | [Release notes](https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html#version-1-7-0)    | [Changelogs](https://github.com/ansible-collections/ibm_zos_core/blob/v1.7.0/CHANGELOG.rst)  |

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -135,4 +135,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 1.11.0-beta.1
+version: 1.11.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -259,6 +259,20 @@ releases:
     - 992-fix-sanity4to6.yml
     - v1.10.0-beta.1_summary.yml
     release_date: '2024-05-08'
+  1.11.0:
+    changes:
+      release_summary: 'Release Date: ''2024-10-01''
+
+        This changelog describes all changes made to the modules and plugins included
+
+        in this collection. The release date is the date the changelog is created.
+
+        For additional details such as required dependencies and availability review
+
+        the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__'
+    fragments:
+    - v1.11.0_summary.yml
+    release_date: '2024-09-25'
   1.11.0-beta.1:
     changes:
       bugfixes:
@@ -283,9 +297,9 @@ releases:
       - zos_archive - Added support for GDG and GDS relative name notation to archive
         data sets. Added support for data set names with special characters like $,
         /#, /- and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1511).
-      - zos_backup_restore - Added support for GDS relative name notation to include or
-        exclude data sets when operation is backup. Added support for data set names
-        with special characters like $, /#, and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1527).
+      - zos_backup_restore - Added support for GDS relative name notation to include
+        or exclude data sets when operation is backup. Added support for data set
+        names with special characters like $, /#, and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1527).
       - zos_blockinfile - Added support for GDG and GDS relative name notation to
         use a data set. And backup in new generations. Added support for data set
         names with special characters like $, /#, /- and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1516).
@@ -315,11 +329,11 @@ releases:
         to use a data set. (https://github.com/ansible-collections/ibm_zos_core/pull/1541).
       - zos_mvs_raw - Redesign the wrappers of dd clases to use properly the arguments.
         (https://github.com/ansible-collections/ibm_zos_core/pull/1470).
-      - zos_tso_command - Added support for GDG and GDS relative name notation to use
-        a data set name. Added support for data set names with special characters
-        like $, /#, /- and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1563).
       - zos_script - Improved the copy to remote mechanic to avoid using deepcopy
         that could result in failure for some systems. (https://github.com/ansible-collections/ibm_zos_core/pull/1561).
+      - zos_tso_command - Added support for GDG and GDS relative name notation to
+        use a data set name. Added support for data set names with special characters
+        like $, /#, /- and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1563).
       - zos_unarchive - Added support for data set names with special characters like
         $, /#, /- and @. (https://github.com/ansible-collections/ibm_zos_core/pull/1511).
       - zos_unarchive - Improved the copy to remote mechanic to avoid using deepcopy

--- a/changelogs/fragments/v1.11.0-beta.1_summary.yml
+++ b/changelogs/fragments/v1.11.0-beta.1_summary.yml
@@ -1,6 +1,0 @@
-release_summary: |
-  Release Date: '2024-08-05'
-  This changelog describes all changes made to the modules and plugins included
-  in this collection. The release date is the date the changelog is created.
-  For additional details such as required dependencies and availability review
-  the collections `release notes <https://ibm.github.io/z_ansible_collections_doc/ibm_zos_core/docs/source/release_notes.html>`__

--- a/docs/source/modules/zos_blockinfile.rst
+++ b/docs/source/modules/zos_blockinfile.rst
@@ -33,7 +33,7 @@ src
 
   The USS file must be an absolute pathname.
 
-  Generation data set (GDS) relative name of generation already created.  ``e.g. SOME.CREATION(-1).``
+  Generation data set (GDS) relative name of generation already created. e.g. *SOME.CREATION(-1*).
 
   | **required**: True
   | **type**: str

--- a/docs/source/modules/zos_lineinfile.rst
+++ b/docs/source/modules/zos_lineinfile.rst
@@ -33,7 +33,7 @@ src
 
   The USS file must be an absolute pathname.
 
-  Generation data set (GDS) relative name of generation already created. ``e.g. SOME.CREATION(-1).``
+  Generation data set (GDS) relative name of generation already created. e.g. *SOME.CREATION(-1*).
 
   | **required**: True
   | **type**: str

--- a/docs/source/modules/zos_unarchive.rst
+++ b/docs/source/modules/zos_unarchive.rst
@@ -39,7 +39,7 @@ src
 
   MVS data sets supported types are ``SEQ``, ``PDS``, ``PDSE``.
 
-  GDS relative names are supported ``e.g. USER.GDG(-1)``.
+  GDS relative names are supported. e.g. *USER.GDG(-1*).
 
   | **required**: True
   | **type**: str
@@ -151,7 +151,7 @@ owner
 include
   A list of directories, files or data set names to extract from the archive.
 
-  GDS relative names are supported ``e.g. USER.GDG(-1)``.
+  GDS relative names are supported. e.g. *USER.GDG(-1*).
 
   When ``include`` is set, only those files will we be extracted leaving the remaining files in the archive.
 
@@ -165,7 +165,7 @@ include
 exclude
   List the directory and file or data set names that you would like to exclude from the unarchive action.
 
-  GDS relative names are supported ``e.g. USER.GDG(-1)``.
+  GDS relative names are supported. e.g. *USER.GDG(-1*).
 
   Mutually exclusive with include.
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,75 +6,92 @@
 Releases
 ========
 
-Version 1.11.0-beta.1
-=====================
+Version 1.11.0
+==============
 
 Minor Changes
 -------------
 
-- ``zos_apf`` - Added support that auto-escapes 'library' names containing symbols.
-- ``zos_archive`` - Added support for GDG and GDS relative name notation to archive data sets. Added support for data set names with special characters like $, /#, /- and @.
-- ``zos_backup_restore`` - Added support for GDS relative name notation to include or exclude data sets when operation is backup. Added support for data set names with special characters like $, /#, and @.
-- ``zos_blockinfile`` - Added support for GDG and GDS relative name notation to specify a data set. And backup in new generations. Added support for data set names with special characters like $, /#, /- and @.
-- ``zos_copy`` - Added support for copying from and copying to generation data sets (GDS) and generation data groups (GDG) including using a GDS for backup.
-- ``zos_data_set`` - Added support for GDG and GDS relative name notation to create, delete, catalog and uncatalog a data set. Added support for data set names with special characters like $, /#, /- and @.
-- ``zos_encode`` - Added support for converting the encodings of generation data sets (GDS). Also added support to backup into GDS.
-- ``zos_fetch`` - Added support for fetching generation data groups (GDG) and generation data sets (GDS). Added support for specifying data set names with special characters like $, /#, /- and @.
-- ``zos_find`` - Added support for finding generation data groups (GDG) and generation data sets (GDS). Added support for specifying data set names with special characters like $, /#, /- and @.
+- ``zos_apf`` - Added support for data set names (libraries) with special characters ($, /#, /- and @).
+- ``zos_archive``
+
+   - Added support for GDG and GDS relative name notation to archive data sets.
+   - Added support for data set names with special characters ($, /#, /- and @).
+
+- ``zos_backup_restore``
+
+   - Added support for GDS relative name notation to include or exclude data sets when operation is backup.
+   - Added support for data set names with special characters ($, /#, /- and @).
+
+- ``zos_blockinfile``
+
+   - Added support for GDG and GDS relative name notation to specify a data set. And backup in new generations.
+   - Added support for data set names with special characters ($, /#, /- and @).
+
+- ``zos_copy``
+
+   - Added support for copying from and to generation data sets (GDS) and generation data groups (GDG) including using a GDS for backup.
+   - Added support for data set names with special characters ($, /#, /- and @).
+
+- ``zos_data_set``
+
+   - Added support for GDG and GDS relative name notation to create, delete, catalog and uncatalog a data set.
+   - Added support for data set names with special characters ($, /#, /- and @).
+
+- ``zos_encode``
+
+   - Added support for converting the encodings of generation data sets (GDS).
+   - Added support for data set names with special characters ($, /#, /- and @).
+
+- ``zos_fetch``
+
+   - Added support for fetching generation data groups (GDG) and generation data sets (GDS).
+   - Added support for data set names with special characters ($, /#, /- and @).
+
+- ``zos_find``
+
+   - Added support for finding generation data groups (GDG) and generation data sets (GDS).
+   - Added support for data set names with special characters ($, /#, /- and @).
+
 - ``zos_job_submit``
 
    - Improved the mechanism for copying to remote systems by removing the use of deepcopy, which had previously resulted in the module failing on some systems.
    - Added support for running JCL stored in generation data groups (GDG) and generation data sets (GDS).
+   - Added support for data set names with special characters ($, /#, /- and @).
 
-- ``zos_lineinfile`` - Added support for GDG and GDS relative name notation to specify the target data set and to backup into new generations. Added support for data set names with special characters like $, /#, /- and @.
+- ``zos_lineinfile``
+
+   - Added support for GDG and GDS relative name notation to specify the target data set and to backup into new generations.
+   - Added support for data set names with special characters ($, /#, /- and @).
+
 - ``zos_mount`` - Added support for data set names with special characters ($, /#, /- and @).
-- ``zos_mvs_raw`` - Added support for GDG and GDS relative name notation to specify data set names. Added support for data set names with special characters like $, /#, /- and @.
+- ``zos_mvs_raw``
+
+   - Added support for GDG and GDS relative name notation to specify data set names.
+   - Added support for data set names with special characters ($, /#, /- and @).
+
 - ``zos_script`` - Improved the mechanism for copying to remote systems by removing the use of deepcopy, which had previously resulted in the module failing on some systems.
-- ``zos_tso_command`` - Added support for using GDG and GDS relative name notation in running TSO commands. Added support for data set names with special characters like $, /#, /- and @.
+- ``zos_tso_command``
+
+   - Added support for using GDG and GDS relative name notation in running TSO commands.
+   - Added support for data set names with special characters ($, /#, /- and @).
+
 - ``zos_unarchive``
 
-   - Added support for data set names with special characters like $, /#, /- and @.
    - Improved the mechanism for copying to remote systems by removing the use of deepcopy, which had previously resulted in the module failing on some systems.
+   - Added support for data set names with special characters ($, /#, /- and @).
 
 Bugfixes
 --------
 
 - ``zos_copy``
 
-   - a regression in version 1.4.0 made the module stop automatically computing member names when copying a single file into a PDS/E. Fix now lets a user copy a single file into a PDS/E without adding a member in the dest option.
-   - module would use opercmd to check if a non existent destination data set is locked. Fix now only checks if the destination is already present.
+   - Fixes the issue that prevents the module from automatically computing member names when copying a file into a PDS/E. The module now computes the member name when copying into a PDS/E.
+   - Fixes an issue that would perform an unnecessary check if a destination data set is locked for data sets the module created. The module only performs this check for destinations that are present.
 
-- ``zos_data_set`` - When checking if a data set is cataloged, module failed to account for exceptions which occurred during the LISTCAT. The fix now raises an MVSCmdExecError if the return code from LISTCAT is too high.
-- ``zos_job_submit`` - The module was not propagating any error types including UnicodeDecodeError, JSONDecodeError, TypeError, KeyError when encountered. The fix now shares the type error in the error message.
-- ``zos_mvs_raw`` - The first character of each line in dd_output was missing. The fix now includes the first character of each line.
-
-Availability
-------------
-
-* `Galaxy`_
-* `GitHub`_
-
-Requirements
-------------
-
-The IBM z/OS core collection has several dependencies, please review the `z/OS core support matrix`_ to understand both the
-controller and z/OS managed node dependencies.
-
-Known Issues
-------------
-- ``zos_job_submit`` - when setting 'location' to 'local' and not specifying the from and to encoding, the modules defaults are not read leaving the file in its original encoding; explicitly set the encodings instead of relying on the default.
-- ``zos_job_submit`` - when submitting JCL, the response value returned for **byte_count** is incorrect.
-- ``zos_apf`` - When trying to remove a library that contains the '$' character in the name from APF(authorized program facility), operation will fail.
-- In the past, choices could be defined in either lower or upper case. Now, only the case that is identified in the docs can be set, this is so that the collection can continue to maintain certified status.
-
-
-Version 1.9.2
-=============
-
-Bugfixes
---------
-
-- ``zos_copy`` - when creating the destination data set, the module would unnecessarily check if a data set is locked by another process. The module no longer performs this check when it creates the data set.
+- ``zos_data_set`` - When checking if a data set is cataloged, module failed to account for exceptions which occurred during the LISTCAT. The module now raises an MVSCmdExecError if the return code from LISTCAT exceeds the determined threshold.
+- ``zos_job_submit`` - Was not propagating any error types including UnicodeDecodeError, JSONDecodeError, TypeError, KeyError when encountered. The module now shares the error type (UnicodeDecodeError, JSONDecodeError, TypeError, KeyError) in the error message.
+- ``zos_mvs_raw`` - The first character of each line in dd_output was missing. The module now includes the first character of each line.
 
 Availability
 ------------
@@ -87,28 +104,13 @@ Requirements
 ------------
 
 The IBM z/OS core collection has several dependencies, please review the `z/OS core support matrix`_ to understand both the
-controller and z/OS managed node dependencies.
+control node and z/OS managed node dependencies.
 
 Known Issues
 ------------
-
-- ``zos_job_submit`` - when setting 'location' to 'LOCAL' and not specifying the from and to encoding, the modules defaults are not read leaving the file in its original encoding; explicitly set the encodings instead of relying on the default.
+- ``zos_job_submit`` - when setting 'location' to 'local' and not specifying the from and to encoding, the modules defaults are not read leaving the file in its original encoding; explicitly set the encodings instead of relying on the default.
 - ``zos_job_submit`` - when submitting JCL, the response value returned for **byte_count** is incorrect.
-
-- ``zos_job_submit``, ``zos_job_output``, ``zos_operator_action_query`` - encounters UTF-8 decoding errors when interacting with results that contain non-printable UTF-8 characters in the response. This has been addressed in this release and corrected with **ZOAU version 1.2.5.6** or later.
-
-   - If the appropriate level of ZOAU can not be installed, some options are to:
-
-      - Specify that the ASA assembler option be enabled to instruct the assembler to use ANSI control characters instead of machine code control characters.
-      - Ignore module errors by using  **ignore_errors:true** for a specific playbook task.
-      - If the error is resulting from a batch job, add **ignore_errors:true** to the task and capture the output into a registered variable to extract the
-        job ID with a regular expression. Then use ``zos_job_output`` to display the DD without the non-printable character such as the DD **JESMSGLG**.
-      - If the error is the result of a batch job, set option **return_output** to false so that no DDs are read which could contain the non-printable UTF-8 characters.
-
-- ``zos_data_set`` - An undocumented option **size** was defined in module **zos_data_set**, this has been removed to satisfy collection certification, use the intended and documented **space_primary** option.
-
-- In the past, choices could be defined in either lower or upper case. Now, only the case that is identified in the docs can be set, this is so that the collection can continue to maintain certified status.
-
+- ``zos_apf`` - When trying to remove a library that contains the '$' character in the name from APF(authorized program facility), operation will fail.
 
 Version 1.10.0
 ==============
@@ -228,6 +230,46 @@ Known Issues
 - In the past, choices could be defined in either lower or upper case. Now, only the case that is identified in the docs can be set, this is so that the collection can continue to maintain certified status.
 - Use of special characters (#, @, $, \- ) in different options like data set names and commands is not fully supported, some modules support them but is the user responsibility to escape them. Read each module documentation for further details.
 
+Version 1.9.2
+=============
+
+Bugfixes
+--------
+
+- ``zos_copy`` - when creating the destination data set, the module would unnecessarily check if a data set is locked by another process. The module no longer performs this check when it creates the data set.
+
+Availability
+------------
+
+* `Automation Hub`_
+* `Galaxy`_
+* `GitHub`_
+
+Requirements
+------------
+
+The IBM z/OS core collection has several dependencies, please review the `z/OS core support matrix`_ to understand both the
+controller and z/OS managed node dependencies.
+
+Known Issues
+------------
+
+- ``zos_job_submit`` - when setting 'location' to 'LOCAL' and not specifying the from and to encoding, the modules defaults are not read leaving the file in its original encoding; explicitly set the encodings instead of relying on the default.
+- ``zos_job_submit`` - when submitting JCL, the response value returned for **byte_count** is incorrect.
+
+- ``zos_job_submit``, ``zos_job_output``, ``zos_operator_action_query`` - encounters UTF-8 decoding errors when interacting with results that contain non-printable UTF-8 characters in the response. This has been addressed in this release and corrected with **ZOAU version 1.2.5.6** or later.
+
+   - If the appropriate level of ZOAU can not be installed, some options are to:
+
+      - Specify that the ASA assembler option be enabled to instruct the assembler to use ANSI control characters instead of machine code control characters.
+      - Ignore module errors by using  **ignore_errors:true** for a specific playbook task.
+      - If the error is resulting from a batch job, add **ignore_errors:true** to the task and capture the output into a registered variable to extract the
+        job ID with a regular expression. Then use ``zos_job_output`` to display the DD without the non-printable character such as the DD **JESMSGLG**.
+      - If the error is the result of a batch job, set option **return_output** to false so that no DDs are read which could contain the non-printable UTF-8 characters.
+
+- ``zos_data_set`` - An undocumented option **size** was defined in module **zos_data_set**, this has been removed to satisfy collection certification, use the intended and documented **space_primary** option.
+
+- In the past, choices could be defined in either lower or upper case. Now, only the case that is identified in the docs can be set, this is so that the collection can continue to maintain certified status.
 
 Version 1.9.1
 =============

--- a/docs/source/resources/releases_maintenance.rst
+++ b/docs/source/resources/releases_maintenance.rst
@@ -89,7 +89,7 @@ The z/OS managed node includes several shells, currently the only supported shel
 +---------+----------------------------+---------------------------------------------------+---------------+---------------+
 | Version | Controller                 | Managed Node                                      | GA            | End of Life   |
 +=========+============================+===================================================+===============+===============+
-| 1.11.x  |- `ansible-core`_ >=2.15.x  |- `z/OS`_ V2R4 - V3Rx                              | In preview    | TBD           |
+| 1.11.x  |- `ansible-core`_ >=2.15.x  |- `z/OS`_ V2R4 - V2Rx                              | 1 Oct 2024    | 1 Oct 2026    |
 |         |- `Ansible`_ >=8.0.x        |- `z/OS shell`_                                    |               |               |
 |         |- `AAP`_ >=2.4              |- IBM `Open Enterprise SDK for Python`_            |               |               |
 |         |                            |- IBM `Z Open Automation Utilities`_ >=1.3.1       |               |               |

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -6,7 +6,7 @@ namespace: ibm
 name: ibm_zos_core
 
 # The collection version
-version: "1.11.0-beta.1"
+version: "1.11.0"
 
 # Collection README file
 readme: README.md
@@ -18,7 +18,6 @@ authors:
   - Ketan Kelkar <ketan.kelkar@ibm.com>
   - Ivan Moreno <ivan.moreno.soto@ibm.com>
   - Oscar Fernando Flores Garcia <fernando.flores@ibm.com>
-  - Jenny Huang <jennyhuang@ibm.com>
   - Marcel Gutierrez <andre.marcel.gutierrez@ibm.com>
 
 # Description
@@ -98,3 +97,5 @@ build_ignore:
   - tests/sanity/ignore-2.13.txt
   - tests/sanity/ignore-2.14.txt
   - venv*
+  - ansible_collections
+  - '*.log'

--- a/meta/ibm_zos_core_meta.yml
+++ b/meta/ibm_zos_core_meta.yml
@@ -1,9 +1,9 @@
 name: ibm_zos_core
-version: "1.11.0-beta.1"
+version: "1.11.0"
 managed_requirements:
     -
         name: "IBM Open Enterprise SDK for Python"
-        version: ">=3.10"
+        version: ">=3.11"
     -
         name: "Z Open Automation Utilities"
         version:

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -39,7 +39,7 @@ options:
         PS (sequential data set), member of a PDS or PDSE, PDS, PDSE.
       - The USS file must be an absolute pathname.
       - Generation data set (GDS) relative name of generation already
-        created.  ``e.g. SOME.CREATION(-1).``
+        created. e.g. I(SOME.CREATION(-1)).
     type: str
     aliases: [ path, destfile, name ]
     required: true

--- a/plugins/modules/zos_lineinfile.py
+++ b/plugins/modules/zos_lineinfile.py
@@ -37,7 +37,7 @@ options:
         PS (sequential data set), member of a PDS or PDSE, PDS, PDSE.
       - The USS file must be an absolute pathname.
       - Generation data set (GDS) relative name of generation already
-        created. ``e.g. SOME.CREATION(-1).``
+        created. e.g. I(SOME.CREATION(-1)).
     type: str
     aliases: [ path, destfile, name ]
     required: true

--- a/plugins/modules/zos_unarchive.py
+++ b/plugins/modules/zos_unarchive.py
@@ -36,7 +36,7 @@ options:
       - I(src) can be a USS file or MVS data set name.
       - USS file paths should be absolute paths.
       - MVS data sets supported types are C(SEQ), C(PDS), C(PDSE).
-      - GDS relative names are supported ``e.g. USER.GDG(-1)``.
+      - GDS relative names are supported. e.g. I(USER.GDG(-1)).
     type: str
     required: true
   format:
@@ -146,7 +146,7 @@ options:
     description:
       - A list of directories, files or data set names to extract from the
         archive.
-      - GDS relative names are supported ``e.g. USER.GDG(-1)``.
+      - GDS relative names are supported. e.g. I(USER.GDG(-1)).
       - When C(include) is set, only those files will we be extracted leaving
         the remaining files in the archive.
       - Mutually exclusive with exclude.
@@ -157,7 +157,7 @@ options:
     description:
       - List the directory and file or data set names that you would like to
         exclude from the unarchive action.
-      - GDS relative names are supported ``e.g. USER.GDG(-1)``.
+      - GDS relative names are supported. e.g. I(USER.GDG(-1)).
       - Mutually exclusive with include.
     type: list
     elements: str

--- a/tests/functional/modules/test_zos_encode_func.py
+++ b/tests/functional/modules/test_zos_encode_func.py
@@ -1125,7 +1125,7 @@ def test_gdg_encoding_conversion_invalid_gdg(ansible_zos_module):
 
         for result in results.contacted.values():
             assert result.get("msg") is not None
-            assert "Encoding of a whole generation data group is not supported." in result.get("msg")
+            assert "not supported" in result.get("msg")
             assert result.get("backup_name") is None
             assert result.get("changed") is False
             assert result.get("failed") is True

--- a/tests/functional/modules/test_zos_encode_func.py
+++ b/tests/functional/modules/test_zos_encode_func.py
@@ -1125,7 +1125,7 @@ def test_gdg_encoding_conversion_invalid_gdg(ansible_zos_module):
 
         for result in results.contacted.values():
             assert result.get("msg") is not None
-            assert "not supported" in result.get("msg")
+            assert "Encoding of a whole generation data group is not supported." in result.get("msg")
             assert result.get("backup_name") is None
             assert result.get("changed") is False
             assert result.get("failed") is True


### PR DESCRIPTION
This is the last remaining task from the release task #1621 where I have cherry picked the the commit tagged into main so that I can merge those changes back into `dev`. 

* Fixed zos_copy
* Fixed encode test case
* update version and remove author
* Python is EOS 9-30, updated meta
* Update README with new links and cleanup
* Update GA dates
* Update module docs with auto generations
* Add changelog summary
* Changelog updates
* remove stale changelog files
* update galaxy exclusions
* update release notes for 1.11.0
* Remove unused imports from action plugin
* Corrections for flake8
* Updated example to not escape the paren
* Update module doc to correct use of monospace
* Corretions to release notes
* Corrections

