### PR TITLE
[zos_mvs_raw] Honor tmp_hlq value when creating backup data sets

### DIFF
--- a/changelogs/fragments/1847-zos_mvs_raw-tmphlq-as-backup-hlq.yml
+++ b/changelogs/fragments/1847-zos_mvs_raw-tmphlq-as-backup-hlq.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - zos_mvs_raw - option tmp_hlq was not being used as HLQ when creating backup data sets. Fix now uses tmp_hlq as HLQ for backup data sets.
+  - zos_mvs_raw - Option ``tmp_hlq`` was not being used as HLQ when creating backup data sets. Fix now uses ``tmp_hlq`` as HLQ for backup data sets.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1847).

--- a/changelogs/fragments/1847-zos_mvs_raw-tmphlq-as-backup-hlq.yml
+++ b/changelogs/fragments/1847-zos_mvs_raw-tmphlq-as-backup-hlq.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - zos_mvs_raw - option tmp_hlq was not being used as HLQ when creating backup data sets. Fix now uses tmp_hlq as HLQ for backup data sets.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1847).

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2549,7 +2549,7 @@ def build_dd_statements(parms):
                       List of DDStatement objects representing DD statements specified in module parms.
     """
     dd_statements = []
-    tmphlq = parms.get("tmphlq")
+    tmphlq = parms.get("tmp_hlq")
     for dd in parms.get("dds"):
         dd_name, key = get_dd_name_and_key(dd)
         dd = set_extra_attributes_in_dd(dd, tmphlq, key)

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -201,7 +201,7 @@ def test_list_cat_for_existing_data_set_with_tmp_hlq_option(ansible_zos_module, 
             assert result.get("ret_code", {}).get("code", -1) == 0
             assert len(result.get("dd_names", [])) > 0
             for backup in result.get("backups"):
-                backup.get("backup_name")[:6] == tmphlq
+                assert backup.get("backup_name")[:6] == tmphlq
         for result in results.contacted.values():
             assert result.get("changed", False) is True
     finally:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module was not honoring tmp_hlq as the HLQ for backup data sets, it was a minor issue where we were trying to fetch the value from params as "tmphlq" instead of "tmp_hlq". I also added an assertion in the test cases which is supposed to test this, not sure when that got changed.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1803 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_mvs_raw
