### PR TITLE
[v1.13.0][Enhancement] Add deploy and forget capability to zos_job_submit

### DIFF
--- a/changelogs/fragments/1746-deploy-forget-zos_job_submit.yml
+++ b/changelogs/fragments/1746-deploy-forget-zos_job_submit.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - zos_job_submit - Add deploy and forget capability. Now when wait_time_s is 0, the module will
+    submit the job and will not wait to get the job details or content, returning only the job id.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1746).

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -1127,7 +1127,7 @@ def run_module():
                         jes_jcl_dd_content_str = " ".join(jes_jcl_dd_content)
                         # The regex can be r"({0})\s*=\s*(COPY|HOLD|JCLHOLD|SCAN)" once zoau support is in.
                         special_processing_keyword = re.search(r"({0})\s*=\s*(SCAN)"
-                                                                .format("|".join(JOB_SPECIAL_PROCESSING)), jes_jcl_dd_content_str)
+                                                               .format("|".join(JOB_SPECIAL_PROCESSING)), jes_jcl_dd_content_str)
 
                         if job_ret_code_msg == 'NOEXEC':
                             job_ret_code.update({"msg": special_processing_keyword[0]})
@@ -1136,7 +1136,7 @@ def run_module():
                             job_ret_code.update({"msg_txt": "The job {0} was run with special job "
                                                  "processing {1}. This will result in no completion, "
                                                  "return code or job steps and changed will be false."
-                                                 .format(job_submitted_id,  special_processing_keyword[0])})
+                                                 .format(job_submitted_id, special_processing_keyword[0])})
                             is_changed = False
                         else:
                             # The job_ret_code_code is None at this point, but the job_ret_code_msg_code could be populated

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -1107,7 +1107,19 @@ def run_module():
                                 job_ret_code.update({"msg_txt": _msg})
                                 raise Exception(_msg)
 
-                    if job_ret_code_code is None or job_ret_code_msg == 'NOEXEC':
+                    if job_ret_code_code is not None and job_ret_code_msg == 'NOEXEC':
+                        job_dd_names = job_output_txt[0].get("ddnames")
+                        jes_jcl_dd = search_dictionaries("ddname", "JESJCL", job_dd_names)
+                        # These are the conditions for a job run with TYPRUN=COPY.
+                        if not jes_jcl_dd:
+                            job_ret_code.update({"msg": "TYPRUN=COPY"})
+                            _msg = ("The job was run with TYPRUN=COPY. "
+                                    "This way, the steps are not executed, but the JCL is validated and stored "
+                                    "in the JES spool. "
+                                    "Please review the job log for further details.")
+                            job_ret_code.update({"msg_txt": _msg})
+
+                    if job_ret_code_code is None:
                         # If there is no job_ret_code_code (Job return code) it may NOT be an error,
                         # some jobs will never return have an RC, eg Started tasks(which are not supported),
                         # so further analyze the

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -1119,7 +1119,7 @@ def run_module():
                                     "Please review the job log for further details.")
                             job_ret_code.update({"msg_txt": _msg})
 
-                    if job_ret_code_code is None:
+                    if job_ret_code_code is None or job_ret_code.get("msg") == 'NOEXEC':
                         # If there is no job_ret_code_code (Job return code) it may NOT be an error,
                         # some jobs will never return have an RC, eg Started tasks(which are not supported),
                         # so further analyze the

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -69,6 +69,11 @@ options:
         node.
       - I(wait_time_s) is measured in seconds and must be a value greater than 0
         and less than 86400.
+      - The module can submit and forget by setting I(wait_time_s) to 0. This way the
+        module will not try to retrieve the job details other than job id.
+        Job details and contents can be retrieved later by using
+        L(zos_job_query,./zos_job_query.html) or L(zos_job_output,./zos_job_output.html)
+        if needed.
   max_rc:
     required: false
     type: int
