### PR TITLE
[v1.9.4][Bug][zos_mvs_raw]Fix fail when return code is 0 and verbose is True

### DIFF
--- a/changelogs/fragments/1801-zos_mvs_raw-fail-when-rc-is-0-and-verbose-true.yml
+++ b/changelogs/fragments/1801-zos_mvs_raw-fail-when-rc-is-0-and-verbose-true.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - zos_mvs_raw - If a program return code was 0 and verbose was true, the module will fail. Fix now will not fail the module. 
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1801).

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1852,7 +1852,7 @@ def run_module():
             response = build_response(program_response.rc, dd_statements)
             result = combine_dicts(result, response)
 
-            if program_response.rc != 0 or program_response.stderr:
+            if program_response.rc != 0:
                 raise ZOSRawError(
                     program,
                     "{0} {1}".format(program_response.stdout, program_response.stderr),

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -47,8 +47,11 @@ def test_failing_name_format(ansible_zos_module):
         pprint(result)
         assert "ValueError" in result.get("msg")
 
-
-def test_disposition_new(ansible_zos_module):
+@pytest.mark.parametrize(
+    "verbose",
+    [True, False],
+)
+def test_disposition_new(ansible_zos_module, verbose):
     try:
         hosts = ansible_zos_module
         default_data_set = get_tmp_ds_name()
@@ -56,6 +59,7 @@ def test_disposition_new(ansible_zos_module):
         results = hosts.all.zos_mvs_raw(
             program_name="idcams",
             auth=True,
+            verbose=verbose,
             dds=[
                 dict(
                     dd_data_set=dict(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With the release v1.9.3 a new bug was introduced, that when a program exits with return code 0 and verbose is True, the module will fail because `stderr` is populated.

Now since mvscmd uses stderr to display verbose messages the module will not use it as a criteria for failure.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1793 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_mvs_raw
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
