### PR TITLE
Correct zos_copy handling of a zoauresponse during opercmd usage for locked data sets.

### DIFF
--- a/ac
+++ b/ac
@@ -684,6 +684,7 @@ ac_test(){
 	    message_error "Unable to find test configration in ${VENV}/config.yml."
 	fi
 
+    # TODO: Consider adding the -vvvv like so `$CURR_DIR/${file}  -vvvv --ignore="${skip}"` so that you can access the verbosity feature of pytest.
     if [ "$file" ]; then
         . ${VENV_BIN}/activate && export ANSIBLE_LIBRARY=$VENV/ansible_collections/ibm/ibm_zos_core/plugins/modules;export ANSIBLE_CONFIG=$VENV/ansible.cfg;${VENV_BIN}/pytest $CURR_DIR/${file} --ignore="${skip}" --host-pattern=all --zinventory=${VENV}/config.yml ${debug} >&2 ; echo $? >&1
     else

--- a/changelogs/fragments/1744-zos_copy-racf-uacc-updates.yml
+++ b/changelogs/fragments/1744-zos_copy-racf-uacc-updates.yml
@@ -1,0 +1,12 @@
+bugfixes:
+  - zos_copy - Improve module zos_copy error handling when the user does not have
+    universal access authority set to UACC(READ) for SAF Profile
+    'MVS.MCSOPER.ZOAU' and SAF Class OPERCMDS. The module now handles the exception
+    and returns an informative message.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1744).
+trivial:
+  - pipeline - Deliver a new users.py framework that allows functional test cases to
+    request a managed user type where this user can have limited access to some SAF
+    profile, or saf class as well as user id's with specific patterns such as including
+    supported special characters such as '@', '#', etc.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1744).

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3141,13 +3141,19 @@ def data_set_locked(dataset_name):
 
     Parameters
     ----------
-    dataset_name : str
+    dataset_name (str):
         The data set name used to check if there is a lock.
 
     Returns
     -------
     bool
         True if the data set is locked, or False if the data set is not locked.
+
+    Raises
+    ------
+    CopyOperationError
+        When the user does not have Universal Access Authority to
+        ZOAU SAF Profile 'MVS.MCSOPER.ZOAU' and SAF Class OPERCMDS.
     """
     # Using operator command "D GRS,RES=(*,{dataset_name})" to detect if a data set
     # is in use, when a data set is in use it will have "EXC/SHR and SHARE"

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3204,7 +3204,7 @@ def data_set_locked(dataset_name):
                 rc=copy_exception.response.rc,
                 stdout=copy_exception.response.stdout_response,
                 stderr=copy_exception.response.stderr_response
-            )
+        )
 
 
 def run_module(module, arg_def):

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3164,14 +3164,14 @@ def data_set_locked(dataset_name):
             for out in stdout.split("\n"):
                 if out:
                     result["stdout"].append(out)
-
+        #raise CopyOperationError(msg=f"Unable to determine if the dest {stdout}")
         if len(result["stdout"]) <= 4 and "NO REQUESTORS FOR RESOURCE" in stdout:
             return False
 
         return True
     except zoau_exceptions.ZOAUException as copy_exception:
         raise CopyOperationError(
-            msg="Unable to determine if the source {0} is in use.".format(dataset_name),
+            msg="Unable to determine if the dest {0} is in use.".format(dataset_name),
                 rc=copy_exception.response.rc,
                 stdout=copy_exception.response.stdout_response,
                 stderr=copy_exception.response.stderr_response

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3194,7 +3194,6 @@ def data_set_locked(dataset_name):
             for out in stdout.split("\n"):
                 if out:
                     result["stdout"].append(out)
-        #raise CopyOperationError(msg=f"Unable to determine if the dest {stdout}")
         if len(result["stdout"]) <= 4 and "NO REQUESTORS FOR RESOURCE" in stdout:
             return False
 

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2103,8 +2103,16 @@ def copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lo
     # Update fixture with the new user
     hosts["options"]["user"] = user
 
-
     print(f"\nNew managed user created = {user}")
+
+    who = hosts.all.shell(cmd="whoami")
+    for person in who.contacted.values():
+        print(f"Who am I = {person.get("stdout")}")
+
+    who = hosts.all.shell(cmd="opercmd 'd t'")
+    for person in who.contacted.values():
+        print(f"Who am I = {person.get("stdout")}")
+
     data_set_1 = get_tmp_ds_name()
     data_set_2 = get_tmp_ds_name()
     member_1 = "MEM1"

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2104,7 +2104,7 @@ def copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lo
     hosts["options"]["user"] = user
 
 
-    print(f"\nNew managed user created = {hosts["options"]["user"] }")
+    print(f"\nNew managed user created = {user}")
     data_set_1 = get_tmp_ds_name()
     data_set_2 = get_tmp_ds_name()
     member_1 = "MEM1"

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2084,7 +2084,8 @@ def test_demo_how_to_use_managed_user(ansible_zos_module):
 
         finally:
             # Delete the managed user on the remote host to avoid proliferation of users.
-            managed_user.delete_managed_user()
+            # managed_user.delete_managed_user()
+            print("END")
 
 def test_copy_dest_lock_test_with_no_opercmd_access_pds_without_force_lock(ansible_zos_module):
     """

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -13,7 +13,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from gh.ibm_zos_core.tests.helpers.users import ManagedUsers
+from ibm_zos_core.tests.helpers.users import ManagedUsers
 import pytest
 import os
 import shutil
@@ -21,6 +21,7 @@ import re
 import time
 import tempfile
 import subprocess
+from ibm_zos_core.tests.helpers.users import *
 
 from ibm_zos_core.tests.helpers.volumes import Volume_Handler
 from ibm_zos_core.tests.helpers.dataset import get_tmp_ds_name
@@ -2010,7 +2011,7 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
         )
         for result in results.contacted.values():
             print(result)
-            if f_lock and apf_auth_user:
+            if f_lock: #and apf_auth_user:
                 assert result.get("changed") == True
                 assert result.get("msg") is None
                 # verify that the content is the same
@@ -2045,18 +2046,19 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
         hosts.all.zos_data_set(name=data_set_2, state="absent")
 
 
