### PR TITLE
[Enhancement][1765]enhance_error_message_when_faiiling_to_import

### DIFF
--- a/changelogs/fragments/1804_enhance_error_message_when_failing_import.yml
+++ b/changelogs/fragments/1804_enhance_error_message_when_failing_import.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - module_utils/import_handler - Change function call to ensure get full traceback when failing import.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1804).

--- a/changelogs/fragments/1804_enhance_error_message_when_failing_import.yml
+++ b/changelogs/fragments/1804_enhance_error_message_when_failing_import.yml
@@ -1,3 +1,4 @@
 minor_changes:
-  - module_utils/import_handler - Change function call to ensure get full traceback when failing import.
+  - module_utils/import_handler - When importing a non supported ZOAU version like 1.2.x the module would throw a non user friendly error message.
+    Error message is now explicit about ZOAU not being properly configured for Ansible.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1804).

--- a/plugins/module_utils/import_handler.py
+++ b/plugins/module_utils/import_handler.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-class MissingZOAUImport(Exception):
+class MissingZOAUImport(object):
     """Error when importing ZOAU.
     """
     def __getattr__(self, name):
@@ -42,7 +42,7 @@ class MissingZOAUImport(Exception):
         return method
 
 
-class ZOAUImportError(Exception):
+class ZOAUImportError(object):
     def __init__(self, exception_traceback):
         """This class serves as a wrapper for any kind of error when importing
         ZOAU. Since ZOAU is used by both modules and module_utils, we need a way
@@ -81,31 +81,29 @@ class ZOAUImportError(Exception):
         and instead return a method that will alert the user that there was
         an error while importing ZOAU.
         """
-        def method(*args, **kwargs):
-            """Raises ImportError as a result of a failed ZOAU import.
+        """Raises ImportError as a result of a failed ZOAU import.
 
-            Parameters
-            ----------
-            *args : dict
-                Arguments ordered in a dictionary.
-            **kwargs : dict
-                Arguments ordered in a dictionary.
+        Parameters
+        ----------
+        *args : dict
+            Arguments ordered in a dictionary.
+        **kwargs : dict
+            Arguments ordered in a dictionary.
 
-            Raises
-            ------
-            ImportError
-                Unable to import a module or library.
-            """
-            raise ImportError(
-                (
-                    "ZOAU is not properly configured for Ansible. Unable to import zoautil_py. "
-                    "Ensure environment variables are properly configured in Ansible for use with ZOAU. "
-                    "Complete traceback: {0}".format(self.traceback)
-                )
+        Raises
+        ------
+        ImportError
+            Unable to import a module or library.
+        """
+        raise ImportError(
+            (
+                "ZOAU is not properly configured for Ansible. Unable to import zoautil_py. "
+                "Ensure environment variables are properly configured in Ansible for use with ZOAU. "
+                "Complete traceback: {0}".format(self.traceback)
             )
-        return method
+        )
 
