### PR TITLE
[1.12.0][Bug][zos_mvs_raw] Bugfix/zos mvs raw verbose 1.12

### DIFF
--- a/changelogs/fragments/1774-zos_mvs_raw-verbose-fail.yml
+++ b/changelogs/fragments/1774-zos_mvs_raw-verbose-fail.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - zos_mvs_raw - If a program failed with a non-zero return code and verbose was false, the module would succeed.
+    Whereas, if the program failed and verbose was true the module would fail.
+    Fix now has a consistent behavior and fails in both cases.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1774).
+  - zos_mvs_raw - Module would obfuscate the return code from the program when failing returning 8 instead.
+    Fix now returns the proper return code from the program.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1774).

--- a/changelogs/fragments/1780-zos_mvs_raw-verbose-fail.yml
+++ b/changelogs/fragments/1780-zos_mvs_raw-verbose-fail.yml
@@ -2,7 +2,7 @@ bugfixes:
   - zos_mvs_raw - If a program failed with a non-zero return code and verbose was false, the module would succeed.
     Whereas, if the program failed and verbose was true the module would fail.
     Fix now has a consistent behavior and fails in both cases.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1774).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1780).
   - zos_mvs_raw - Module would obfuscate the return code from the program when failing returning 8 instead.
     Fix now returns the proper return code from the program.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1774).
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1780).

--- a/changelogs/fragments/1780-zos_mvs_raw-verbose-fail.yml
+++ b/changelogs/fragments/1780-zos_mvs_raw-verbose-fail.yml
@@ -1,5 +1,5 @@
 bugfixes:
-  - zos_mvs_raw - If a program failed with a non-zero return code and verbose was false, the module would succeed.
+  - zos_mvs_raw - If a program failed with a non-zero return code and verbose was false, the module would succeed (false positive).
     Whereas, if the program failed and verbose was true the module would fail.
     Fix now has a consistent behavior and fails in both cases.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1780).

--- a/changelogs/fragments/1780-zos_mvs_raw-verbose-fail.yml
+++ b/changelogs/fragments/1780-zos_mvs_raw-verbose-fail.yml
@@ -1,6 +1,6 @@
 bugfixes:
   - zos_mvs_raw - If a program failed with a non-zero return code and verbose was false, the module would succeed (false positive).
-    Fix now has a consistent behavior and fails in both cases.
+    Fix now fails the module for all instances where a program has a non-zero return code.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1780).
   - zos_mvs_raw - Module would obfuscate the return code from the program when failing returning 8 instead.
     Fix now returns the proper return code from the program.

--- a/changelogs/fragments/1780-zos_mvs_raw-verbose-fail.yml
+++ b/changelogs/fragments/1780-zos_mvs_raw-verbose-fail.yml
@@ -1,6 +1,5 @@
 bugfixes:
   - zos_mvs_raw - If a program failed with a non-zero return code and verbose was false, the module would succeed (false positive).
-    Whereas, if the program failed and verbose was true the module would fail.
     Fix now has a consistent behavior and fails in both cases.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1780).
   - zos_mvs_raw - Module would obfuscate the return code from the program when failing returning 8 instead.

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -22,6 +22,7 @@ module: zos_mvs_raw
 author:
   - "Xiao Yuan Ma (@bjmaxy)"
   - "Blake Becker (@blakeinate)"
+  - "Oscar Fernando Flores (@fernandofloresg)"
 short_description: Run a z/OS program.
 description:
   - Run a z/OS program.
@@ -1897,21 +1898,21 @@ def run_module():
                 verbose=verbose,
                 tmphlq=tmphlq,
             )
-            if program_response.rc != 0 and program_response.stderr:
+            response = build_response(program_response.rc, dd_statements, program_response.stdout)
+            result = combine_dicts(result, response)
+            if program_response.rc != 0 :
                 raise ZOSRawError(
                     program,
                     "{0} {1}".format(program_response.stdout, program_response.stderr),
                 )
 
-            response = build_response(program_response.rc, dd_statements, program_response.stdout)
             result["changed"] = True
         except Exception as e:
             result["backups"] = backups
             module.fail_json(msg=repr(e), **result)
     else:
         result = dict(changed=True, dd_names=[], ret_code=dict(code=0))