-# @pytest.mark.seq
-# @pytest.mark.parametrize("ds_type, f_lock, managed_user",[
-#     ( "pds", False, ManagedUsers.zoau_limited_access_opercmd),  # Module exeception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name),
-#     ( "pdse", False, None), # Module exits with: Unable to write to dest '{0}' because a task is accessing the data set."
-#     ( "seq", False, None),  # Module exits with: Unable to write to dest '{0}' because a task is accessing the data set."
-# ])
-# def test_copy_dest_lock_test_apf_authorization_2(ansible_zos_module, ds_type, f_lock, managed_user ):
-#     hosts = ansible_zos_module
-#     # Request a user not be apf authorized for opercmd
-#     if managed_user:
-#         #x =call users.py , eg users.get_user(managed_user)
-#          hosts["options"]["user"] = x
+@pytest.mark.seq
+@pytest.mark.parametrize("ds_type, f_lock, managed_user",[
+    ( "pds", False, ManagedUsers.ZOAU_LIMITED_ACCESS_OPERCMD),  # Module exeception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name),
+    ( "pdse", False, None), # Module exits with: Unable to write to dest '{0}' because a task is accessing the data set."
+    ( "seq", False, None),  # Module exits with: Unable to write to dest '{0}' because a task is accessing the data set."
+])
+def test_copy_dest_lock_test_apf_authorization_2(ansible_zos_module, ds_type, f_lock, managed_user ):
+    hosts = ansible_zos_module
+    # Request a user not be apf authorized for opercmd
+    if managed_user:
+        #x =call users.py , eg users.get_user(managed_user)
+        hosts["options"]["user"] = "omvsadm"
+        get_managed_user_name(hosts, managed_user)
 
 @pytest.mark.seq
 @pytest.mark.parametrize("ds_type, f_lock, apf_auth_user",[

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -13,6 +13,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from gh.ibm_zos_core.tests.helpers.users import ManagedUsers
 import pytest
 import os
 import shutil
@@ -2043,6 +2044,19 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
         hosts.all.zos_data_set(name=data_set_1, state="absent")
         hosts.all.zos_data_set(name=data_set_2, state="absent")
 
+
+# @pytest.mark.seq
+# @pytest.mark.parametrize("ds_type, f_lock, managed_user",[
+#     ( "pds", False, ManagedUsers.zoau_limited_access_opercmd),  # Module exeception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name),
+#     ( "pdse", False, None), # Module exits with: Unable to write to dest '{0}' because a task is accessing the data set."
+#     ( "seq", False, None),  # Module exits with: Unable to write to dest '{0}' because a task is accessing the data set."
+# ])
+# def test_copy_dest_lock_test_apf_authorization_2(ansible_zos_module, ds_type, f_lock, managed_user ):
+#     hosts = ansible_zos_module
+#     # Request a user not be apf authorized for opercmd
+#     if managed_user:
+#         #x =call users.py , eg users.get_user(managed_user)
+#          hosts["options"]["user"] = x
 
 @pytest.mark.seq
 @pytest.mark.parametrize("ds_type, f_lock, apf_auth_user",[

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2134,7 +2134,7 @@ def copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lo
         # submit jcl
         hosts.all.shell(cmd="submit call_c_pgm.jcl", chdir=f"{temp_dir}/")
         # pause to ensure c code acquires lock
-        time.sleep(5)
+        time.sleep(10)
         results = hosts.all.zos_copy(
             src = src_data_set,
             dest = dest_data_set,
@@ -2166,7 +2166,7 @@ def copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lo
                 assert result.get("rc") == 6
     finally:
         # Delete the managed user on the remote host to avoid proliferation of users.
-        managed_user.delete_managed_user()
+        #managed_user.delete_managed_user()
         # extract pid
         ps_list_res = hosts.all.shell(cmd="ps -e | grep -i 'pdse-lock'")
         # kill process - release lock - this also seems to end the job

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2070,6 +2070,9 @@ def test_demo_how_to_use_managed_user(ansible_zos_module):
 
             # Update the pytest fixture (hosts) with the newly created managed user, important step.
             hosts["options"]["user"] = user
+            # hosts["options"]["ansible_ssh_private_key_file"] = f"/tmp/{user}/id_ed25519"
+            # import pprint
+            # pprint.pprint(vars(hosts))
 
             # Perform operations as usual.
             who = hosts.all.shell(cmd="whoami")
@@ -2081,6 +2084,11 @@ def test_demo_how_to_use_managed_user(ansible_zos_module):
             for person in who.contacted.values():
                 val = person.get("stdout")
                 print(f"opercmd output = {val}")
+
+            who = hosts.all.shell(cmd="cat ~/.ssh/config")
+            for person in who.contacted.values():
+                val = person.get("stdout")
+                print(f"config out = {val}")
 
         finally:
             # Delete the managed user on the remote host to avoid proliferation of users.

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2148,11 +2148,13 @@ def copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lo
     # Perform operations as usual.
     who = hosts.all.shell(cmd="whoami")
     for person in who.contacted.values():
-        print(f"Who am I = {person.get("stdout")}")
+        val = person.get("stdout")
+        print(f"Who am I = {val}")
 
     who = hosts.all.shell(cmd="opercmd 'd t'")
     for person in who.contacted.values():
-        print(f"opercmd output = {person.get("stdout")}")
+        person.get("stdout")
+        print(f"opercmd output = {val}")
 
     data_set_1 = get_tmp_ds_name()
     data_set_2 = get_tmp_ds_name()

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2069,7 +2069,7 @@ def test_demo_how_to_use_managed_user(ansible_zos_module):
             print(f"New managed password created = {passwd}")
 
             # Update the pytest fixture (hosts) with the newly created managed user, important step.
-            hosts["options"]["user"] = user
+            hosts["options"]["user"] = remote_user
 
             # Perform operations as usual.
             who = hosts.all.shell(cmd="whoami")

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -13,7 +13,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from ibm_zos_core.tests.helpers.users import ManagedUserType
+from ibm_zos_core.tests.helpers.users import ManagedUserType, ManagedUser
 import pytest
 import os
 import shutil
@@ -21,7 +21,6 @@ import re
 import time
 import tempfile
 import subprocess
-from ibm_zos_core.tests.helpers.users import *
 
 from ibm_zos_core.tests.helpers.volumes import Volume_Handler
 from ibm_zos_core.tests.helpers.dataset import get_tmp_ds_name
@@ -367,6 +366,7 @@ def link_loadlib_from_cobol(hosts, cobol_src_pds, cobol_src_mem, loadlib_pds, lo
             wait_time_s=60
         )
         for result in job_result.contacted.values():
+            print(result)
             rc = result.get("jobs")[0].get("ret_code").get("code")
     finally:
         hosts.all.file(path=temp_jcl_uss_path, state="absent")
@@ -2048,28 +2048,28 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
 
 def test_copy_dest_lock_test_with_no_opercmd_access_pds_without_force_lock(ansible_zos_module):
     """
-    Module exeception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name)
-    Because this rely's on a managedUser, the test should not be parametized.
+    This tests the module exeception raised 'msg="Unable to determine if the source {0} is in use.".format(dataset_name)'. 
+    This this a wrapper for the actual test case `managed_user_copy_dest_lock_test_with_no_opercmd_access`.
     """
     managed_user = None
-
+    managed_user_test_case_name = "managed_user_copy_dest_lock_test_with_no_opercmd_access"
     try:
         # Initialize the Managed user API from the pytest fixture.
         managed_user = ManagedUser.from_fixture(ansible_zos_module)
 
         # Important: Execute the test case with the managed users execution utility.
         managed_user.execute_managed_user_test(
-            managed_user_test_case = "managed_user_copy_dest_lock_test_with_no_opercmd_access",
-            debug = True, verbose = False, managed_user_type=ManagedUserType.ZOAU_LIMITED_ACCESS_OPERCMD)
+            managed_user_test_case = managed_user_test_case_name,debug = True,
+            verbose = False, managed_user_type=ManagedUserType.ZOAU_LIMITED_ACCESS_OPERCMD)
 
     finally:
         # Delete the managed user on the remote host to avoid proliferation of users.
         managed_user.delete_managed_user()
 
 @pytest.mark.parametrize("ds_type, f_lock",[
-    ( "pds", False),    # Module exeception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name)
-    ( "pdse", False),   # Module exeception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name)
-    ( "seq", False),    # Module exeception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name)
+    ( "pds", False),    # Module exception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name)
+    ( "pdse", False),   # Module exception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name)
+    ( "seq", False),    # Module exception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name)
     ( "seq", True),     # Opercmd is not called so a user with limited UACC will not matter and will succeed
 ])
 def managed_user_copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lock ):

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2069,7 +2069,7 @@ def test_demo_how_to_use_managed_user(ansible_zos_module):
             print(f"New managed password created = {passwd}")
 
             # Update the pytest fixture (hosts) with the newly created managed user, important step.
-            hosts["options"]["user"] = remote_user
+            hosts["options"]["user"] = user
 
             # Perform operations as usual.
             who = hosts.all.shell(cmd="whoami")

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2074,11 +2074,13 @@ def test_demo_how_to_use_managed_user(ansible_zos_module):
             # Perform operations as usual.
             who = hosts.all.shell(cmd="whoami")
             for person in who.contacted.values():
-                print(f"Who am I = {person.get("stdout")}")
+                val = person.get("stdout")
+                print(f"Who am I = {val}")
 
             who = hosts.all.shell(cmd="opercmd 'd t'")
             for person in who.contacted.values():
-                print(f"opercmd output = {person.get("stdout")}")
+                val = person.get("stdout")
+                print(f"opercmd output = {val}")
 
         finally:
             # Delete the managed user on the remote host to avoid proliferation of users.

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2097,10 +2097,14 @@ def copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lo
     if managed_user_type:
         managed_user = ManagedUser(remote_user, remote_host)
         user, passwd = managed_user.create_managed_user(managed_user_type)
+        print(f"\nNew managed user created = {user}")
+        print(f"New managed password created = {passwd}")
 
     # Update fixture with the new user
     hosts["options"]["user"] = user
 
+
+    print(f"\nNew managed user created = {hosts["options"]["user"] }")
     data_set_1 = get_tmp_ds_name()
     data_set_2 = get_tmp_ds_name()
     member_1 = "MEM1"
@@ -2161,8 +2165,6 @@ def copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lo
                 assert "BGYSC0819E Insufficient security authorization for resource MVS.MCSOPER.ZOAU in class OPERCMDS" in result.get("stderr")
                 assert result.get("rc") == 6
     finally:
-        # When the operations are complete reset the user back to the remote_user who has authority to create users.
-        hosts["options"]["user"] = remote_user
         # Delete the managed user on the remote host to avoid proliferation of users.
         managed_user.delete_managed_user()
         # extract pid

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2074,7 +2074,7 @@ def test_copy_dest_lock_test_with_no_opercmd_access_pds_without_force_lock(ansib
 ])
 def managed_user_copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lock ):
     """
-    When force_lock option is false, it exercies the opercmd call which requres RACF universal access.
+    When force_lock option is false, it exercises the opercmd call which requires RACF universal access.
     This negative test will ensure that if the user does not have RACF universal access that the module
     not halt execution and instead bubble up the ZOAU exception.
     """

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2046,55 +2046,6 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
         hosts.all.zos_data_set(name=data_set_2, state="absent")
 
 
-def test_demo_how_to_use_managed_user(ansible_zos_module):
-        # Request a user who has no authority to execute zoau opercmd
-        hosts = ansible_zos_module
-        managed_user, user, passwd = None, None, None
-
-        # Managed user type requested, requesting a z/OS user with no opercmd access
-        managed_user_type = ManagedUserType.ZOAU_LIMITED_ACCESS_OPERCMD
-
-        try:
-
-            # Instance of the ManagedUser initialized with a user who has authority to create users and the remote host.
-            remote_host = hosts["options"]["inventory"].replace(",", "")
-            remote_user = hosts["options"]["user"]
-
-            # Initialize the Managed user API
-            managed_user = ManagedUser(remote_user, remote_host)
-            # Pass the managed user type needed, there are several types.
-            user, passwd = managed_user.create_managed_user(managed_user_type)
-            # Print the results.
-            print(f"\nNew managed user created = {user}")
-            print(f"New managed password created = {passwd}")
-
-            # Update the pytest fixture (hosts) with the newly created managed user, important step.
-            hosts["options"]["user"] = user
-            # hosts["options"]["ansible_ssh_private_key_file"] = f"/tmp/{user}/id_ed25519"
-            # import pprint
-            # pprint.pprint(vars(hosts))
-
-            # Perform operations as usual.
-            who = hosts.all.shell(cmd="whoami")
-            for person in who.contacted.values():
-                val = person.get("stdout")
-                print(f"Who am I = {val}")
-
-            who = hosts.all.shell(cmd="opercmd 'd t'")
-            for person in who.contacted.values():
-                val = person.get("stdout")
-                print(f"opercmd output = {val}")
-
-            who = hosts.all.shell(cmd="cat ~/.ssh/config")
-            for person in who.contacted.values():
-                val = person.get("stdout")
-                print(f"config out = {val}")
-
-        finally:
-            # Delete the managed user on the remote host to avoid proliferation of users.
-            # managed_user.delete_managed_user()
-            print("END")
-
 def test_copy_dest_lock_test_with_no_opercmd_access_pds_without_force_lock(ansible_zos_module):
     """
     Module exeception raised msg="Unable to determine if the source {0} is in use.".format(dataset_name)
@@ -2146,24 +2097,12 @@ def copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lo
     if managed_user_type:
         managed_user = ManagedUser(remote_user, remote_host)
         user, passwd = managed_user.create_managed_user(managed_user_type)
-        print(f"\nNew managed user created = {user}")
-        print(f"New managed password created = {passwd}")
+        # print(f"\nNew managed user created = {user}")
+        # print(f"New managed password created = {passwd}")
 
     # Update fixture with the new user
     hosts["options"]["user"] = user
-
     print(f"\nNew managed user created = {user}")
-
-    # Perform operations as usual.
-    who = hosts.all.shell(cmd="whoami")
-    for person in who.contacted.values():
-        val = person.get("stdout")
-        print(f"Who am I = {val}")
-
-    who = hosts.all.shell(cmd="opercmd 'd t'")
-    for person in who.contacted.values():
-        person.get("stdout")
-        print(f"opercmd output = {val}")
 
     data_set_1 = get_tmp_ds_name()
     data_set_2 = get_tmp_ds_name()
@@ -2226,7 +2165,7 @@ def copy_dest_lock_test_with_no_opercmd_access(ansible_zos_module, ds_type, f_lo
                 assert result.get("rc") == 6
     finally:
         # Delete the managed user on the remote host to avoid proliferation of users.
-        #managed_user.delete_managed_user()
+        managed_user.delete_managed_user()
         # extract pid
         ps_list_res = hosts.all.shell(cmd="ps -e | grep -i 'pdse-lock'")
         # kill process - release lock - this also seems to end the job

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -567,10 +567,6 @@ class ManagedUser:
         cmd=f"{command.getvalue()}"
         results_stdout_lines = self._connect(self._remote_host, self._model_user,cmd)
 
-        # Shared error message and details.
-        err_details = ""
-        err_msg = f"Unable to {err_details} for managed user [{managed_racf_user}, review output {results_stdout_lines}."
-
         try:
             # Evaluate the results
             rdefine_rc = [v for v in results_stdout_lines if f"RDEFINE RC=" in v][0].split('=')[1].strip() or None

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -16,37 +16,279 @@ The helpers/users.py file contains various utility functions that
 will support test case user needs. Such cases could be randomly
 generated users with specific limitations or users with UID 0.
 """
-
 from collections import OrderedDict
+from io import StringIO
 from enum import Enum
-import json
-from __future__ import annotations
-from typing import Annotated
+import random
+import string
+
+
+def get_random_passwd():
+    letters = string.ascii_uppercase
+    return ''.join(random.choice(letters) for i in range(8))
+
+def get_random_user():
+    letters = string.ascii_uppercase
+    suffix = ''.join(random.choice(letters) for i in range(4))
+    return "ANSI" + suffix
+
 
 class ManagedUsers (Enum):
-    zoau_limited_access_opercmd=("zoau_limited_access_opercmd")
     """
+    Represents the z/OS users available for functional testing.
+
+    Attributes:
+    ZOAU_LIMITED_ACCESS_OPERCMD: ManagedUsers
+        A z/OS managed user with restricted access to ZOAU
+        SAF Profile 'MVS.MCSOPER.ZOAU' and SAF Class OPERCMDS
+        with universal access authority set to UACC(NONE). With
+        UACC as NONE, this user will be refused access to the
+        ZOAU opercmd utility.
+    ZOS_LIMITED_HLQ: ManagedUsers
+        A z/OS managed user with restricted access to High Level
+        Qualifiers (HLQ): (RESTRICT, NOPERMIT, ....).
+    ZOS_LIMITED_TMP_HLQ: ManagedUsers
+        A z/OS managed user with restricted access to temporary
+        High Level Qualifiers (HLQ): (TSTRICT, TNOPERM, ....).
+
+    Methods:
+        user_access() - Returns the user access requested.
+        user_name() - Returns the user name to be used in the functional test.
+        is_equal(user_name) - Checks if this user name is equal to user name.
+    """
+
+    ZOAU_LIMITED_ACCESS_OPERCMD=("zoau_limited_access_opercmd")
+    """
+    user_access:user_name
     A z/OS managed user with restricted access to ZOAU
-    SAF Profile 'MVS..MCSOPER.ZOAU' and SAF Class OPERCMDS
+    SAF Profile 'MVS.MCSOPER.ZOAU' and SAF Class OPERCMDS
     with universal access authority set to UACC(NONE). With
     UACC as NONE, this user will be refused access to the
     ZOAU opercmd utility.
     """
-    zos_limited_hlq=("zos_limited_hlq")
+    ZOS_LIMITED_HLQ=("zos_limited_hlq","ANSUSR02")
     """
     A z/OS managed user with restricted access to High Level
     Qualifiers (HLQ): (RESTRICT, NOPERMIT, ....).
     """
 
-    zos_limited_tmp_hlq=("zos_limited_tmp_hlq")
+    ZOS_LIMITED_TMP_HLQ=("zos_limited_tmp_hlq", "ANSUSR03")
     """
     A z/OS managed user with restricted access to temporary
     High Level Qualifiers (HLQ): (TSTRICT, TNOPERM, ....).
     """
 
+    def __str__(self) -> str:
+        """
+        Convert the name of the project to uppercase when converting it to a string.
+
+        Return:
+            str: The lowercase name of the project.
+        """
+        return self.name.upper()
+
+    def string(self) -> str:
+        """
+        Returns the string value contained in the tuple.
+        'online' for ONLINE and 'offline' for OFFLINE.
+
+        Return:
+            str: The string value contained in the tuple.
+                'online' for ONLINE and 'offline' for OFFLINE.
+        """
+        return self.value.upper()
+
+
+def get_managed_user_name(ansible_zos_module, managed_user: ManagedUsers) -> str:
+
+    # TODO: Check if user exists and retry? Given this a randomly generated user, we can pass on this
+    # until it becomes an issue to reduce the compute. 
+    user = get_random_user()
+
+    # Generate the password to establish an password-less connection and use with RACF.
+    passwd = get_random_passwd()
+
+    # An existing user (model) will be used to access system specific values used to create a new user
+    model_user = ansible_zos_module["options"]["user"]
+
+    results_tso_noracf = ansible_zos_module.all.shell(
+            cmd=f"tsocmd LISTUSER {model_user} TSO NORACF"
+    )
+
+    # Extract the model user TSO entries for reuse in a new user
+    model_listuser_tso_attributes = list(results_tso_noracf.contacted.values())[0].get("stdout_lines")
+
+    # Match the tso list results and place in variables (not all are used)
+    model_tso_acctnum = [v for v in model_listuser_tso_attributes if "ACCTNUM" in v][0].split('=')[1].strip() or ""
+    model_tso_proc = [v for v in model_listuser_tso_attributes if "PROC" in v][0].split('=')[1].strip() or ""
+    model_tso_size = [v for v in model_listuser_tso_attributes if "SIZE" in v][0].split('=')[1].strip() or ""
+    model_tso_maxsize = [v for v in model_listuser_tso_attributes if "MAXSIZE" in v][0].split('=')[1].strip() or ""
+    model_tso_unit = [v for v in model_listuser_tso_attributes if "UNIT" in v][0].split('=')[1].strip() or ""
+    model_tso_userdata = [v for v in model_listuser_tso_attributes if "USERDATA" in v][0].split('=')[1].strip() or ""
+    model_tso_command = [v for v in model_listuser_tso_attributes if "COMMAND" in v][0].split('=')[1].strip() or ""
+
+    # Print the matches for validation
+    print(f"model_tso_acctnum: [{model_tso_acctnum}]")
+    print(f"model_tso_proc: [{model_tso_proc}]")
+    print(f"model_tso_size: [{model_tso_size}]")
+    print(f"model_tso_maxsize: [{model_tso_maxsize}]")
+    print(f"model_tso_unit: [{model_tso_unit}]")
+    print(f"model_tso_userdata: [{model_tso_userdata}]")
+    print(f"model_tso_command: [{model_tso_command}]")
+
+    results_listuser = ansible_zos_module.all.shell(
+            cmd=f"tsocmd LISTUSER {model_user}"
+    )
+
+    # Extract the model user TSO entries for reuse in a new user
+    model_listuser_attributes = list(results_listuser.contacted.values())[0].get("stdout_lines")
+
+    # Match the list user results and place in variables (not all are used)
+    model_owner = [v for v in model_listuser_attributes if "OWNER" in v][0].split('OWNER=')[1].split()[0].strip() or ""
+
+    print(f"model_owner: [{model_owner}]")
+
+    add_user_cmd = StringIO()
+
+    # Construct a shell command consisting of shell and tso operations to create a user.
+    # -------------------------------------------------------------------------
+    # (1) Create group ANSIGRP for general identification of users and auto assign the UID
+    #     General success of the command yields:
+    #       tsocmd "ADDGROUP ANSIGRP OMVS(AUTOGID)"
+    #       ADDGROUP ANSIGRP OMVS(AUTOGID)
+    #       Group ANSIGRP was assigned an OMVS GID value of 4.``
+    #     If the group exists, it will error but will change or matter, in the future we can advance this snippet.
+    #       tsocmd "ADDGROUP ANSIGRP OMVS(AUTOGID)"
+    #       ADDGROUP ANSIGRP OMVS(AUTOGID)
+    #       INVALID GROUP, ANSIGRP
+    # -------------------------------------------------------------------------
+    user_group = "ANSIGRP"
+    add_user_cmd.write(f"tsocmd 'ADDGROUP {user_group} OMVS(AUTOGID)';")
+    add_user_cmd.write(f"echo Create {user_group} RC=$?;")
+
+    # -------------------------------------------------------------------------
+    # (2) Create/add the user to be owned by the model_owner
+    #     Expect a similar error (below) because when a new TSO userid is defined,
+    #     that id can not receive deferred messages until the id is defined in
+    #     SYS1.BRODCAST and thus the SEND message fails to that user id.
+    #       BROADCAST DATA SET NOT USABLE+
+    #       I/O SYNAD ERROR
+    #     # tsocmd "ADDUSER FOOBAR DFLTGRP(ANSIGRP) OWNER(RACF000) PASSWORD(BOOBAR) TSO(ACCTNUM(ACCT#) PROC(ISPFPROC)) OMVS(HOME('/u/{user}') PROGRAM(' bin/sh') AUTOUID"
+    # -------------------------------------------------------------------------
+    add_user_cmd.write(f"tsocmd ADDUSER {user} DFLTGRP\\({user_group}\\) OWNER\\({model_owner}\\) PASSWORD\\({passwd}\\) TSO\\(ACCTNUM\\({model_tso_acctnum}\\) PROC\\({model_tso_proc}\\)\\) OMVS\\(HOME\\('/u/{user}'\\) PROGRAM\\(' bin/sh'\\) AUTOUID;")
+    add_user_cmd.write(f"echo ADDUSER {user} RC=$?;")
+    add_user_cmd.write(f"mkdir /u/{user};")              # Do we need to create this home directory for a temporary user?
+    add_user_cmd.write(f"echo mkdir {user} RC=$?;")
+    add_user_cmd.write(f"chown {user} /u/{user};")
+    add_user_cmd.write(f"echo chown {user} RC=$?;")
+    add_user_cmd.write(f"chgrp {user_group} /u/{user};")
+    add_user_cmd.write(f"echo chgrp {user_group} RC=$?;")
+
+    print(f"add_user_cmd [{add_user_cmd.getvalue()}]")
+
+    results_add_user_cmd = ansible_zos_module.all.shell(
+            cmd=f"{add_user_cmd.getvalue()}"
+    )
+
+    print(f"results_tso_noracf.contacted.values() are [{results_add_user_cmd.contacted.values()}]")
+    return None #operations[managed_user.name](ansible_zos_module)
+
+
+
+
+    # These will serve the general purpose of our test cases
+def create_user_zoau_limited_access_opercmd(ansible_zos_module) -> str:
+
+
+
+
+
+    # tsocmd f"ADDUSER ANSUSR01 DFLTGRP(ANSIGROUP) OWNER(RACF000) PASSWORD(PASSWD) TSO(ACCTNUM(ACCT#) PROC(ISPFPROC)) OMVS(HOME('/u/fflores') PROGRAM(' bin/sh') AUTOUID "
+    # _USER="usrt001"
+    # SAF_PROFILE="MVS.MCSOPER.ZOAU"
+    # SAF_CLASS="OPERCMDS"
+    # tsocmd "RDEFINE ${SAF_CLASS} ${SAF_PROFILE} UACC(NONE) AUDIT(ALL)"
+    # tsocmd "PERMIT ${SAF_PROFILE} CLASS(${SAF_CLASS}) ID(${_USER}) ACCESS(NONE)"
+    # tsocmd "SETROPTS RACLIST(${SAF_CLASS}) REFRESH"
+    # return None
+
+    # Build a command from this and the below and above for a new user with limited powers.
+    # To start, we can create a new group for our use.
+    # ```bash
+    # tsocmd "ADDGROUP ANSUSER1 OMVS(AUTOGID) "
+    # ```
+
+    # We can create a user using the following:
+    # ```bash
+    # tsocmd "ADDUSER fflores DFLTGRP(ANSUSER1) OWNER(SYS1) PASSWORD(RESET1A) TSO(ACCTNUM(ACCT#) PROC(ISPFPROC)) OMVS(HOME('/u/fflores') PROGRAM('/bin/sh') AUTOUID "
+    # mkdir /u/fflores
+    # chown fflores /u/fflores
+    # chgrp ANSUSER1 /u/fflores
+    # ```
+
+
+    # LISTUSER USRt001 RESULTS:
+    # USER=USRT001  NAME=UNKNOWN  OWNER=RACF000   CREATED=81.208
+    # DEFAULT-GROUP=SYS1     PASSDATE=24.273 PASS-INTERVAL= 90 PHRASEDATE=N/A
+    # ATTRIBUTES=NONE
+    # REVOKE DATE=NONE   RESUME DATE=NONE
+    # LAST-ACCESS=24.275/15:51:54
+    # CLASS AUTHORIZATIONS=NONE
+    # NO-INSTALLATION-DATA
+    # NO-MODEL-NAME
+    # LOGON ALLOWED   (DAYS)          (TIME)
+    # ---------------------------------------------
+    # ANYDAY                          ANYTIME
+    # GROUP=SYS1      AUTH=USE      CONNECT-OWNER=RACF000   CONNECT-DATE=81.208
+    #     CONNECTS=   900  UACC=NONE     LAST-CONNECT=24.275/15:51:54
+    #     CONNECT ATTRIBUTES=NONE
+    #     REVOKE DATE=NONE   RESUME DATE=NONE
+    # GROUP=RAD       AUTH=USE      CONNECT-OWNER=RACF000   CONNECT-DATE=87.056
+    #     CONNECTS=    00  UACC=NONE     LAST-CONNECT=UNKNOWN
+    #     CONNECT ATTRIBUTES=NONE
+    #     REVOKE DATE=NONE   RESUME DATE=NONE
+    # GROUP=DB2       AUTH=USE      CONNECT-OWNER=USER000   CONNECT-DATE=94.287
+    #     CONNECTS=    00  UACC=NONE     LAST-CONNECT=UNKNOWN
+    #     CONNECT ATTRIBUTES=NONE
+    #     REVOKE DATE=NONE   RESUME DATE=NONE
+    # SECURITY-LEVEL=NONE SPECIFIED
+    # CATEGORY-AUTHORIZATION
+    # NONE SPECIFIED
+    # SECURITY-LABEL=NONE SPECIFIED
+
+    # tsocmd LISTUSER OMVSADM TSO NORACF
+    # LISTUSER OMVSADM TSO NORACF
+    # USER=OMVSADM
+
+    # TSO INFORMATION
+    # ---------------
+    # ACCTNUM= D1001
+    # PROC= TPROC02
+    # SIZE= 00512000
+    # MAXSIZE= 00000000
+    # UNIT= SYSDA
+    # USERDATA= 0000
+
+    return "result create_user_zoau_limited_access_opercmd"
+
+def create_user_zos_limited_hlq(ansible_zos_module) -> str:
+    return "result create_user_zos_limited_hlq"
+
+def create_user_zos_limited_tmp_hlq(ansible_zos_module) -> str:
+    return "result create_user_zos_limited_tmp_hlq"
+
+operations = {
+    ManagedUsers.ZOAU_LIMITED_ACCESS_OPERCMD.name: create_user_zoau_limited_access_opercmd,
+    ManagedUsers.ZOS_LIMITED_HLQ.name: create_user_zos_limited_hlq,
+    ManagedUsers.ZOS_LIMITED_TMP_HLQ.name: create_user_zos_limited_tmp_hlq
+}
+
+
 class Racf:
+    from collections import OrderedDict
+    import json
     # Try to provide ordered execution to avoid command failure
-    racf = OrderedDict()  # Better to remove the ordered dictionary and allow the class to accept an ordering yet follow a default. 
+    racf = OrderedDict()  # Better to remove the ordered dictionary and allow the class to accept an ordering yet follow a default.
     racf['adduser'] = []
     racf['xxx'] = []
     racf['xxx'] = []
@@ -128,23 +370,12 @@ class Racf:
         setropts = OrderedDict()
         setropts['raclist'] = []
 
-    # get_user(ENUM)
-    # Check if the user exist 
-    # # lookup enum call right method 
-    # return get_zoau_limited_access_opercmd
 
-
-    # These will serve the general purpose of our test cases
-    def get_zoau_limited_access_opercmd() -> str:
-    # _USER="usrt001"
-    # SAF_PROFILE="MVS.MCSOPER.ZOAU"
-    # SAF_CLASS="OPERCMDS"
-    # tsocmd "RDEFINE ${SAF_CLASS} ${SAF_PROFILE} UACC(NONE) AUDIT(ALL)"
-    # tsocmd "PERMIT ${SAF_PROFILE} CLASS(${SAF_CLASS}) ID(${_USER}) ACCESS(NONE)"
-    # tsocmd "SETROPTS RACLIST(${SAF_CLASS}) REFRESH"
-    # return None
-
+def main():
+    x=get_managed_user_name("nothing", ManagedUsers.zoau_limited_access_opercmd)
+    print(x)
 
 if __name__ == '__main__':
-    racf = Racf()
-    adduser = Racf.Adduser()
+    # racf = Racf()
+    # adduser = Racf.Adduser()
+    main()

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -485,7 +485,7 @@ class ManagedUser:
             cmd=f"{add_user_cmd.getvalue()}"
             add_user_attributes = self._connect(self._remote_host, self._model_user,cmd)
 
-            print(r"DEBUG OUT {add_user_attributes}")
+            print(f"DEBUG OUT {add_user_attributes}")
             # Because this is a tsocmd run through shell, any user with a $ will be expanded and thus truncated, you can't change
             # that behavior since its happening on the managed node, solution is to match a shorter pattern without the user.
             is_assigned_omvs_uid = True if [v for v in add_user_attributes if f"was assigned an OMVS UID value" in v] else False

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -110,7 +110,7 @@ class ManagedUser:
     be updated with the new user or use the fixture to perform managed node inquiries,
     thus SSH is used for those managed node commands.
 
-    Another important not is when using this API, you can't parametrize test cases, because
+    Another important note is when using this API, you can't parametrize test cases, because
     once the pytest fixture (ansible_zos_module) is updated with a new user and performs a
     remote operation on a managed node, the fixture's user can not be changed because control
     is passed back and all attempts to change the user for reuse will fail, unless your goal
@@ -155,12 +155,6 @@ class ManagedUser:
         Who am I BEFORE asking for a managed user = BPXROOT
         Who am I AFTER asking for a managed user = LJBXMONV
     """
-    # _model_user = None
-    # _managed_racf_user = None
-    # _managed_user_group = None
-    # _remote_host = None
-    # _ssh_config_file_size = 0
-    # _ssh_directory_present = True
 
     def __init__(self, model_user: str = None, remote_host: str = None, zoau_path: str = None, pyz_path: str = None, pythonpath: str = None, volumes: str = None, hostpattern: str = None) -> None:
         """

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) IBM Corporation 2024
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The helpers/users.py file contains various utility functions that
+will support test case user needs. Such cases could be randomly
+generated users with specific limitations or users with UID 0.
+"""
+
+from collections import OrderedDict
+from enum import Enum
+import json
+from __future__ import annotations
+from typing import Annotated
+
+class ManagedUsers (Enum):
+    zoau_limited_access_opercmd=("zoau_limited_access_opercmd")
+    """
+    A z/OS managed user with restricted access to ZOAU
+    SAF Profile 'MVS..MCSOPER.ZOAU' and SAF Class OPERCMDS
+    with universal access authority set to UACC(NONE). With
+    UACC as NONE, this user will be refused access to the
+    ZOAU opercmd utility.
+    """
+    zos_limited_hlq=("zos_limited_hlq")
+    """
+    A z/OS managed user with restricted access to High Level
+    Qualifiers (HLQ): (RESTRICT, NOPERMIT, ....).
+    """
+
+    zos_limited_tmp_hlq=("zos_limited_tmp_hlq")
+    """
+    A z/OS managed user with restricted access to temporary
+    High Level Qualifiers (HLQ): (TSTRICT, TNOPERM, ....).
+    """
+
+class Racf:
+    # Try to provide ordered execution to avoid command failure
+    racf = OrderedDict()  # Better to remove the ordered dictionary and allow the class to accept an ordering yet follow a default. 
+    racf['adduser'] = []
+    racf['xxx'] = []
+    racf['xxx'] = []
+    racf['xxx'] = []
+    racf['xxx'] = []
+    racf['xxx'] = []
+    racf['xxx'] = []
+    racf['rdefine'] = []
+    racf['permit'] = []
+    racf['setropts'] = []
+
+
+    # tsocmd "ADDUSER fflores DFLTGRP(ANSUSER1) OWNER(SYS1) PASSWORD(RESET1A) TSO(ACCTNUM(ACCT#) PROC(ISPFPROC)) OMVS(HOME('/u/fflores') PROGRAM(' bin/sh') AUTOUID "
+    # mkdir /u/fflores
+    # chown fflores /u/fflores
+    # chgrp ANSUSER1 /u/fflores
+
+    # tsocmd "ADDGROUP (MISC) OWNER(OMVSADM) SUPGROUP(SYS1) DATA('HLQ STUB')"
+    # tsocmd "CONNECT FFLORES GROUP(MISC)"
+    # tsocmd "ADDSD 'MISC.FFLORES.*'    UACC(NONE)   DATA ('only allow to create under misc.fflores')"
+    # tsocmd "PERMIT 'MISC.FFLORES.*'  CLASS(DATASET) ACCESS(ALTER) ID(FFLORES)"
+    # tsocmd "SETROPTS GENERIC(DATASET) REFRESH"
+    # tsocmd "LISTDSD ALL PREFIX(MISC.FFLORES)"
+
+    class Adduser:
+        user = OrderedDict()
+        user['user'] = []
+        user['dfltgrp'] = []
+        user['password'] = []
+        user['tso'] = []
+        user['proc'] = []
+        user['omvs'] = []
+        user['program'] = []
+
+        def __str__(self) -> str:
+            return str(json.dumps(self.user, indent=4))
+
+        class User_parameter (Enum):
+            user=("USER")
+            dfltgrp=("DFLTGRP")
+
+        def __str__(self) -> str:
+            """
+            Convert the name of the project to lowercase when converting it to a string.
+
+            Return:
+                str: The lowercase name of the project.
+            """
+            return self.name.lower()
+
+        def set_parameter(self, parm: User_parameter):
+           # self.racf['user'] = "foobar"
+           return None
+
+        def __exit__(self):
+            #on exit build a command and set RACF with a function pointer
+
+            #self.racf['user'] = self (as a function pointer) or maybe a command built out is sufficient so string
+            # The only reason I see why function pointers would be good is in case there other things to do , eg
+            # before you can use TSO commands for RACF, you might need to do some shell commands to set up the users home
+            # in USS, this is two different types commands, one being TSO other being shell. 
+            return None
+
+    class Redefine:
+        redefine = OrderedDict()
+        redefine['class'] = []
+        redefine['profile'] = []
+        redefine['uacc'] = []
+        redefine['audit'] = []
+
+    class Permit:
+        redefine = OrderedDict()
+        redefine['class'] = []
+        redefine['profile'] = []
+        redefine['user'] = []
+        redefine['access'] = []
+
+    class Setropts:
+        setropts = OrderedDict()
+        setropts['raclist'] = []
+
+    # get_user(ENUM)
+    # Check if the user exist 
+    # # lookup enum call right method 
+    # return get_zoau_limited_access_opercmd
+
+
+    # These will serve the general purpose of our test cases
+    def get_zoau_limited_access_opercmd() -> str:
+    # _USER="usrt001"
+    # SAF_PROFILE="MVS.MCSOPER.ZOAU"
+    # SAF_CLASS="OPERCMDS"
+    # tsocmd "RDEFINE ${SAF_CLASS} ${SAF_PROFILE} UACC(NONE) AUDIT(ALL)"
+    # tsocmd "PERMIT ${SAF_PROFILE} CLASS(${SAF_CLASS}) ID(${_USER}) ACCESS(NONE)"
+    # tsocmd "SETROPTS RACLIST(${SAF_CLASS}) REFRESH"
+    # return None
+
+
+if __name__ == '__main__':
+    racf = Racf()
+    adduser = Racf.Adduser()

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -447,7 +447,9 @@ class ManagedUser:
             raise Exception(f"Unable to LISTUSER for {self._model_user}, exception [{err}]")
 
         # Collect the various public keys for use with the z/OS managed node, some accept only RSA and others ED25519
-        public_keys = self._read_files_in_directory("~/.ssh/", "*.pub")
+        #public_keys = self._read_files_in_directory("~/.ssh/", "*.pub")
+        public_keys = self._read_files_in_directory("/var/lib/jenkins/workspace/ansible-zos-core-dev-2@tmp/", "*.pub")
+        
 
         # The command consisting of shell and tso operations to create a user.
         add_user_cmd = StringIO()

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -12,9 +12,9 @@
 # limitations under the License.
 
 """
