### PR TITLE
[Bugfix] [zos_mvs_raw] [Tests] Added correct dataset size in zos_mvs_raw test

### DIFF
--- a/changelogs/fragments/1775-zos_mvs_raw-size-tests.yml
+++ b/changelogs/fragments/1775-zos_mvs_raw-size-tests.yml
@@ -1,0 +1,4 @@
+trivial:
+  - test_zos_mvs_raw_func.py - Correct the size used when allocating datasets inside
+    the test suite.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1775).

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -355,7 +355,7 @@ def test_normal_dispositions_data_set(
         ("cyl", 3, 1, 2549880),
         ("b", 3, 1, 56664),
         ("k", 3, 1, 56664),
-        ("m", 3, 1, 3003192),
+        ("m", 3, 1, 3173184),
     ],
 )
 def test_space_types(ansible_zos_module, space_type, primary, secondary, expected):


### PR DESCRIPTION
##### SUMMARY
Fixes size used for datasets in the test suite.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
zos_mvs_raw

##### ADDITIONAL INFORMATION
Pipeline results:

![Screenshot 2024-10-29 at 16 08 52](https://github.com/user-attachments/assets/ae8ae622-ad73-4a86-9212-e0328c6a9102)
![Screenshot 2024-10-29 at 16 09 02](https://github.com/user-attachments/assets/ecbb3ac6-488c-4f9d-b007-b88865d7e17a)

