### PR TITLE
[zos_find] Find VSAM cluster when DISP=OLD

### DIFF
--- a/.github/workflows/ac-ansible-test-sanity.yml
+++ b/.github/workflows/ac-ansible-test-sanity.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         source venv/venv-2.16/bin/activate
         python -m pip install --upgrade pip
-        pip install ansible
+        pip install ansible-core==2.17.6
 
     - name: Run ac-sanity
       run: |

--- a/changelogs/fragments/1818-zos_find-vsam-disp-old.yml
+++ b/changelogs/fragments/1818-zos_find-vsam-disp-old.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_find - Module would not find a VSAM cluster resource type if it was in use with DISP=OLD. Fix now finds the VSAM cluster.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1818).
+  - zos_find - Module would not find VSAM data and index resource types. Fix now finds the data and index resource types.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1818).

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -1104,7 +1104,7 @@ def run_module(module):
 
         res_args['examined'] = init_filtered_data_sets.get("searched")
 
-    elif resource_type == "CLUSTER":
+    elif resource_type in ["CLUSTER", "DATA", "INDEX"]:
         filtered_data_sets = vsam_filter(module, patterns, resource_type, age=age)
         res_args['examined'] = len(filtered_data_sets)
     elif resource_type == "GDG":

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -503,7 +503,8 @@ def vsam_filter(module, patterns, resource_type, age=None):
     filtered_data_sets = set()
     now = time.time()
     for pattern in patterns:
-        rc, out, err = _vls_wrapper(pattern, details=True)
+        request_details = age is not None
+        rc, out, err = _vls_wrapper(pattern, details=request_details)
         if rc > 4:
             module.fail_json(
                 msg="Non-zero return code received while executing ZOAU shell command 'vls'",
@@ -1069,7 +1070,6 @@ def run_module(module):
             size = int(m.group(1)) * bytes_per_unit.get(m.group(2), 1)
         else:
             module.fail_json(size=size, msg="failed to process size")
-
     if resource_type == "NONVSAM":
         if contains:
             init_filtered_data_sets = content_filter(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes finding a VSAM when DISP=OLD, note that if age is provided the module won't find the data set that is because detailed vls call fails when data set is DISP=OLD.

So, now we are only using `vls -l` when age is provided, that way we can find the VSAM even when DISP=OLD.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #643 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_find
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