-The helpers/users.py file contains various utility functions that
-will support test case user needs. Such cases could be randomly
-generated users with specific limitations or users with UID 0.
+The users.py file contains various utility functions that
+will support functional test cases. For example, request a randomly
+generated user with specific limitations.
 """
 from collections import OrderedDict
 from io import StringIO
@@ -26,41 +26,14 @@ import sys
 import os
 import glob
 
-def get_random_passwd():
-    letters = string.ascii_uppercase
-    start = ''.join(random.choice(letters) for i in range(3))
-    middle = ''.join(str(random.randint(1,9)))
-    finish = ''.join(random.choice(letters) for i in range(4))
-    return f"{start}{middle}{finish}"
-
-def get_random_user():
-    letters = string.ascii_uppercase
-    suffix = ''.join(random.choice(letters) for i in range(4))
-    return "ANSI" + suffix
-
-
 class ManagedUsers (Enum):
     """
     Represents the z/OS users available for functional testing.
 
     Attributes:
     ZOAU_LIMITED_ACCESS_OPERCMD: ManagedUsers
-        A z/OS managed user with restricted access to ZOAU
-        SAF Profile 'MVS.MCSOPER.ZOAU' and SAF Class OPERCMDS
-        with universal access authority set to UACC(NONE). With
-        UACC as NONE, this user will be refused access to the
-        ZOAU opercmd utility.
     ZOS_LIMITED_HLQ: ManagedUsers