-    to_return = combine_dicts(result, response)
-    module.exit_json(**to_return)
+    module.exit_json(**result)
     # ---------------------------------------------------------------------------- #
 
 

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -2281,7 +2281,7 @@ def test_authorized_program_run_authorized(ansible_zos_module, verbose):
         results = hosts.all.zos_mvs_raw(
             program_name="idcams",
             auth=True,
-            verbose=True,
+            verbose=verbose,
             dds=[
                 {
                     "dd_output":{

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -2269,7 +2269,7 @@ def test_unauthorized_program_run_authorized(ansible_zos_module):
 
 @pytest.mark.parametrize(
         # Added this verbose to test issue https://github.com/ansible-collections/ibm_zos_core/issues/1359
-        # Where a program will fail if rc != 0 only if verbose was True.
+        # Where previously a program would NOT fail when rc != 0 unless verbose was True.
         "verbose",
         [True, False],
 )

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -59,8 +59,13 @@ def test_failing_name_format(ansible_zos_module):
     for result in results.contacted.values():
         assert "ValueError" in result.get("msg")
 
-
-def test_disposition_new(ansible_zos_module):
+@pytest.mark.parametrize(
+        # Added this verbose to test issue https://github.com/ansible-collections/ibm_zos_core/issues/1359
+        # Where a program will fail if rc != 0 only if verbose was True.
+        "verbose",
+        [True, False],
+)
+def test_disposition_new(ansible_zos_module, verbose):
     idcams_dataset = None
     try:
         hosts = ansible_zos_module
@@ -71,6 +76,7 @@ def test_disposition_new(ansible_zos_module):
         results = hosts.all.zos_mvs_raw(
             program_name="idcams",
             auth=True,
+            verbose=verbose,
             dds=[
                 {
                     "dd_data_set":{
@@ -94,6 +100,7 @@ def test_disposition_new(ansible_zos_module):
         for result in results.contacted.values():
             assert result.get("ret_code", {}).get("code", -1) == 0
             assert len(result.get("dd_names", [])) > 0
+            assert result.get("failed", False) is False
     finally:
         hosts.all.zos_data_set(name=default_data_set, state="absent")
         if idcams_dataset:
@@ -2236,7 +2243,7 @@ def test_authorized_program_run_unauthorized(ansible_zos_module):
             dds=[],
         )
         for result in results.contacted.values():
-            assert result.get("ret_code", {}).get("code", -1) == 8
+            assert result.get("ret_code", {}).get("code", -1) == 36
             assert len(result.get("dd_names", [])) == 0
             assert "BGYSC0236E" in result.get("msg", "")
     finally:
@@ -2254,14 +2261,19 @@ def test_unauthorized_program_run_authorized(ansible_zos_module):
             dds=[],
         )
         for result in results.contacted.values():
-            assert result.get("ret_code", {}).get("code", -1) == 8
+            assert result.get("ret_code", {}).get("code", -1) == 15
             assert len(result.get("dd_names", [])) == 0
             assert "BGYSC0215E" in result.get("msg", "")
     finally:
         hosts.all.zos_data_set(name=default_data_set, state="absent")
 
-
-def test_authorized_program_run_authorized(ansible_zos_module):
+@pytest.mark.parametrize(
+        # Added this verbose to test issue https://github.com/ansible-collections/ibm_zos_core/issues/1359
+        # Where a program will fail if rc != 0 only if verbose was True.
+        "verbose",
+        [True, False],
+)
+def test_authorized_program_run_authorized(ansible_zos_module, verbose):
     try:
         hosts = ansible_zos_module
         default_data_set = get_tmp_ds_name()
@@ -2269,6 +2281,7 @@ def test_authorized_program_run_authorized(ansible_zos_module):
         results = hosts.all.zos_mvs_raw(
             program_name="idcams",
             auth=True,
+            verbose=True,
             dds=[
                 {
                     "dd_output":{

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -61,7 +61,7 @@ def test_failing_name_format(ansible_zos_module):
 
 @pytest.mark.parametrize(
         # Added this verbose to test issue https://github.com/ansible-collections/ibm_zos_core/issues/1359
-        # Where a program will fail if rc != 0 only if verbose was True.
+        # Where previously a program would NOT fail when rc != 0 unless verbose was True.
         "verbose",
         [True, False],
 )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Looks like mvccmd utility won't return anything in the stderr even if a program executed fails, so we only changed and if statement.

Changing that statement from 'and' to 'or' will in theory, fail any non-zero programs, which is better than having them fail only when verbose=True. Anyways, there is a task in the backlog to add a max_rc option to the module, so we can polish this mechanism there.

While testing this noticed that the module will hide the return code coming from the program if it fail, returning 8 as return code instead, fixed that and had to change some test cases that were expecting a wrong return code.

**NOTE: This was not originally added into the beta release because there was no time to test the fix with latest code. Good thing that we did, because we found and edge case. **


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- 
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_mvs_raw


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