-class MissingImport(Exception):
+class MissingImport(object):
     def __init__(self, import_name=""):
         """Error when it is unable to import a module due to it being missing.
 
@@ -122,20 +120,18 @@ class MissingImport(Exception):
         self.import_name = import_name
 
     def __getattr__(self, name):
-        def method(*args, **kwargs):
-            """Raises ImportError as a result of trying to import a missing module.
+        """Raises ImportError as a result of trying to import a missing module.
 
-            Parameter
-            ---------
-            *args : dict
-                Arguments ordered in a dictionary.
-            **kwargs : dict
-                Arguments ordered in a dictionary.
+        Parameter
+        ---------
+        *args : dict
+            Arguments ordered in a dictionary.
+        **kwargs : dict
+            Arguments ordered in a dictionary.
 
-            Raises
-            ------
-            ImportError
-                Unable to import a module or library.
-            """
-            raise ImportError("Import {0} was not available.".format(self.import_name))
-        return method
+        Raises
+        ------
+        ImportError
+            Unable to import a module or library.
+        """
+        raise ImportError("Import {0} was not available.".format(self.import_name))

--- a/plugins/module_utils/import_handler.py
+++ b/plugins/module_utils/import_handler.py
@@ -84,10 +84,8 @@ class ZOAUImportError(object):
 
         Parameters
         ----------
-        *args : dict
-            Arguments ordered in a dictionary.
-        **kwargs : dict
-            Arguments ordered in a dictionary.
+        name : str
+            Value of object not properly imported.
 
         Raises
         ------
@@ -124,10 +122,8 @@ class MissingImport(object):
 
         Parameter
         ---------
-        *args : dict
-            Arguments ordered in a dictionary.
-        **kwargs : dict
-            Arguments ordered in a dictionary.
+        name : str
+            Value of object not properly imported.
 
         Raises
         ------

--- a/plugins/module_utils/import_handler.py
+++ b/plugins/module_utils/import_handler.py
@@ -13,37 +13,23 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-
-class MissingZOAUImport(object):
+class MissingZOAUImport(Exception):
     """Error when importing ZOAU.
     """
-    def __getattr__(self, name):
-        def method(*args, **kwargs):
-            """Raises ImportError as a result of a failed ZOAU import.
+    def __init__(self):
+        """Error when it is unable to import a module due to it being missing.
 
-            Parameters
-            ----------
-            *args : dict
-                Arguments ordered in a dictionary.
-            **kwargs : dict
-                Arguments ordered in a dictionary.
-
-            Raises
-            ------
-            ImportError
-                Unable to import a module or library.
-            """
-            raise ImportError(
-                (
-                    "ZOAU is not properly configured for Ansible. Unable to import zoautil_py. "
-                    "Ensure environment variables are properly configured in Ansible for use with ZOAU."
-                )
-            )
-
-        return method
+        Attributes
+        ----------
+        msg : str
+            Human readable string describing th exception.
+        """
+        self.msg = """ZOAU is not properly configured for Ansible. Unable to import zoautil_py. 
+Ensure environment variables are properly configured in Ansible for use with ZOAU."""
+        super().__init__(self.msg)
 
 
-class ZOAUImportError(object):
+class ZOAUImportError(Exception):
     def __init__(self, exception_traceback):
         """This class serves as a wrapper for any kind of error when importing
         ZOAU. Since ZOAU is used by both modules and module_utils, we need a way
@@ -73,41 +59,13 @@ class ZOAUImportError(object):
         exception_traceback : str
             The formatted traceback of the exception.
         """
-        self.traceback = exception_traceback
-
-    def __getattr__(self, name):
-        """This code is virtually the same from `MissingZOAUImport`. What we
-        do here is hijack all calls to any method from a missing ZOAU library
-        and instead return a method that will alert the user that there was
-        an error while importing ZOAU.
-        """
-        def method(*args, **kwargs):
-            """Raises ImportError as a result of a failed ZOAU import.
-
-            Parameters
-            ----------
-            *args : dict
-                Arguments ordered in a dictionary.
-            **kwargs : dict
-                Arguments ordered in a dictionary.
-
-            Raises
-            ------
-            ImportError
-                Unable to import a module or library.
-            """
-            raise ImportError(
-                (
-                    "ZOAU is not properly configured for Ansible. Unable to import zoautil_py. "
-                    "Ensure environment variables are properly configured in Ansible for use with ZOAU. "
-                    "Complete traceback: {0}".format(self.traceback)
-                )
-            )
-
-        return method
+        self.msg = """ZOAU is not properly configured for Ansible. Unable to import zoautil_py. 
+Ensure environment variables are properly configured in Ansible for use with ZOAU.
+Complete traceback: {0}""".format(self.traceback)
+        super().__init__(self.msg)
 
 
-class MissingImport(object):
+class MissingImport(Exception):
     def __init__(self, import_name=""):
         """Error when it is unable to import a module due to it being missing.
 
@@ -121,24 +79,5 @@ class MissingImport(object):
         import_name : str
             The name of the module to import.
         """
-        self.import_name = import_name
-
-    def __getattr__(self, name):
-        def method(*args, **kwargs):
-            """Raises ImportError as a result of trying to import a missing module.
-
-            Parameter
-            ---------
-            *args : dict
-                Arguments ordered in a dictionary.
-            **kwargs : dict
-                Arguments ordered in a dictionary.
-
-            Raises
-            ------
-            ImportError
-                Unable to import a module or library.
-            """
-            raise ImportError("Import {0} was not available.".format(self.import_name))
-
-        return method
+        self.msg = "Import {0} was not available.".format(import_name)
+        super().__init__(self.msg)

--- a/plugins/module_utils/import_handler.py
+++ b/plugins/module_utils/import_handler.py
@@ -74,7 +74,6 @@ class ZOAUImportError(object):
         """
         self.traceback = exception_traceback
 