-        A z/OS managed user with restricted access to High Level
-        Qualifiers (HLQ): (RESTRICT, NOPERMIT, ....).
     ZOS_LIMITED_TMP_HLQ: ManagedUsers
-        A z/OS managed user with restricted access to temporary
-        High Level Qualifiers (HLQ): (TSTRICT, TNOPERM, ....).
-
-    Methods:
-        user_access() - Returns the user access requested.
-        user_name() - Returns the user name to be used in the functional test.
-        is_equal(user_name) - Checks if this user name is equal to user name.
     """
 
     ZOAU_LIMITED_ACCESS_OPERCMD=("zoau_limited_access_opercmd")
@@ -72,38 +45,79 @@ class ManagedUsers (Enum):
     UACC as NONE, this user will be refused access to the
     ZOAU opercmd utility.
     """
-    ZOS_LIMITED_HLQ=("zos_limited_hlq","ANSUSR02")
+    # TODO: Implement this, use the recommended HLQ
+    ZOS_LIMITED_HLQ=("zos_limited_hlq")
     """
     A z/OS managed user with restricted access to High Level
     Qualifiers (HLQ): (RESTRICT, NOPERMIT, ....).
     """
 
-    ZOS_LIMITED_TMP_HLQ=("zos_limited_tmp_hlq", "ANSUSR03")
+    # TODO: Implement this, use the recommended tmp HLQ
+    ZOS_LIMITED_TMP_HLQ=("zos_limited_tmp_hlq")
     """
     A z/OS managed user with restricted access to temporary
     High Level Qualifiers (HLQ): (TSTRICT, TNOPERM, ....).
     """
 
