### PR TITLE
[v1.12.0][Bug][zos_mvs_raw] Remove stdout being replaced by stderr when RC=0 and verbosity is true

### DIFF
--- a/changelogs/fragments/1800-zos_mvs_raw-stdout-replaced-by-stderr.yml
+++ b/changelogs/fragments/1800-zos_mvs_raw-stdout-replaced-by-stderr.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_mvs_raw - Module would return the stderr content in stdout when verbose was true and return code was 0.
+    Fix now does not replace stdout content with stderr.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1800).
+

--- a/plugins/module_utils/zos_mvs_raw.py
+++ b/plugins/module_utils/zos_mvs_raw.py
@@ -60,8 +60,6 @@ class MVSCmd(object):
             MVSCmd._build_command(pgm, dds, parm),
         )
         rc, out, err = module.run_command(command, errors='replace')
-        if rc == 0 and verbose:
-            out = err
         return MVSCmdResponse(rc, out, err)
 
     @staticmethod
@@ -92,8 +90,6 @@ class MVSCmd(object):
             MVSCmd._build_command(pgm, dds, parm),
         )
         rc, out, err = module.run_command(command, errors='replace')
-        if rc == 0 and verbose:
-            out = err
         return MVSCmdResponse(rc, out, err)
 
     @staticmethod


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
**This is the same fix as** #1794

Module would return stderr in stdout when verbosity true and rc = 0

This fix was originally planned to be in v1.11.1 just to remove the following lines from the code:

```python
        if rc == 0 and verbose:
            out = err
```

This issue was reported by the CICS collection, after testing the module I was not able to find a case that returned some output in `stdout` when the command `mvscmd` ran successfully. So why was CICS experiencing issues with this change? That is because they are using `mvscmd.execute` function directly, now, our collection is not intended to be used as a library, but if they are using it is fine, we are not reverting this change to support them, we are reverting this change because it is legitimately a bug from users perspective, to get `stderr` content in `stdout` when `verbose` is true and return code is 0.

Because of that, I was not able to create a test case that didn't involve checking that `stdout` was not containing results from `stderr`, in my opinion that would be a redundant test case, because we always return the `stdout` in some `dd_output` inside `dd_names`.

However, I got Andrew Hughes from CICS collection team to test this branch and they are not having issues with it anymore, hence I'm not adding a test case for this. If you think differently, let me know and I can find a way to create a test case.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1796 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_mvs_raw

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