-
     def __getattr__(self, name):
         """This code is virtually the same from `MissingZOAUImport`. What we
         do here is hijack all calls to any method from a missing ZOAU library
@@ -102,6 +101,7 @@ class ZOAUImportError(object):
                 "Complete traceback: {0}".format(self.traceback)
             )
         )
+
 
 class MissingImport(object):
     def __init__(self, import_name=""):

--- a/plugins/module_utils/import_handler.py
+++ b/plugins/module_utils/import_handler.py
@@ -13,18 +13,17 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+
 class MissingZOAUImport(Exception):
-    """Error when importing ZOAU.
-    """
     def __init__(self):
         """Error when it is unable to import a module due to it being missing.
 
         Attributes
         ----------
         msg : str
-            Human readable string describing th exception.
+            Human readable string describing the exception.
         """
-        self.msg = """ZOAU is not properly configured for Ansible. Unable to import zoautil_py. 
+        self.msg = """ZOAU is not properly configured for Ansible. Unable to import zoautil_py.
 Ensure environment variables are properly configured in Ansible for use with ZOAU."""
         super().__init__(self.msg)
 
@@ -58,8 +57,11 @@ class ZOAUImportError(Exception):
         ----------
         exception_traceback : str
             The formatted traceback of the exception.
+        msg : str
+            Human readable string describing the exception.
         """
-        self.msg = """ZOAU is not properly configured for Ansible. Unable to import zoautil_py. 
+        self.traceback = exception_traceback
+        self.msg = """ZOAU is not properly configured for Ansible. Unable to import zoautil_py. "
 Ensure environment variables are properly configured in Ansible for use with ZOAU.
 Complete traceback: {0}""".format(self.traceback)
         super().__init__(self.msg)
@@ -78,6 +80,9 @@ class MissingImport(Exception):
         ----------
         import_name : str
             The name of the module to import.
+        msg : str
+            Human readable string describing the exception.
         """
-        self.msg = "Import {0} was not available.".format(import_name)
+        self.import_name = import_name
+        self.msg = "Import {0} was not available.".format(self.import_name)
         super().__init__(self.msg)

--- a/plugins/module_utils/import_handler.py
+++ b/plugins/module_utils/import_handler.py
@@ -15,17 +15,31 @@ __metaclass__ = type
 
 
 class MissingZOAUImport(Exception):
-    def __init__(self):
-        """Error when it is unable to import a module due to it being missing.
+    """Error when importing ZOAU.
+    """
+    def __getattr__(self, name):
+        def method(*args, **kwargs):
+            """Raises ImportError as a result of a failed ZOAU import.
 
-        Attributes
-        ----------
-        msg : str
-            Human readable string describing the exception.
-        """
-        self.msg = """ZOAU is not properly configured for Ansible. Unable to import zoautil_py.
-Ensure environment variables are properly configured in Ansible for use with ZOAU."""
-        super().__init__(self.msg)
+            Parameters
+            ----------
+            *args : dict
+                Arguments ordered in a dictionary.
+            **kwargs : dict
+                Arguments ordered in a dictionary.
+
+            Raises
+            ------
+            ImportError
+                Unable to import a module or library.
+            """
+            raise ImportError(
+                (
+                    "ZOAU is not properly configured for Ansible. Unable to import zoautil_py. "
+                    "Ensure environment variables are properly configured in Ansible for use with ZOAU."
+                )
+            )
+        return method
 
 
 class ZOAUImportError(Exception):
@@ -57,15 +71,39 @@ class ZOAUImportError(Exception):
         ----------
         exception_traceback : str
             The formatted traceback of the exception.
-        msg : str
-            Human readable string describing the exception.
         """
         self.traceback = exception_traceback