+    ZOS_BEGIN_WITH_AT_SIGN=("zos_begin_with_at_sign")
+    """
+    A z/OS managed user....
+    """
+
+    ZOS_BEGIN_WITH_POUND=("zos_begin_with_pound")
+    """
+    A z/OS managed user....
+    """
+
+    ZOS_RANDOM_SYMBOLS=("zos_random_symbols")
+    """
+    A z/OS managed user....user ID cannot exceed seven characters and must begin with an alphabetic, # (X'7B'), $ (X'5B'), or @ (X'7C') character.
+    """
     def __str__(self) -> str:
         """
-        Convert the name of the project to uppercase when converting it to a string.
-
-        Return:
-            str: The lowercase name of the project.
+        Return the enum name as upper case.
         """
         return self.name.upper()
 
     def string(self) -> str:
         """
-        Returns the string value contained in the tuple.
-        'online' for ONLINE and 'offline' for OFFLINE.
-
-        Return:
-            str: The string value contained in the tuple.
-                'online' for ONLINE and 'offline' for OFFLINE.
+        Returns the enum value as uppercase.
         """
         return self.value.upper()
 
+def get_random_passwd() -> str:
+    letters = string.ascii_uppercase
+    start = ''.join(random.choice(letters) for i in range(3))
+    middle = ''.join(str(random.randint(1,9)))
+    finish = ''.join(random.choice(letters) for i in range(4))
+    return f"{start}{middle}{finish}"
+
+def get_random_user(managed_user: ManagedUsers = None) -> str:
+    """A-Z, 0-9, #, $, or @."""
+    letters = string.ascii_uppercase
+    if managed_user is not None:
+        if managed_user.name == ManagedUsers.ZOS_BEGIN_WITH_AT_SIGN.name:
+            return "@" + ''.join(random.choice(letters) for i in range(7))
+        elif managed_user.name == ManagedUsers.ZOS_BEGIN_WITH_POUND.name:
+            return "#" + ''.join(random.choice(letters) for i in range(7))
+        elif managed_user.name == ManagedUsers.ZOS_RANDOM_SYMBOLS.name:
+            letters = string.ascii_uppercase
+            numbers = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+            symbols = ['#', '$', '@',]
+
+            prefix = random.sample(letters,1)
+            alphas = random.sample(letters,2)
+            num = random.sample(numbers,2)
+            sym = random.sample(symbols,3)
+            alphas.extend(num)
+            alphas.extend(sym)
+
+            random.shuffle(alphas)
+
+            return str(prefix[0]) + ''.join([str(entry) for entry in alphas])
+
+    # All other cases can use any formatted user name, so random 8 letters is fine.
+    return ''.join(random.choice(letters) for i in range(8))
 
 def read_files_in_directory(directory: str = "~/.ssh", pattern: str = "*.pub") -> list:
     """Reads files in a directory that match the pattern and return file contents as a list entry."""
@@ -119,26 +133,37 @@ def read_files_in_directory(directory: str = "~/.ssh", pattern: str = "*.pub") -
     return file_contents_as_list
 
 def copy_ssh_key(user, passwd, host, key_path):