@@ -712,7 +717,8 @@ def submit_src_jcl(module, src, src_name=None, timeout=0, is_unix=True, start_ti
     kwargs = {
         # Since every fetch retry waits for a second before continuing,
         # we can just pass the timeout (also in seconds) to this arg.
-        "fetch_max_retries": timeout,
+        # When timeout is 0 we still want to retry to get the job id.
+        "fetch_max_retries": timeout if timeout > 0 else 3,
     }
 
     duration = 0
@@ -722,49 +728,51 @@ def submit_src_jcl(module, src, src_name=None, timeout=0, is_unix=True, start_ti
     try:
         job_submitted = jobs.submit(src, is_unix=is_unix, **kwargs)
 
-        # Introducing a sleep to ensure we have the result of job submit carrying the job id.
-        while (job_submitted is None and duration <= timeout):
-            current_time = timer()
-            duration = round(current_time - start_time)
-            sleep(0.5)
+        if timeout > 0:
 
-        # Second sleep is to wait long enough for the job rc to not equal a `?`
-        # which is what ZOAU sends back, opitonally we can check the 'status' as
-        # that is sent back as `AC` when the job is not complete but the problem
-        # with monitoring 'AC' is that STARTED tasks never exit the AC status.
-        job_fetched = None
-        job_fetch_rc = None
-        job_fetch_status = None
-
-        if job_submitted:
-            try:
-                job_fetched = jobs.fetch_multiple(job_submitted.job_id)[0]
-                job_fetch_rc = job_fetched.return_code
-                job_fetch_status = job_fetched.status
-            except zoau_exceptions.JobFetchException:
-                pass
-
-            # Before moving forward lets ensure our job has completed but if we see
-            # status that matches one in JOB_STATUSES, don't wait, let the code
-            # drop through and get analyzed in the main as it will scan the job ouput
-            # Any match to JOB_STATUSES ends our processing and wait times
-            while (job_fetch_status not in JOB_STATUSES and
-                    job_fetch_status == 'AC' and
-                    ((job_fetch_rc is None or len(job_fetch_rc) == 0 or
-                      job_fetch_rc == '?') and duration < timeout)):
+            # Introducing a sleep to ensure we have the result of job submit carrying the job id.
+            while (job_submitted is None and duration <= timeout):
                 current_time = timer()
                 duration = round(current_time - start_time)
-                sleep(1)
+                sleep(0.5)
+
+            # Second sleep is to wait long enough for the job rc to not equal a `?`
+            # which is what ZOAU sends back, opitonally we can check the 'status' as
+            # that is sent back as `AC` when the job is not complete but the problem
+            # with monitoring 'AC' is that STARTED tasks never exit the AC status.
+            job_fetched = None
+            job_fetch_rc = None
+            job_fetch_status = None
+
+            if job_submitted:
                 try:
                     job_fetched = jobs.fetch_multiple(job_submitted.job_id)[0]
                     job_fetch_rc = job_fetched.return_code
                     job_fetch_status = job_fetched.status
-                # Allow for jobs that need more time to be fectched to run the wait_time_s
-                except zoau_exceptions.JobFetchException as err:
-                    if duration >= timeout:
-                        raise err
-                    else:
-                        continue
+                except zoau_exceptions.JobFetchException:
+                    pass
+
+                # Before moving forward lets ensure our job has completed but if we see
+                # status that matches one in JOB_STATUSES, don't wait, let the code
+                # drop through and get analyzed in the main as it will scan the job ouput
+                # Any match to JOB_STATUSES ends our processing and wait times
+                while (job_fetch_status not in JOB_STATUSES and
+                        job_fetch_status == 'AC' and
+                        ((job_fetch_rc is None or len(job_fetch_rc) == 0 or
+                          job_fetch_rc == '?') and duration < timeout)):
+                    current_time = timer()
+                    duration = round(current_time - start_time)
+                    sleep(1)
+                    try:
+                        job_fetched = jobs.fetch_multiple(job_submitted.job_id)[0]
+                        job_fetch_rc = job_fetched.return_code
+                        job_fetch_status = job_fetched.status
+                    # Allow for jobs that need more time to be fectched to run the wait_time_s
+                    except zoau_exceptions.JobFetchException as err:
+                        if duration >= timeout:
+                            raise err
+                        else:
+                            continue
 
     # ZOAU throws a JobSubmitException when the job sumbission fails thus there is no
     # JCL RC to share with the user, if there is a RC, that will be processed
@@ -822,6 +830,51 @@ def submit_src_jcl(module, src, src_name=None, timeout=0, is_unix=True, start_ti
         module.fail_json(**result)
 
     return job_submitted.job_id if job_submitted else None, duration
+
+
+def build_return_schema(result):
+    """ Builds return values schema with empty values.
+
+        Parameters
+        ----------
+        result : dict
+            Dictionary used to return values at execution finalization.
+
+        Returns
+        -------
+        dict
+            Dictionary used to return values at execution finalization.
+    """
+    result = {
+        "jobs": [],
+        "job_id": None,
+        "job_name": None,
+        "duration": None,
+        "ddnames": {
+            "ddname": None,
+            "record_count": None,
+            "id": None,
+            "stepname": None,
+            "procstep": None,
+            "byte_count": None,
+            "content": [],
+        },
+        "ret_code": {
+            "code": None,
+            "msg": None,
+            "msg_code": None,
+            "msg_txt": None,
+            "steps": [],
+        },
+        "job_class": None,
+        "svc_class": None,
+        "priority": None,
+        "asid": None,
+        "creation_date": None,
+        "queue_position": None,
+        "program_name": None,
+    }
+    return result
 
 
 def run_module():
@@ -944,8 +997,9 @@ def run_module():
 
     # Default 'changed' is False in case the module is not able to execute
     result = dict(changed=False)
+    result = build_return_schema(result)
 
-    if wait_time_s <= 0 or wait_time_s > MAX_WAIT_TIME_S:
+    if wait_time_s < 0 or wait_time_s > MAX_WAIT_TIME_S:
         result["failed"] = True
         result["msg"] = ("The value for option 'wait_time_s' is not valid, it must "
                          "be greater than 0 and less than {0}.".format(str(MAX_WAIT_TIME_S)))
@@ -990,142 +1044,147 @@ def run_module():
     # Explictly pass None for the unused args else a default of '*' will be
     # used and return undersirable results
     job_output_txt = None
+    result['job_id'] = job_submitted_id
+    # Populate return schema to not have a conditional return schema.
+    is_changed = True
+    # If wait_time_s is 0, we do a deploy and forget strategy.
+    if wait_time_s != 0:
 
-    try:
-        job_output_txt = job_output(
-            job_id=job_submitted_id, owner=None, job_name=None, dd_name=None,
-            dd_scan=return_output, duration=duration, timeout=wait_time_s, start_time=start_time)
+        try:
+            job_output_txt = job_output(
+                job_id=job_submitted_id, owner=None, job_name=None, dd_name=None,
+                dd_scan=return_output, duration=duration, timeout=wait_time_s, start_time=start_time)
 
-        # This is resolvig a bug where the duration coming from job_output is passed by value, duration
-        # being an immutable type can not be changed and must be returned or accessed from the job.py.
-        if job_output is not None:
-            duration = job_output_txt[0].get("duration") if not None else duration
+            # This is resolvig a bug where the duration coming from job_output is passed by value, duration
+            # being an immutable type can not be changed and must be returned or accessed from the job.py.
+            if job_output is not None:
+                duration = job_output_txt[0].get("duration") if not None else duration
 
-        result["duration"] = duration
+            result["duration"] = duration
 
-        if duration >= wait_time_s:
-            result["failed"] = True
-            result["changed"] = False
-            _msg = ("The JCL submitted with job id {0} but appears to be a long "
-                    "running job that exceeded its maximum wait time of {1} "
-                    "second(s). Consider using module zos_job_query to poll for "
-                    "a long running job or increase option 'wait_times_s' to a value "
-                    "greater than {2}.".format(str(job_submitted_id), str(wait_time_s), str(duration)))
-            _msg_suffix = ("Consider using module zos_job_query to poll for "
-                           "a long running job or increase option 'wait_times_s' to a value "
-                           "greater than {0}.".format(str(duration)))
+            if duration >= wait_time_s:
+                result["failed"] = True
+                result["changed"] = False
+                _msg = ("The JCL submitted with job id {0} but appears to be a long "
+                        "running job that exceeded its maximum wait time of {1} "
+                        "second(s). Consider using module zos_job_query to poll for "
+                        "a long running job or increase option 'wait_times_s' to a value "
+                        "greater than {2}.".format(str(job_submitted_id), str(wait_time_s), str(duration)))
+                _msg_suffix = ("Consider using module zos_job_query to poll for "
+                               "a long running job or increase option 'wait_times_s' to a value "
+                               "greater than {0}.".format(str(duration)))
 
-            if job_output_txt is not None:
+                if job_output_txt is not None:
+                    result["jobs"] = job_output_txt
+                    job_ret_code = job_output_txt[0].get("ret_code")
+                    job_ret_code.update({"msg_txt": _msg_suffix})
+                result["msg"] = _msg
+                module.exit_json(**result)
+
+            # Job has submitted, the module changed the managed node
+            is_changed = True
+
+            if job_output_txt:
                 result["jobs"] = job_output_txt
                 job_ret_code = job_output_txt[0].get("ret_code")
-                job_ret_code.update({"msg_txt": _msg_suffix})
-            result["msg"] = _msg
-            module.exit_json(**result)
 
-        # Job has submitted, the module changed the managed node
-        is_changed = True
+                if job_ret_code:
+                    job_ret_code_msg = job_ret_code.get("msg")
+                    job_ret_code_code = job_ret_code.get("code")
+                    job_ret_code_msg_code = job_ret_code.get("msg_code")
 
-        if job_output_txt:
-            result["jobs"] = job_output_txt
-            job_ret_code = job_output_txt[0].get("ret_code")
+                    if return_output is True and max_rc is not None:
+                        is_changed = assert_valid_return_code(max_rc, job_ret_code_code, job_ret_code, result)
 
-            if job_ret_code:
-                job_ret_code_msg = job_ret_code.get("msg")
-                job_ret_code_code = job_ret_code.get("code")
-                job_ret_code_msg_code = job_ret_code.get("msg_code")
+                    if job_ret_code_msg is not None:
+                        if re.search("^(?:{0})".format("|".join(JOB_STATUSES)), job_ret_code_msg):
+                            # If the job_ret_code_msg doesn't have a CC (completion code), the job failed.
+                            if re.search("^(?:CC)", job_ret_code_msg) is None:
+                                _msg = ("The job completion code (CC) was not in the job log. "
+                                        "please review the job log for status {0}.".format(job_ret_code_msg))
+                                result["stderr"] = _msg
+                                job_ret_code.update({"msg_txt": _msg})
+                                raise Exception(_msg)
 
-                if return_output is True and max_rc is not None:
-                    is_changed = assert_valid_return_code(max_rc, job_ret_code_code, job_ret_code, result)
+                    if job_ret_code_code is None:
+                        # If there is no job_ret_code_code (Job return code) it may NOT be an error,
+                        # some jobs will never return have an RC, eg Jobs with TYPRUN=*,
+                        # Started tasks (which are not supported) so further analyze the
+                        # JESJCL DD to figure out if its a TYPRUN job
 
-                if job_ret_code_msg is not None:
-                    if re.search("^(?:{0})".format("|".join(JOB_STATUSES)), job_ret_code_msg):
-                        # If the job_ret_code_msg doesn't have a CC (completion code), the job failed.
-                        if re.search("^(?:CC)", job_ret_code_msg) is None:
-                            _msg = ("The job completion code (CC) was not in the job log. "
-                                    "please review the job log for status {0}.".format(job_ret_code_msg))
-                            result["stderr"] = _msg
-                            job_ret_code.update({"msg_txt": _msg})
-                            raise Exception(_msg)
+                        job_dd_names = job_output_txt[0].get("ddnames")
+                        jes_jcl_dd = search_dictionaries("ddname", "JESJCL", job_dd_names)
 
-                if job_ret_code_code is None:
-                    # If there is no job_ret_code_code (Job return code) it may NOT be an error,
-                    # some jobs will never return have an RC, eg Jobs with TYPRUN=*,
-                    # Started tasks (which are not supported) so further analyze the
-                    # JESJCL DD to figure out if its a TYPRUN job
-
-                    job_dd_names = job_output_txt[0].get("ddnames")
-                    jes_jcl_dd = search_dictionaries("ddname", "JESJCL", job_dd_names)
-
-                    # Its possible jobs don't have a JESJCL which are active and this would
-                    # cause an index out of range error.
-                    if not jes_jcl_dd:
-                        _msg_detail = " for status {0}.".format(job_ret_code_msg) if job_ret_code_msg else "."
-                        _msg = ("The job return code was not available in the job log, "
-                                "please review the job log{0}".format(_msg_detail))
-                        job_ret_code.update({"msg_txt": _msg})
-                        raise Exception(_msg)
-
-                    jes_jcl_dd_content = jes_jcl_dd[0].get("content")
-                    jes_jcl_dd_content_str = " ".join(jes_jcl_dd_content)
-
-                    # The regex can be r"({0})\s*=\s*(COPY|HOLD|JCLHOLD|SCAN)" once zoau support is in.
-                    special_processing_keyword = re.search(r"({0})\s*=\s*(SCAN)"
-                                                           .format("|".join(JOB_SPECIAL_PROCESSING)), jes_jcl_dd_content_str)
-
-                    if special_processing_keyword:
-                        job_ret_code.update({"msg": special_processing_keyword[0]})
-                        job_ret_code.update({"code": None})
-                        job_ret_code.update({"msg_code": None})
-                        job_ret_code.update({"msg_txt": "The job {0} was run with special job "
-                                             "processing {1}. This will result in no completion, "
-                                             "return code or job steps and changed will be false."
-                                             .format(job_submitted_id, special_processing_keyword[0])})
-                        is_changed = False
-                    else:
-                        # The job_ret_code_code is None at this point, but the job_ret_code_msg_code could be populated
-                        # so check both and provide a proper response.
-
-                        if job_ret_code_msg_code is None:
+                        # Its possible jobs don't have a JESJCL which are active and this would
+                        # cause an index out of range error.
+                        if not jes_jcl_dd:
                             _msg_detail = " for status {0}.".format(job_ret_code_msg) if job_ret_code_msg else "."
                             _msg = ("The job return code was not available in the job log, "
                                     "please review the job log{0}".format(_msg_detail))
                             job_ret_code.update({"msg_txt": _msg})
                             raise Exception(_msg)
 
-                        # raise Exception("The job return code was not available in the job log, "
-                        #                 "please review the job log and error {0}.".format(job_ret_code_msg))
-                elif job_ret_code_code != 0 and max_rc is None:
-                    _msg = ("The job return code {0} was non-zero in the "
-                            "job output, this job has failed.".format(str(job_ret_code_code)))
-                    job_ret_code.update({"msg_txt": _msg})
+                        jes_jcl_dd_content = jes_jcl_dd[0].get("content")
+                        jes_jcl_dd_content_str = " ".join(jes_jcl_dd_content)
+
+                        # The regex can be r"({0})\s*=\s*(COPY|HOLD|JCLHOLD|SCAN)" once zoau support is in.
+                        special_processing_keyword = re.search(r"({0})\s*=\s*(SCAN)"
+                                                               .format("|".join(JOB_SPECIAL_PROCESSING)), jes_jcl_dd_content_str)
+
+                        if special_processing_keyword:
+                            job_ret_code.update({"msg": special_processing_keyword[0]})
+                            job_ret_code.update({"code": None})
+                            job_ret_code.update({"msg_code": None})
+                            job_ret_code.update({"msg_txt": "The job {0} was run with special job "
+                                                 "processing {1}. This will result in no completion, "
+                                                 "return code or job steps and changed will be false."
+                                                 .format(job_submitted_id, special_processing_keyword[0])})
+                            is_changed = False
+                        else:
+                            # The job_ret_code_code is None at this point, but the job_ret_code_msg_code could be populated
+                            # so check both and provide a proper response.
+
+                            if job_ret_code_msg_code is None:
+                                _msg_detail = " for status {0}.".format(job_ret_code_msg) if job_ret_code_msg else "."
+                                _msg = ("The job return code was not available in the job log, "
+                                        "please review the job log{0}".format(_msg_detail))
+                                job_ret_code.update({"msg_txt": _msg})
+                                raise Exception(_msg)
+
+                            # raise Exception("The job return code was not available in the job log, "
+                            #                 "please review the job log and error {0}.".format(job_ret_code_msg))
+                    elif job_ret_code_code != 0 and max_rc is None:
+                        _msg = ("The job return code {0} was non-zero in the "
+                                "job output, this job has failed.".format(str(job_ret_code_code)))
+                        job_ret_code.update({"msg_txt": _msg})
+                        result["stderr"] = _msg
+                        raise Exception(_msg)
+
+                    if not return_output:
+                        for job in result.get("jobs", []):
+                            job["ddnames"] = []
+                else:
+                    _msg = "The 'ret_code' dictionary was unavailable in the job log."
+                    result["ret_code"] = None
                     result["stderr"] = _msg
                     raise Exception(_msg)
-
-                if not return_output:
-                    for job in result.get("jobs", []):
-                        job["ddnames"] = []
             else:
-                _msg = "The 'ret_code' dictionary was unavailable in the job log."
-                result["ret_code"] = None
+                _msg = "The job output log is unavailable."
                 result["stderr"] = _msg
+                result["jobs"] = None
                 raise Exception(_msg)
-        else:
-            _msg = "The job output log is unavailable."
-            result["stderr"] = _msg
-            result["jobs"] = None
-            raise Exception(_msg)
-    except Exception as err:
-        result["failed"] = True
-        result["changed"] = False
-        result["msg"] = ("The JCL submitted with job id {0} but "
-                         "there was an error, please review "
-                         "the error for further details: {1}".format
-                         (str(job_submitted_id), to_text(err)))
-        module.exit_json(**result)
+        except Exception as err:
+            result["failed"] = True
+            result["changed"] = False
+            result["msg"] = ("The JCL submitted with job id {0} but "
+                             "there was an error, please review "
+                             "the error for further details: {1}".format
+                             (str(job_submitted_id), to_text(err)))
+            module.exit_json(**result)
 
-    finally:
-        if temp_file is not None:
-            remove(temp_file)
+        finally:
+            if temp_file is not None:
+                remove(temp_file)
 
     # If max_rc is set, we don't want to default to changed=True, rely on 'is_changed'
     result["changed"] = True if is_changed else False

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -69,7 +69,7 @@ options:
         node.
       - I(wait_time_s) is measured in seconds and must be a value greater than 0
         and less than 86400.
-      - The module can submit and forget by setting I(wait_time_s) to 0. This way the
+      - The module can submit and forget jobs by setting I(wait_time_s) to 0. This way the
         module will not try to retrieve the job details other than job id.
         Job details and contents can be retrieved later by using
         L(zos_job_query,./zos_job_query.html) or L(zos_job_output,./zos_job_output.html)

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -997,6 +997,7 @@ def run_module():
 
     # Default 'changed' is False in case the module is not able to execute
     result = dict(changed=False)
+    # Builds return value schema to make sure we return the return values schema.
     result = build_return_schema(result)
 
     if wait_time_s < 0 or wait_time_s > MAX_WAIT_TIME_S:
@@ -1045,7 +1046,6 @@ def run_module():
     # used and return undersirable results
     job_output_txt = None
     result['job_id'] = job_submitted_id
-    # Populate return schema to not have a conditional return schema.
     is_changed = True
     # If wait_time_s is 0, we do a deploy and forget strategy.
     if wait_time_s != 0:

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -249,6 +249,8 @@ jobs:
             - Job status `SEC` or `SEC ERROR` indicates the job as encountered a security error.
             - Job status `SYS` indicates a system failure.
             - Job status `?` indicates status can not be determined.
+            - Job status `TYPRUN=SCAN` indicates that the job had the TYPRUN parameter with SCAN option.
+            - Job status `NOEXEC` indicates that the job had the TYPRUN parameter with COPY option.
             - Jobs where status can not be determined will result in None (NULL).
           type: str
           sample: AC

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -942,15 +942,18 @@ def test_job_submit_local_jcl_typrun_copy(ansible_zos_module):
                                             "to": "IBM-1047"
                                         },)
     for result in results.contacted.values():
-        assert result.get("changed") is False
+        # With ZOAU 1.3.3 changes now code and return msg_code are 0 and 0000 respectively.
+        # assert result.get("changed") is False
+        # When running a job with TYPRUN=COPY, a copy of the JCL will be kept in the JES spool, so
+        # effectively, the system is changed even though the job didn't run.
+        assert result.get("changed") is True
         assert result.get("jobs")[0].get("job_id") is not None
         assert re.search(
-            r'please review the job log',
+            r'The job was run with TYPRUN=COPY.',
             repr(result.get("jobs")[0].get("ret_code").get("msg_txt"))
         )
-        # With ZOAU 1.3.3 changes now code and return msg_code are 0 and 0000 respectively.
         assert result.get("jobs")[0].get("ret_code").get("code") == 0
-        assert result.get("jobs")[0].get("ret_code").get("msg") == 'NOEXEC'
+        assert result.get("jobs")[0].get("ret_code").get("msg") == 'TYPRUN=COPY'
         assert result.get("jobs")[0].get("ret_code").get("msg_code") == '0000'
         # assert result.get("jobs")[0].get("ret_code").get("code") is None
         # assert result.get("jobs")[0].get("ret_code").get("msg") is None

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -487,6 +487,47 @@ def test_job_submit_uss(ansible_zos_module):
         hosts.all.file(path=temp_path, state="absent")
 
 
+def test_job_submit_and_forget_uss(ansible_zos_module):
+    try:
+        hosts = ansible_zos_module
+        temp_path = get_random_file_name(dir=TMP_DIRECTORY)
+        hosts.all.file(path=temp_path, state="directory")
+        hosts.all.shell(
+            cmd="echo {0} > {1}/SAMPLE".format(quote(JCL_FILE_CONTENTS), temp_path)
+        )
+        results = hosts.all.zos_job_submit(
+            src=f"{temp_path}/SAMPLE", location="uss", volume=None, wait_time_s=0,
+        )
+        for result in results.contacted.values():
+            assert result.get("job_id") is not None
+            assert result.get("changed") is True
+            assert len(result.get("jobs")) == 0
+            assert result.get("job_name") is None
+            assert result.get("duration") is None
+            assert result.get("ddnames") is not None
+            assert result.get("ddnames").get("ddname") is None
+            assert result.get("ddnames").get("record_count") is None
+            assert result.get("ddnames").get("id") is None
+            assert result.get("ddnames").get("stepname") is None
+            assert result.get("ddnames").get("procstep") is None
+            assert result.get("ddnames").get("byte_count") is None
+            assert len(result.get("ddnames").get("content")) == 0  
+            assert result.get("ret_code") is not None
+            assert result.get("ret_code").get("msg") is None
+            assert result.get("ret_code").get("msg_code") is None
+            assert result.get("ret_code").get("code") is None
+            assert len(result.get("ret_code").get("steps")) == 0 
+            assert result.get("job_class") is None
+            assert result.get("svc_class") is None
+            assert result.get("priority") is None
+            assert result.get("asid") is None
+            assert result.get("creation_time") is None
+            assert result.get("queue_position") is None
+            assert result.get("program_name") is None
+    finally:
+        hosts.all.file(path=temp_path, state="absent")
+
+
 def test_job_submit_local(ansible_zos_module):
     tmp_file = tempfile.NamedTemporaryFile(delete=True)
     with open(tmp_file.name, "w",encoding="utf-8") as f:

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -948,9 +948,13 @@ def test_job_submit_local_jcl_typrun_copy(ansible_zos_module):
             r'please review the job log',
             repr(result.get("jobs")[0].get("ret_code").get("msg_txt"))
         )