-        self.msg = """ZOAU is not properly configured for Ansible. Unable to import zoautil_py. "
-Ensure environment variables are properly configured in Ansible for use with ZOAU.
-Complete traceback: {0}""".format(self.traceback)
-        super().__init__(self.msg)
 
+
+    def __getattr__(self, name):
+        """This code is virtually the same from `MissingZOAUImport`. What we
+        do here is hijack all calls to any method from a missing ZOAU library
+        and instead return a method that will alert the user that there was
+        an error while importing ZOAU.
+        """
+        def method(*args, **kwargs):
+            """Raises ImportError as a result of a failed ZOAU import.
+
+            Parameters
+            ----------
+            *args : dict
+                Arguments ordered in a dictionary.
+            **kwargs : dict
+                Arguments ordered in a dictionary.
+
+            Raises
+            ------
+            ImportError
+                Unable to import a module or library.
+            """
+            raise ImportError(
+                (
+                    "ZOAU is not properly configured for Ansible. Unable to import zoautil_py. "
+                    "Ensure environment variables are properly configured in Ansible for use with ZOAU. "
+                    "Complete traceback: {0}".format(self.traceback)
+                )
+            )
+        return method
 
 class MissingImport(Exception):
     def __init__(self, import_name=""):
@@ -80,9 +118,24 @@ class MissingImport(Exception):
         ----------
         import_name : str
             The name of the module to import.