-    """Copy SSH key to a remote host using subprocess, note that some systems will not have sshpass installed."""
+    """
+    Copy SSH key to a remote host using subprocess.
+
+    Note:
+        This requires the host have sshpass installed.
+
+    See:
+        Method read_files_in_directory instead to copy the public keys.
+    """
 
     command = ["sshpass", "-p", f"{passwd}", "ssh-copy-id", "-o", "StrictHostKeyChecking=no", "-i", f"{key_path}", f"{user}@{host}"] #, "&>/dev/null"]
     result = subprocess.run(args=command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
 
     if result.returncode != 0:
-        raise Exception("Unable to copy public keys to remote host, check that sshpass is installed.") 
+        raise Exception("Unable to copy public keys to remote host, check that sshpass is installed.")
 
 def get_managed_user_name(ansible_zos_module, managed_user: ManagedUsers = None) -> str:
 
-    # TODO: Check if user exists and retry? Given this a randomly generated user, we can assume
-    # this won't be an issue and save the compute.
-    user = get_random_user()
+    # TODO: Check if user exists and retry?
+    # Given this a randomly generated user, we can assume this won't be an issue and save the compute.
+    user = get_random_user(managed_user)
 
-    # Generate the password to establish an password-less connection and use with RACF.
+    # print("USER " + user)
+    # Generate the password to establish a password-less connection and use with RACF.
     passwd = get_random_passwd()
 
+    # print("PASSWD " + user)
     # An existing user (model) will be used to access system specific values used to create a new user
     model_user = ansible_zos_module["options"]["user"]
 
+    # Access module user's TSO attributes for reuse
     results_tso_noracf = ansible_zos_module.all.shell(
             cmd=f"tsocmd LISTUSER {model_user} TSO NORACF"
     )
@@ -147,23 +172,31 @@ def get_managed_user_name(ansible_zos_module, managed_user: ManagedUsers = None)
     model_listuser_tso_attributes = list(results_tso_noracf.contacted.values())[0].get("stdout_lines")
 
     # Match the tso list results and place in variables (not all are used)
-    model_tso_acctnum = [v for v in model_listuser_tso_attributes if "ACCTNUM" in v][0].split('=')[1].strip() or ""
-    model_tso_proc = [v for v in model_listuser_tso_attributes if "PROC" in v][0].split('=')[1].strip() or ""
-    model_tso_size = [v for v in model_listuser_tso_attributes if "SIZE" in v][0].split('=')[1].strip() or ""
-    model_tso_maxsize = [v for v in model_listuser_tso_attributes if "MAXSIZE" in v][0].split('=')[1].strip() or ""
-    model_tso_unit = [v for v in model_listuser_tso_attributes if "UNIT" in v][0].split('=')[1].strip() or ""
-    model_tso_userdata = [v for v in model_listuser_tso_attributes if "USERDATA" in v][0].split('=')[1].strip() or ""
-    model_tso_command = [v for v in model_listuser_tso_attributes if "COMMAND" in v][0].split('=')[1].strip() or ""
+    model_tso_acctnum = [v for v in model_listuser_tso_attributes if "ACCTNUM" in v][0].split('=')[1].strip() or None
+    if not model_tso_acctnum:
+        raise Exception(f"Unable to determine the TSO Account number required for adding TSO {user}.")
 
-    # Print the matches for validation
-    print(f"model_tso_acctnum: [{model_tso_acctnum}]")
-    print(f"model_tso_proc: [{model_tso_proc}]")
-    print(f"model_tso_size: [{model_tso_size}]")
-    print(f"model_tso_maxsize: [{model_tso_maxsize}]")
-    print(f"model_tso_unit: [{model_tso_unit}]")
-    print(f"model_tso_userdata: [{model_tso_userdata}]")
-    print(f"model_tso_command: [{model_tso_command}]")
+    model_tso_proc = [v for v in model_listuser_tso_attributes if "PROC" in v][0].split('=')[1].strip() or None
+    if not model_tso_proc:
+        raise Exception(f"Unable to determine the TSO Proc required for adding TSO {user}.")
 
+    # These are currently not used when creating the user but are with considering minimally SIZE and MAXXSIZE
+    # model_tso_size = [v for v in model_listuser_tso_attributes if "SIZE" in v][0].split('=')[1].strip() or None
+    # model_tso_maxsize = [v for v in model_listuser_tso_attributes if "MAXSIZE" in v][0].split('=')[1].strip() or None
+    # model_tso_unit = [v for v in model_listuser_tso_attributes if "UNIT" in v][0].split('=')[1].strip() or ""
+    # model_tso_userdata = [v for v in model_listuser_tso_attributes if "USERDATA" in v][0].split('=')[1].strip() or ""
+    # model_tso_command = [v for v in model_listuser_tso_attributes if "COMMAND" in v][0].split('=')[1].strip() or ""
+
+    # Print the matches for validation, leaving this for debugging given this is new code.
+    # print(f"model_tso_acctnum: [{model_tso_acctnum}]")
+    # print(f"model_tso_proc: [{model_tso_proc}]")
+    # print(f"model_tso_size: [{model_tso_size}]")
+    # print(f"model_tso_maxsize: [{model_tso_maxsize}]")
+    # print(f"model_tso_unit: [{model_tso_unit}]")
+    # print(f"model_tso_userdata: [{model_tso_userdata}]")
+    # print(f"model_tso_command: [{model_tso_command}]")
+
+    # Access additional module user attributes for use in a new user.
     results_listuser = ansible_zos_module.all.shell(
             cmd=f"tsocmd LISTUSER {model_user}"
     )
@@ -174,35 +207,40 @@ def get_managed_user_name(ansible_zos_module, managed_user: ManagedUsers = None)
     # Match the list user results and place in variables (not all are used)
     model_owner = [v for v in model_listuser_attributes if "OWNER" in v][0].split('OWNER=')[1].split()[0].strip() or ""
 
-    # The shell command consisting of shell and tso operations to create a user.
+    # Collect the various public keys for use with the z/OS managed node, some accept only RSA and others ED25519
+    public_keys = read_files_in_directory("~/.ssh/", "*.pub")
+
+    # The command consisting of shell and tso operations to create a user.
     add_user_cmd = StringIO()
 
     # (1) Create group ANSIGRP for general identification of users and auto assign the UID
-    #     Success of the command yields 'Group ANSIGRP was assigned an OMVS GID value of 4'
+    #     Success of the command yields 'Group ANSIGRP was assigned an OMVS GID value of...'
     #     Failure of the command yields 'INVALID GROUP, ANSIGRP' with usually a RC 8 if the group exists.
     user_group = "ANSIGRP"
     add_user_cmd.write(f"tsocmd 'ADDGROUP {user_group} OMVS(AUTOGID)';")
     add_user_cmd.write(f"echo Create {user_group} RC=$?;")
-    public_keys = read_files_in_directory("~/.ssh/", "*.pub")
-    print(str(public_keys))
 
     # (2) Add the user to be owned by the model_owner. Expect a similar error when a new TSO userid is defined,
-    #     because that id can't receive deferred messages until the id is defined in SYS1.BRODCAST,  thus the SEND
+    #     because that id can't receive deferred messages until the id is defined in SYS1.BRODCAST, thus the SEND
     #     message fails to that user id.
     #       BROADCAST DATA SET NOT USABLE+
     #       I/O SYNAD ERROR
     add_user_cmd.write(f"tsocmd ADDUSER {user} DFLTGRP\\({user_group}\\) OWNER\\({model_owner}\\) NOPASSWORD TSO\\(ACCTNUM\\({model_tso_acctnum}\\) PROC\\({model_tso_proc}\\)\\) OMVS\\(HOME\\('/u/{user}'\\) PROGRAM\\('/bin/sh'\\) AUTOUID;")
-    add_user_cmd.write(f"echo ADDUSER {user} RC=$?;")
+    add_user_cmd.write(f"echo ADDUSER '{user}' RC=$?;")
     add_user_cmd.write(f"mkdir -p /u/{user}/.ssh;")
-    add_user_cmd.write(f"echo mkdir {user} RC=$?;")
+    add_user_cmd.write(f"echo mkdir '{user}' RC=$?;")
     add_user_cmd.write(f"umask 0022;")
     add_user_cmd.write(f"touch /u/{user}/.ssh/authorized_keys;")
+    add_user_cmd.write(f"echo touch authorized_keys RC=$?;")
     add_user_cmd.write(f"chown -R {user} /u/{user};")
-    add_user_cmd.write(f"echo chown {user} RC=$?;")
+    add_user_cmd.write(f"echo chown '{user}' RC=$?;")
     for pub_key in public_keys:
         add_user_cmd.write(f"echo {pub_key} >> /u/{user}/.ssh/authorized_keys;")
-    add_user_cmd.write(f"tsocmd ALTUSER {user} PASSWORD\\({passwd}\\) NOEXPIRED")
-    print(f"add_user_cmd [{add_user_cmd.getvalue()}]")
+    add_user_cmd.write(f"tsocmd ALTUSER {user} PASSWORD\\({passwd}\\) NOEXPIRED;")
+    add_user_cmd.write(f"echo ALTUSER '{user}' RC=$?;")
+
+    # Print the command being used to add the new user. Commented out for now.
+    # print(f"add_user_cmd [{add_user_cmd.getvalue()}]")
 
     results_add_user_cmd = ansible_zos_module.all.shell(
             cmd=f"{add_user_cmd.getvalue()}"
@@ -210,24 +248,50 @@ def get_managed_user_name(ansible_zos_module, managed_user: ManagedUsers = None)
 
     # Extract the new user stdout lines for evaluation
     add_user_attributes = list(results_add_user_cmd.contacted.values())[0].get("stdout_lines")
-    print("results_add_user_cmd.contacted.values() " + str(results_add_user_cmd.contacted.values()))
-    print("add_user_attributes: " + str(add_user_attributes))
-    # Match the new user return codes
-    assigned_omvs_uid = True if [v for v in add_user_attributes if f"User {user} was assigned an OMVS UID value" in v] else False
+
+    # Print stdout from add user.
+    # print("add_user_attributes stdout: " + str(add_user_attributes))
+
+    # Because this is a tsocmd run through shell, any user with a $ will be expanded and thus truncated so you can't change
+    # that behavior since its happening on the managed node, solution is to match a shorter pattern without the user. 
+    is_assigned_omvs_uid = True if [v for v in add_user_attributes if f"was assigned an OMVS UID value" in v] else False
+    if not is_assigned_omvs_uid:
+        raise Exception(f"Unable to create OMVS UID.")
+
     create_group_rc = [v for v in add_user_attributes if f"Create {user_group} RC=" in v][0].split('=')[1].strip() or None
+    if not create_group_rc or int(create_group_rc[0]) > 8:
+        raise Exception(f"Unable to create user group {user_group}.")
+
     add_user_rc = [v for v in add_user_attributes if f"ADDUSER {user} RC=" in v][0].split('=')[1].strip() or None
+    if not add_user_rc or int(add_user_rc[0]) > 0:
+        raise Exception(f"Unable to ADDUSER {user}.")
+
     mkdir_rc = [v for v in add_user_attributes if f"mkdir {user} RC=" in v][0].split('=')[1].strip() or None
+    if not mkdir_rc or int(mkdir_rc[0]) > 0:
+        raise Exception(f"Unable to make home directories for {user}.")
+
+    authorized_keys_rc = [v for v in add_user_attributes if f"touch authorized_keys RC=" in v][0].split('=')[1].strip() or None
+    if not authorized_keys_rc or int(authorized_keys_rc[0]) > 0:
+        raise Exception(f"Unable to make authorized_keys file for {user}.")
+
     chown_rc = [v for v in add_user_attributes if f"chown {user} RC=" in v][0].split('=')[1].strip() or None
+    if not chown_rc or int(chown_rc[0]) > 0:
+        raise Exception(f"Unable to change ownership of home directory for {user}.")
+
+    altuser_rc = [v for v in add_user_attributes if f"ALTUSER {user} RC=" in v][0].split('=')[1].strip() or None
+    if not altuser_rc or int(altuser_rc[0]) > 0:
+        raise Exception(f"Unable to update password for {user}.")
 
     # Print the RCs for validation
-    print(f"assigned_omvs_uid: [{assigned_omvs_uid}]")
-    print(f"create_group_rc: [{create_group_rc}]")
-    print(f"add_user_rc: [{add_user_rc}]")
-    print(f"mkdir_rc: [{mkdir_rc}]")
-    print(f"chown_rc: [{chown_rc}]")
+    # print(f"is_assigned_omvs_uid: [{is_assigned_omvs_uid}]")
+    # print(f"create_group_rc: [{create_group_rc}]")
+    # print(f"add_user_rc: [{add_user_rc}]")
+    # print(f"mkdir_rc: [{mkdir_rc}]")
+    # print(f"authorized_keys_rc: [{authorized_keys_rc}]")
+    # print(f"chown_rc: [{chown_rc}]")
 
     # remote_host = ansible_zos_module["options"]["inventory"].replace(",", "")
-    return None #operations[managed_user.name](ansible_zos_module)
+    # return None #operations[managed_user.name](ansible_zos_module)
 
     # These will serve the general purpose of our test cases
 def create_user_zoau_limited_access_opercmd(ansible_zos_module) -> str:

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -485,6 +485,7 @@ class ManagedUser:
             cmd=f"{add_user_cmd.getvalue()}"
             add_user_attributes = self._connect(self._remote_host, self._model_user,cmd)
 
+            print(r"DEBUG OUT {add_user_attributes}")
             # Because this is a tsocmd run through shell, any user with a $ will be expanded and thus truncated, you can't change
             # that behavior since its happening on the managed node, solution is to match a shorter pattern without the user.
             is_assigned_omvs_uid = True if [v for v in add_user_attributes if f"was assigned an OMVS UID value" in v] else False

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -310,7 +310,7 @@ class ManagedUser:
                 # If the config does not exist, set it to -1 so we know to completely remove the config.
                 self._ssh_config_file_size = -1
                 # Create the empty file
-                open(ssh_config_dir, 'a').close()
+                open(ssh_config_file, 'a').close()
 
 
     def _ssh_config_remove_host(self):

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -539,7 +539,7 @@ class ManagedUser:
             cmd=f"{add_user_cmd.getvalue()}"
             # need to connect with ssh  -i /tmp/UPGLSFLH/id_rsa UPGLSFLH@ec01136a.vmec.svl.ibm.com
             add_user_attributes = self._connect(self._remote_host, self._model_user,cmd)
-
+            os.system("cat ~/.ssh/config")
             print(f"DEBUG OUT {add_user_attributes}")
             # Because this is a tsocmd run through shell, any user with a $ will be expanded and thus truncated, you can't change
             # that behavior since its happening on the managed node, solution is to match a shorter pattern without the user.

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -17,38 +17,33 @@ will support functional test cases. For example, request a randomly
 generated user with specific limitations.
 
 Usage:
-    @pytest.mark.seq
-    @pytest.mark.parametrize("ds_type, f_lock, managed_user_type",[
-        ( "pds", False, ManagedUserType.ZOAU_LIMITED_ACCESS_OPERCMD), # Request user with limited ZOAU universal access
-        ( "pdse", False, ManagedUserType.ZOS_BEGIN_WITH_AT_SIGN), # Request a user that begins with @ symbol
-        ( "seq", False, ManagedUserType.ZOS_BEGIN_WITH_POUND), # Request a user that begings with the # symbol
-        ( "seq", False, ManagedUserType.ZOS_RANDOM_SYMBOLS), # Request at user with randome symbols '#', '$', '@'
-    ])
-    def test_copy_dest_lock_test_apf_authorization_3(ansible_zos_module, ds_type, f_lock, managed_user_type ):
-        # Instnace of the pytest-ansible fixture that will be passed to ManagedUser and updated with a new user
-        hosts = ansible_zos_module
-        # Instance of the ManagedUser call seeded with the hosts (pytest-ansible fixture)
+def test_copy_dest_lock_test_apf_authorization_3(ansible_zos_module):
+    # Request a user who has no authority to execute zoau opercmd
+    hosts = ansible_zos_module
+    managed_user, user, passwd = None, None, None
+    managed_user_type = ManagedUserType.ZOAU_LIMITED_ACCESS_OPERCMD
 
-        # Peek at who the current user is
-        print(f"\nOriginal user in hosts before requesting a managed user = {hosts['options']['user']}")
-
-        managed_user = ManagedUser(hosts)
-        # Check for managed user type request, an enum listing of supported user types.
+    # Instance of the ManagedUser initialized with a user who has authority to create users and the remote host.
+    remote_host = hosts["options"]["inventory"].replace(",", "")
+    remote_user = hosts["options"]["user"]
+    try:
+        # Check for a managed user type request
         if managed_user_type:
-            # Call get
-            hosts, user, passwd = managed_user.create_and_update_user(managed_user_type)
+            managed_user = ManagedUser(remote_user, remote_host)
+            user, passwd = managed_user.create_managed_user(managed_user_type)
             print(f"New managed user created = {user}")
             print(f"New managed password created = {passwd}")
-            print(f"User added to hosts object = {hosts['options']['user']}")
 
-        # Pefrorm Ansible module operations as usual
-        # hosts.all.zos_data_set....
-        # hosts.all.zos_copy.....
+        # Update fixture with the new user
+        hosts["options"]["user"] = user
 
-        # Delete and restore user, this is important to do to not only clena up the managed node
-        # but also so the original user is restored and can be used as model by in next call.
-        hosts = managed_user.delete_and_restore_user()
-        print(f"Restored user added to hosts object = {hosts['options']['user']}")
+        who = hosts.all.shell(cmd="whoami")
+        for person in who.contacted.values():
+            print("Who am I = " + str(person))
+
+    finally:
+        # Delete the managed user on the remote host to avoid proliferation of users.
+        managed_user.delete_managed_user()
 """
 from collections import OrderedDict
 from io import StringIO
@@ -60,6 +55,7 @@ import sys
 import os
 import glob
 import re
+import subprocess
 
 class ManagedUserType (Enum):
     """
@@ -135,11 +131,22 @@ class ManagedUser:
     _user = None
     _user_group = None
     _ansible_zos_module = None
+    _host = None
 
-    def __init__(self, ansible_zos_module):
-        self._ansible_zos_module = ansible_zos_module
+    def __init__(self, model_user, host):
+        self._model_user = model_user
+        self._host = host
 
-    def delete_and_restore_user(self):
+    def connect(self, host, user, command):
+        ssh_command = ["ssh", f"{user}@{host}", command]
+        result = subprocess.run(ssh_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+        # Don't do anything with stderr, there is code that will check RCs to determine if there is an error
+        # std_err = result.stderr
+
+        return [line.strip() for line in result.stdout.split('\n')]
+
+    def delete_managed_user(self):
         escaped_user = re.escape(self._user)
         command = StringIO()
         command.write(f"echo Deleting USER '{self._user}';")
@@ -148,15 +155,9 @@ class ManagedUser:
         command.write(f"tsocmd DELGROUP {self._user_group};")
         command.write(f"echo DELGROUP '{self._user_group}' RC=$?;")
 
-        # Restore the original user who has authority to perform deletes
-        self._ansible_zos_module["options"]["user"] = self._model_user
-
-        results_delete = self._ansible_zos_module.all.shell(
-                cmd=f"{command.getvalue()}"
-        )
-
-        # Extract the new user stdout lines for evaluation
-        results_stdout_lines = list(results_delete.contacted.values())[0].get("stdout_lines")
+        # Access additional module user attributes for use in a new user.
+        cmd=f"{command.getvalue()}"
+        results_stdout_lines = self.connect(self._host, self._model_user,cmd)
 
         deluser_rc = [v for v in results_stdout_lines if f"DELUSER {escaped_user} RC=" in v][0].split('=')[1].strip() or None
         if not deluser_rc or int(deluser_rc[0]) > 0:
@@ -166,7 +167,6 @@ class ManagedUser:
         if not delgroup_rc or int(delgroup_rc[0]) > 0:
             raise Exception(f"Unable to delete user {escaped_user}, please review the command output {results_stdout_lines}.")
 
-        return self._ansible_zos_module
 
     def __get_random_passwd(self) -> str:
         letters = string.ascii_uppercase
@@ -228,23 +228,16 @@ class ManagedUser:
         if result.returncode != 0:
             raise Exception("Unable to copy public keys to remote host, check that sshpass is installed.")
 
-    def create_and_update_user(self, managed_user: ManagedUserType) -> str:
+    def create_managed_user(self, managed_user: ManagedUserType) -> str:
         # Create random user based on ManagedUserType requirements
         self._user = self.__get_random_user(managed_user)
 
         # Generate the password to establish a password-less connection and use with RACF.
         passwd = self.__get_random_passwd()
 
-        # An existing user (model) will be used to access system specific values used to create a new user
-        self._model_user = self._ansible_zos_module["options"]["user"]
-
         # Access module user's TSO attributes for reuse
-        results_tso_noracf = self._ansible_zos_module.all.shell(
-                cmd=f"tsocmd LISTUSER {self._model_user} TSO NORACF"
-        )
-
-        # Extract the model user TSO entries for reuse in a new user
-        model_listuser_tso_attributes = list(results_tso_noracf.contacted.values())[0].get("stdout_lines")
+        cmd=f"tsocmd LISTUSER {self._model_user} TSO NORACF"
+        model_listuser_tso_attributes = self.connect(self._host, self._model_user,cmd)
 
         # Match the tso list results and place in variables (not all are used)
         model_tso_acctnum = [v for v in model_listuser_tso_attributes if "ACCTNUM" in v][0].split('=')[1].strip() or None
@@ -263,12 +256,8 @@ class ManagedUser:
         # model_tso_command = [v for v in model_listuser_tso_attributes if "COMMAND" in v][0].split('=')[1].strip() or ""
 
         # Access additional module user attributes for use in a new user.
-        results_listuser = self._ansible_zos_module.all.shell(
-                cmd=f"tsocmd LISTUSER {self._model_user}"
-        )
-
-        # Extract the model user TSO entries for reuse in a new user
-        model_listuser_attributes = list(results_listuser.contacted.values())[0].get("stdout_lines")
+        cmd=f"tsocmd LISTUSER {self._model_user}"
+        model_listuser_attributes = self.connect(self._host, self._model_user,cmd)
 
         # Match the list user results and place in variables (not all are used)
         model_owner = [v for v in model_listuser_attributes if "OWNER" in v][0].split('OWNER=')[1].split()[0].strip() or ""
@@ -278,9 +267,6 @@ class ManagedUser:
 
         # The command consisting of shell and tso operations to create a user.
         add_user_cmd = StringIO()
-
-        # For verbosity, extract the host for debugging if needed.
-        remote_host = self._ansible_zos_module["options"]["inventory"].replace(",", "")
 
         # (1) Create group ANSIGRP for general identification of users and auto assign the UID
         #     Success of the command yields 'Group ANSIGRP was assigned an OMVS GID value of...'
@@ -295,7 +281,7 @@ class ManagedUser:
         #       BROADCAST DATA SET NOT USABLE+
         #       I/O SYNAD ERROR
         escaped_user = re.escape(self._user)
-        add_user_cmd.write(f"Creating USER '{escaped_user}' with PASSWORD {passwd} for remote host {remote_host};")
+        add_user_cmd.write(f"Creating USER '{escaped_user}' with PASSWORD {passwd} for remote host {self._host};")
         add_user_cmd.write(f"tsocmd ADDUSER {escaped_user} DFLTGRP\\({self._user_group}\\) OWNER\\({model_owner}\\) NOPASSWORD TSO\\(ACCTNUM\\({model_tso_acctnum}\\) PROC\\({model_tso_proc}\\)\\) OMVS\\(HOME\\(/u/{escaped_user}\\) PROGRAM\\('/bin/sh'\\) AUTOUID;")
         add_user_cmd.write(f"echo ADDUSER '{escaped_user}' RC=$?;")
         add_user_cmd.write(f"mkdir -p /u/{escaped_user}/.ssh;")
@@ -311,13 +297,8 @@ class ManagedUser:
         add_user_cmd.write(f"tsocmd ALTUSER {escaped_user} PASSWORD\\({passwd}\\) NOEXPIRED;")
         add_user_cmd.write(f"echo ALTUSER '{escaped_user}' RC=$?;")
 
-        # Extract command from from StringsIO and run it on the z/OS managed node.
-        results_add_user_cmd = self._ansible_zos_module.all.shell(
-                cmd=f"{add_user_cmd.getvalue()}"
-        )
-
-        # Extract the new user stdout lines for evaluation
-        add_user_attributes = list(results_add_user_cmd.contacted.values())[0].get("stdout_lines")
+        cmd=f"{add_user_cmd.getvalue()}"
+        add_user_attributes = self.connect(self._host, self._model_user,cmd)
 
         # Because this is a tsocmd run through shell, any user with a $ will be expanded and thus truncated, you can't change
         # that behavior since its happening on the managed node, solution is to match a shorter pattern without the user.
@@ -349,12 +330,10 @@ class ManagedUser:
         if not altuser_rc or int(altuser_rc[0]) > 0:
             raise Exception(f"Unable to update password for {escaped_user}, please review the command output {add_user_attributes}.")
 
-        # Now that the user is created, update the user according to the ManagedUserType type
+        # Update the user according to the ManagedUserType type by invoking the mapped function
         self.operations[managed_user.name](self, self._user)
 
-        # Update the ansible fixture with new user credential for use by the test that requested it.
-        self._ansible_zos_module["options"]["user"] = self._user
-        return (self._ansible_zos_module, self._user, passwd)
+        return (self._user, passwd)
 
 
     def create_user_zoau_limited_access_opercmd(self, user: str) -> None:
@@ -370,13 +349,10 @@ class ManagedUser:
         command.write(f"tsocmd SETROPTS RACLIST\\({saf_class}\\) REFRESH;")
         command.write(f"echo SETROPTS RC=$?;")
 
-        results_limited_access_opercmd = self._ansible_zos_module.all.shell(
-                cmd=f"{command.getvalue()}"
-        )
+        cmd=f"{command.getvalue()}"
+        results_stdout_lines = self.connect(self._host, self._model_user,cmd)
 
-        # Extract the new user stdout lines for evaluation
-        results_stdout_lines = list(results_limited_access_opercmd.contacted.values())[0].get("stdout_lines")
-
+        # Evaluate the results
         rdefine_rc = [v for v in results_stdout_lines if f"RDEFINE RC=" in v][0].split('=')[1].strip() or None
         if not rdefine_rc or int(rdefine_rc[0]) > 4:
             raise Exception(f"Unable to rdefine {saf_class} {saf_profile}, please review the command output {results_stdout_lines}.")

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -614,7 +614,7 @@ class ManagedUser:
 
     def _create_managed_user(self, managed_user: ManagedUserType) -> Tuple[str, str]:
         """
-        Generate a managed user for the remote node according to the ManagedUseeType selected.
+        Generate a managed user for the remote node according to the ManagedUserType selected.
 
         Parameters
         ----------


### PR DESCRIPTION
##### SUMMARY
This addresses #1254 that updates the `zos_copy` code that calls opercmd to check if data sets are in use. When the user does not have SAF UACC for ZOAU SAF Profile 'MVS.MCSOPER.ZOAU' and SAF Class OPERCMDS, an exception is  thrown by ZOAU and the code now catches it and handles it. 

To support this in automation, another story #1757  was opened to create an api that enables test cases to request various types of id's to use in the automated test cases, one such OMVS segment is one that does not have the proper access to run opercmd and causes the exception. 

When using the new `users.py`, please review the comments/pydoc in the api, as there are some limitations in place because pytest-ansible does not support all the Ansible proper options , until that changes, we do have some limitations. 

To handle the case where `pytest-ansible` does not support `ansible_ssh_private_key_file`, the solution was to dynamically create a `~/.ssh/config` so that Ansible can find the private keys to complete the passwor-dless authentication which later is removed. 
 
Examples of the various managedUserTypes supported:
1) `ManagedUserType.ZOAU_LIMITED_ACCESS_OPERCMD`

    ```
    tests/functional/modules/test_zos_copy_func.py
    New managed user created = MSRMOBUH
    New managed password created = CHANGE
    Who am I = MSRMOBUH
    ```
    
2) `ManagedUserType.ZOS_BEGIN_WITH_AT_SIGN`

    ```
    tests/functional/modules/test_zos_copy_func.py
    New managed user created = @GECFWLJ
    New managed password created = CHANGE
    Who am I = @GECFWLJ
    ```
    
3) `ManagedUserType.ZOS_BEGIN_WITH_POUND`

    ```
    tests/functional/modules/test_zos_copy_func.py
    New managed user created = #PEMXQKZ
    New managed password created = CHANGE
    Who am I = #PEMXQKZ
    ```
 
4) `ManagedUserType.ZOS_RANDOM_SYMBOLS`

    ```
    tests/functional/modules/test_zos_copy_func.py
    New managed user created = P@$X3C6#
    New managed password created = CHANGE
    Who am I = P@$X3C6#
    ```

Some output showing the user being dynamically changed between two different test cases:
```
        Who am I BEFORE asking for a managed user = BPXROOT
        Who am I AFTER asking for a managed user = LJBXMONV
```

Results of some of the tests using the managed user:
```
tests/functional/modules/test_zos_copy_func.py ....

=============================== warnings summary ===============================
functional/modules/test_zos_copy_func.py::managed_user_copy_dest_lock_test_with_no_opercmd_access[pds-False]
functional/modules/test_zos_copy_func.py::managed_user_copy_dest_lock_test_with_no_opercmd_access[pds-False]
functional/modules/test_zos_copy_func.py::managed_user_copy_dest_lock_test_with_no_opercmd_access[pds-False]
functional/modules/test_zos_copy_func.py::managed_user_copy_dest_lock_test_with_no_opercmd_access[pds-False]
functional/modules/test_zos_copy_func.py::managed_user_copy_dest_lock_test_with_no_opercmd_access[pdse-False]
functional/modules/test_zos_copy_func.py::managed_user_copy_dest_lock_test_with_no_opercmd_access[seq-False]
functional/modules/test_zos_copy_func.py::managed_user_copy_dest_lock_test_with_no_opercmd_access[seq-True]
functional/modules/test_zos_copy_func.py::managed_user_copy_dest_lock_test_with_no_opercmd_access[seq-True]
  /Users/ddimatos/git/gh/ibm_zos_core/venv/venv-2.16/lib/python3.12/site-packages/ansible/plugins/loader.py:1498: UserWarning: AnsibleCollectionFinder has already been configured
    warnings.warn('AnsibleCollectionFinder has already been configured')

functional/modules/test_zos_copy_func.py: 61 warnings

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================== 4 passed, 69 warnings in 163.69s (0:02:43) ================
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