-        assert result.get("jobs")[0].get("ret_code").get("code") is None
-        assert result.get("jobs")[0].get("ret_code").get("msg") is None
-        assert result.get("jobs")[0].get("ret_code").get("msg_code") is None
+        # With ZOAU 1.3.3 changes now code and return msg_code are 0 and 0000 respectively.
+        assert result.get("jobs")[0].get("ret_code").get("code") == 0
+        assert result.get("jobs")[0].get("ret_code").get("msg") == 'NOEXEC'
+        assert result.get("jobs")[0].get("ret_code").get("msg_code") == '0000'
+        # assert result.get("jobs")[0].get("ret_code").get("code") is None
+        # assert result.get("jobs")[0].get("ret_code").get("msg") is None
+        # assert result.get("jobs")[0].get("ret_code").get("msg_code") is None
 
 
 def test_job_submit_local_jcl_typrun_hold(ansible_zos_module):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add deploy and forget capability to zos_job_submit. When `wait_time_s` is equal to 0, the module will only submit the job and not wait to pick additional details like job name, ret_code and so on.

We will still return the values in the result dictionary, for that we create an empty schema to make sure we return those values as empty when we don't explicitly modify them.

Created a new test case that calls the module with `wait_time_s` as 0 (this would previously fail) and asserts that we the schema is in place.


Also modified a few things that changed when ZOAU implemented the TYPRUN=SCAN enhancement, however, they set NOEXEC status for both TYPRUN=SCAN and TYPRUN=COPY. So had to change the test case and add the entry into the docs.

Left some comments in the test case for TYPRUN that are intended to be addressed in #1737 

NOTE: **The PR seems a bit strange in GitHub but there are not as many changes as it may seem, I only indented some portions of the code with under an if. Read carefully and you may notice that I didn't remove much code other that a couple of lines, if it seems like it do search for the same line in the new added sections. is just an illusion.**



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue --> 
Fixes #715 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_submit 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