-        msg : str
-            Human readable string describing the exception.
         """
         self.import_name = import_name
-        self.msg = "Import {0} was not available.".format(self.import_name)
-        super().__init__(self.msg)
+
+    def __getattr__(self, name):
+        def method(*args, **kwargs):
+            """Raises ImportError as a result of trying to import a missing module.
+
+            Parameter
+            ---------
+            *args : dict
+                Arguments ordered in a dictionary.
+            **kwargs : dict
+                Arguments ordered in a dictionary.
+
+            Raises
+            ------
+            ImportError
+                Unable to import a module or library.
+            """
+            raise ImportError("Import {0} was not available.".format(self.import_name))
+        return method


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Send to the user the full traceback for import errors, also catch python bad configuration
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1765 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enhance Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
__getattr__ only set the value not the method
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Playbook
```
- hosts : zvm
  collections :
    - ibm.ibm_zos_core
  gather_facts: False
  vars:
    ZOAU: "/zoau/v1.2.5"
    #ZOAU: "/zoau/v1.3.3"
    PYZ: "/allpython/3.10/usr/lpp/IBM/cyp/v3r10/pyz"
    RC_0_DATA_SET_NAME: "USER.WHAT.EVER.ONE"
    DATA_SET_TO_LISTCAT: "USER.WHAT.EVER"
    IDCAMS_STDIN: " LISTCAT NTRIES('{{ DATA_SET_TO_LISTCAT | upper }}')"
    # " LISTCAT ENTRIES('OMVSADM.TEST')"

  environment: "{{ environment_vars }}"
  tasks:

    - name: create some data set
      block:
        - name: create data set to LISTCAT
          zos_data_set:
            name: "{{ DATA_SET_TO_LISTCAT }}"
            type: seq
            state: present
            replace: yes

        - name: mvs raw with verbose with rc=0
          zos_mvs_raw:
            verbose: True
            program_name: idcams
            auth: True
            dds:
              - dd_data_set:
                  dd_name: SYSPRINT
                  data_set_name: "{{ RC_0_DATA_SET_NAME }}"
                  disposition: new
                  type: seq
                  return_content:
                    type: text
              - dd_input:
                  dd_name: SYSIN
                  content: "{{ IDCAMS_STDIN }}"
          register: output_rc_0
          ignore_errors: True

        - name: print output
          debug:
            msg:
              - "{{ output_rc_0 }}"

        - name: mvs raw with verbose with rc=0
          zos_mvs_raw:
            verbose: False
            program_name: idcams
            auth: True
            dds:
              - dd_data_set:
                  dd_name: SYSPRINT
                  data_set_name: "{{ RC_0_DATA_SET_NAME }}"
                  disposition: old
                  type: seq
              - dd_input:
                  dd_name: SYSIN
                  content: "{{ IDCAMS_STDIN }}"
          register: output_rc_0

        - name: print output
          debug:
            msg:
              - "{{ output_rc_0 }}"

      always:
        - name: delete data sets
          zos_data_set:
            name: "{{ item }}"
            state: absent
          loop:
            - "{{ DATA_SET_TO_LISTCAT }}"
            - "{{ RC_0_DATA_SET_NAME }}"
```
Output
```
andre@mbp-de-andre-2 1765_enhance_error_message_failing_import % ansible-playbook -i inventory.yml 1_test.yaml

PLAY [zvm] *************************************************************************************************************************************************************************************

TASK [create data set to LISTCAT] **************************************************************************************************************************************************************
fatal: [zvm]: FAILED! => {"changed": false, "message": "", "msg": "ImportError('ZOAU is not properly configured for Ansible. Unable to import zoautil_py. Ensure environment variables are properly configured in Ansible for use with ZOAU. Complete traceback: Traceback (most recent call last):\\n  File \"/tmp/ansible_zos_data_set_payload_se3ooiyn/ansible_zos_data_set_payload.zip/ansible_collections/ibm/ibm_zos_core/plugins/module_utils/data_set.py\", line 38, in <module>\\n    from zoautil_py import datasets, exceptions, gdgs\\nModuleNotFoundError: No module named \\'zoautil_py\\'\\n')", "names": ["USER.WHAT.EVER"]}

TASK [delete data sets] ************************************************************************************************************************************************************************
ok: [zvm] => (item=USER.WHAT.EVER)
ok: [zvm] => (item=USER.WHAT.EVER.ONE)

PLAY RECAP *************************************************************************************************************************************************************************************
zvm                        : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0 
```
<img width="1360" alt="Captura de pantalla 2024-11-14 a la(s) 6 07 01 p m" src="https://github.com/user-attachments/assets/967ae409-4e18-4156-8973-3b0d0f1a89ed">
<img width="645" alt="Captura de pantalla 2024-11-14 a la(s) 6 07 13 p m" src="https://github.com/user-attachments/assets/287a54da-5e85-4e53-b99e-4f9a3daf1e47">
<img width="1357" alt="Captura de pantalla 2024-11-15 a la(s) 6 54 18 a m" src="https://github.com/user-attachments/assets/b2fc0138-37be-4121-ae92-07956fde515b">
<img width="757" alt="Captura de pantalla 2024-11-15 a la(s) 6 54 32 a m" src="https://github.com/user-attachments/assets/a5069635-3614-44ff-a52c-388819481d26">
<img width="1354" alt="Captura de pantalla 2024-11-15 a la(s) 8 14 21 p m" src="https://github.com/user-attachments/assets/6d5dc96b-54d3-4e43-bed2-a6cdcf746480">
<img width="668" alt="Captura de pantalla 2024-11-15 a la(s) 8 14 34 p m" src="https://github.com/user-attachments/assets/754cb1b4-ad07-453f-a312-0f196fe9bb91">
<img width="1358" alt="Captura de pantalla 2024-11-19 a la(s) 10 37 07 a m" src="https://github.com/user-attachments/assets/3e22444a-5952-46c4-a0a3-f2cb94b2464c">
<img width="697" alt="Captura de pantalla 2024-11-19 a la(s) 10 37 18 a m" src="https://github.com/user-attachments/assets/7a9ecd2f-e659-4d32-8eb9-7937c7c16540">
<img width="1353" alt="Captura de pantalla 2024-11-19 a la(s) 10 44 43 a m" src="https://github.com/user-attachments/assets/eafd265a-6bf2-41ba-b9e4-5576f0bd60fa">
<img width="715" alt="Captura de pantalla 2024-11-19 a la(s) 10 44 52 a m" src="https://github.com/user-attachments/assets/5344bd5e-e9ad-4b2a-a1bb-4f9fcbabb01c">
<img width="1365" alt="Captura de pantalla 2024-11-19 a la(s) 1 24 45 p m" src="https://github.com/user-attachments/assets/18b6c761-4130-4dd6-a191-473bc2d18347">
<img width="649" alt="Captura de pantalla 2024-11-19 a la(s) 1 24 55 p m" src="https://github.com/user-attachments/assets/77f90c81-c2b0-45f5-b68d-51f44aacd84d">


