### PR TITLE
Added new message in result when operation succeeds

### DIFF
--- a/changelogs/fragments/1864-zos_data_set-return-message.yml
+++ b/changelogs/fragments/1864-zos_data_set-return-message.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zos_data_set - Added new return messages to the module when it succeeds or fails.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1864).

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1893,6 +1893,7 @@ def run_module():
                     tmp_hlq=data_set_params.get("tmp_hlq"),
                     force=data_set_params.get("force"),
                 ) or result.get("changed", False)
+            result["message"] = "Operation succeed." if result["changed"] else "Operation failed."
         except Exception as e:
             module.fail_json(msg=repr(e), **result)
     else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added message in the result dictionary.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_data_set

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

new message for success
```
TASK [print out result] *****************************************************************************************************************
ok: [zvm] => {
    "msg": {
        "changed": true,
        "failed": false,
        "message": "Operation succeed.",
        "names": [
            "OMVSADM.TEST.ABC"
        ]
    }
}

```

new message for failure
```
ok: [zvm] => {
    "msg": {
        "changed": true,
        "failed": false,
        "message": "Operation succeed.",
        "names": [
            "OMVSADM.TEST.ABC"
        ]
    }
}

```
