### PR TITLE
[Bug][zos_mvs_raw] Return stderr in return values

### DIFF
--- a/.github/workflows/ac-ansible-test-sanity.yml
+++ b/.github/workflows/ac-ansible-test-sanity.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         source venv/venv-2.16/bin/activate
         python -m pip install --upgrade pip
-        pip install ansible
+        pip install ansible-core==2.17.6
 
     - name: Run ac-sanity
       run: |

--- a/changelogs/fragments/1808-zos_mvs_raw-stderr-not-returned.yml
+++ b/changelogs/fragments/1808-zos_mvs_raw-stderr-not-returned.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zos_mvs_raw - Module would not populate stderr return value. Fix now populates stderr in return values.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1808).
+

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1898,7 +1898,7 @@ def run_module():
                 verbose=verbose,
                 tmphlq=tmphlq,
             )
-            response = build_response(program_response.rc, dd_statements, program_response.stdout)
+            response = build_response(program_response.rc, dd_statements, program_response.stdout, program_response.stderr)
             result = combine_dicts(result, response)
             if program_response.rc != 0 :
                 raise ZOSRawError(
@@ -2766,7 +2766,7 @@ def run_zos_program(
     return response
 
 
-def build_response(rc, dd_statements, stdout):
+def build_response(rc, dd_statements, stdout, stderr):
     """Build response dictionary to return at module completion.
 
     Parameters
@@ -2785,6 +2785,7 @@ def build_response(rc, dd_statements, stdout):
     response["backups"] = gather_backups(dd_statements)
     response["dd_names"] = gather_output(dd_statements)
     response["stdout"] = stdout
+    response["stderr"] = stderr
     return response
 
 

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -101,6 +101,8 @@ def test_disposition_new(ansible_zos_module, verbose):
             assert result.get("ret_code", {}).get("code", -1) == 0
             assert len(result.get("dd_names", [])) > 0
             assert result.get("failed", False) is False
+            if verbose:
+                assert result.get("stderr") is not None
     finally:
         hosts.all.zos_data_set(name=default_data_set, state="absent")
         if idcams_dataset:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
stderr is not being populated in the return values, just always being empty. This PR populates the value and introduces a new test case to validate that it is not empty.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1805 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_mvs_raw
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
