### PR TITLE
[v1.12.0][Bug]Return system and subsystem in zos_job_query

### DIFF
--- a/changelogs/fragments/1761-system-subsystem-job_query.yml
+++ b/changelogs/fragments/1761-system-subsystem-job_query.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - zos_job_query - Module was not returning values for system and subsystem. Fix now returns these values.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1761).

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -240,7 +240,6 @@ def job_status(job_id=None, owner=None, job_name=None, dd_name=None):
         job_id=job_id,
         owner=owner,
         job_name=job_name,
-        dd_scan=False
     )
 
     if len(job_status_result) == 0:
@@ -252,7 +251,6 @@ def job_status(job_id=None, owner=None, job_name=None, dd_name=None):
             job_id=job_id,
             owner=owner,
             job_name=job_name,
-            dd_scan=False
         )
 
     return job_status_result

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -124,6 +124,16 @@ jobs:
          Type of address space used by the job.
       type: str
       sample: STC
+    system:
+      description:
+         The job entry system that MVS uses to do work.
+      type: str
+      sample: STL1
+    subsystem:
+      description:
+         The job entry subsystem that MVS uses to do work.
+      type: str
+      sample: STL1
     ret_code:
       description:
          Return code output collected from job log.

--- a/tests/functional/modules/test_zos_job_query_func.py
+++ b/tests/functional/modules/test_zos_job_query_func.py
@@ -93,6 +93,8 @@ def test_zos_job_id_query_multi_wildcards_func(ansible_zos_module):
             qresults = hosts.all.zos_job_query(job_id=jobmask)
             for qresult in qresults.contacted.values():
                 assert qresult.get("jobs") is not None
+                assert qresult.get("jobs")[0].get("system") is not None
+                assert qresult.get("jobs")[0].get("subsystem") is not None
 
     finally:
         hosts.all.file(path=temp_path, state="absent")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enabled the dd scan when fetching a job status, while this is less performant it enables us to fetch both SYSTEM and NODE values from JES output.

We know that this won't be the same final implementation that will go into dev branch since we have requested ZOAU to provide these values when fetching the job list instead of us parsing the JES output.

Same as https://github.com/ansible-collections/ibm_zos_core/pull/1723 but this time for dev branch.

Fixes https://github.com/ansible-collections/ibm_zos_core/issues/1681

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_query

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
