### PR TITLE
[v1.11.1][Bug][zos_mvs_raw] Multiple fixes

### DIFF
--- a/changelogs/fragments/1799-zos_mvs_raw-verbose-fail.yml
+++ b/changelogs/fragments/1799-zos_mvs_raw-verbose-fail.yml
@@ -6,6 +6,6 @@ bugfixes:
   - zos_mvs_raw - Module would obfuscate the return code from the program when failing returning 8 instead.
     Fix now returns the proper return code from the program.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1799).
-  - zos_mvs_raw - The module would return the stderr content in stdout when verbose was true and return code was 0.
+  - zos_mvs_raw - Module would return the stderr content in stdout when verbose was true and return code was 0.
     Fix now does not replace stdout content with stderr.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1799).

--- a/changelogs/fragments/1799-zos_mvs_raw-verbose-fail.yml
+++ b/changelogs/fragments/1799-zos_mvs_raw-verbose-fail.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - zos_mvs_raw - If a program failed with a non-zero return code and verbose was false, the module would succeed.
+    Whereas, if the program failed and verbose was true the module would fail.
+    Fix now has a consistent behavior and fails in both cases.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1799).
+  - zos_mvs_raw - Module would obfuscate the return code from the program when failing returning 8 instead.
+    Fix now returns the proper return code from the program.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1799).

--- a/changelogs/fragments/1799-zos_mvs_raw-verbose-fail.yml
+++ b/changelogs/fragments/1799-zos_mvs_raw-verbose-fail.yml
@@ -1,8 +1,11 @@
 bugfixes:
   - zos_mvs_raw - If a program failed with a non-zero return code and verbose was false, the module would succeed.
-    Whereas, if the program failed and verbose was true the module would fail.
+    Whereas, if the program failed and verbose was true the module would fail(false positive).
     Fix now has a consistent behavior and fails in both cases.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1799).
   - zos_mvs_raw - Module would obfuscate the return code from the program when failing returning 8 instead.
     Fix now returns the proper return code from the program.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1799).
+  - zos_mvs_raw - The module would return the stderr content in stdout when verbose was true and return code was 0.
+    Fix now does not replace stdout content with stderr.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1799).

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -60,8 +60,6 @@ class MVSCmd(object):
             MVSCmd._build_command(pgm, dds, parm),
         )
         rc, out, err = module.run_command(command)
-        if rc == 0 and verbose:
-            out = err
         return MVSCmdResponse(rc, out, err)
 
     @staticmethod
@@ -92,8 +90,6 @@ class MVSCmd(object):
             MVSCmd._build_command(pgm, dds, parm),
         )
         rc, out, err = module.run_command(command)
-        if rc == 0 and verbose:
-            out = err
         return MVSCmdResponse(rc, out, err)
 
     @staticmethod

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1897,7 +1897,7 @@ def run_module():
             )
             response = build_response(program_response.rc, dd_statements, program_response.stdout)
             result = combine_dicts(result, response)
-            if program_response.rc != 0 :
+            if program_response.rc != 0:
                 raise ZOSRawError(
                     program,
                     "{0} {1}".format(program_response.stdout, program_response.stderr),

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -22,6 +22,7 @@ module: zos_mvs_raw
 author:
   - "Xiao Yuan Ma (@bjmaxy)"
   - "Blake Becker (@blakeinate)"
+  - "Oscar Fernando Flores (@fernandofloresg)"
 short_description: Run a z/OS program.
 description:
   - Run a z/OS program.
@@ -1894,21 +1895,21 @@ def run_module():
                 verbose=verbose,
                 tmphlq=tmphlq,
             )
-            if program_response.rc != 0 and program_response.stderr:
+            response = build_response(program_response.rc, dd_statements, program_response.stdout)
+            result = combine_dicts(result, response)
+            if program_response.rc != 0 :
                 raise ZOSRawError(
                     program,
                     "{0} {1}".format(program_response.stdout, program_response.stderr),
                 )
 
-            response = build_response(program_response.rc, dd_statements, program_response.stdout)
             result["changed"] = True
         except Exception as e:
             result["backups"] = backups
             module.fail_json(msg=repr(e), **result)
     else:
         result = dict(changed=True, dd_names=[], ret_code=dict(code=0))
-    to_return = combine_dicts(result, response)
-    module.exit_json(**to_return)
+    module.exit_json(**result)
     # ---------------------------------------------------------------------------- #
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix False positive when RC != 0 and verbosity is false, fix not obfuscate program return codes when failing and stdout replaced by stderr.


## First bug: Module would return stderr in stdout when verbosity true and rc = 0

This fix was originally planned to be in v1.11.1 just to remove the following lines from the code:

```python
        if rc == 0 and verbose:
            out = err
```

This issue was reported by the CICS collection, after testing the module I was not able to find a case that returned some output in `stdout` when the command `mvscmd` ran successfully. So why was CICS experiencing issues with this change? That is because they are using `mvscmd.execute` function directly, now, our collection is not intended to be used as a library, but if they are using it is fine, we are not reverting this change to support them, we are reverting this change because it is legitimately a bug from users perspective, to get `stderr` content in `stdout` when `verbose` is true and return code is 0.

Because of that, I was not able to create a test case that didn't involve checking that `stdout` was not containing results from `stderr`, in my opinion that would be a redundant test case, because we always return the `stdout` in some `dd_output` inside `dd_names`.

However, I got Andrew Hughes from CICS collection team to test this branch and they are not having issues with it anymore, hence I'm not adding a test case for this. If you think differently, let me know and I can find a way to create a test case.


## Second bug 

Looks like mvccmd utility won't return anything in the stderr even if a program executed fails, so we only changed and if statement.

Changing that statement from 'and' to only fail any non-zero programs, is better than having them fail only when verbose=True. Anyways, there is a task in the backlog to add a max_rc option to the module, so we can polish this mechanism there.

## Third bug

While testing this noticed that the module will hide the return code coming from the program if it fail, returning 8 as return code instead, fixed that and had to change some test cases that were expecting a wrong return code.



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1797 
Fixes #1798 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_mvs_raw
