### PR TITLE
[Sanity] [module_utils/encode] Sanity error failing with 2.18

### DIFF
--- a/changelogs/fragments/1865-fix-sanity-2.18-encode.yml
+++ b/changelogs/fragments/1865-fix-sanity-2.18-encode.yml
@@ -1,0 +1,3 @@
+trivial:
+  - module_utils/encode.py - Fixed sanity error using variable 'dest_f' before assignment.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1865).

--- a/plugins/module_utils/encode.py
+++ b/plugins/module_utils/encode.py
@@ -432,6 +432,8 @@ class EncodeUtils(object):
                     "Directory {0} is empty. Please check the path.".format(src)
                 )
             elif len(file_list) == 1:
+                dest_f = dest
+                src_f = src
                 if path.isdir(dest):
                     file_name = path.basename(file_list[0])
                     src_f = path.join(validation.validate_safe_path(src), validation.validate_safe_path(file_name))

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -479,9 +479,10 @@ class ManagedUser:
         if not delgroup_rc or int(delgroup_rc[0]) > 0:
             raise Exception(f"Unable to delete user {escaped_user}, please review the command output {results_stdout_lines}.")
 
-        delmanagedgroup_rc = [v for v in results_stdout_lines if f"DELMANAGEDGROUP {self._managed_group} RC=" in v][0].split('=')[1].strip() or None
-        if not delgroup_rc or int(delgroup_rc[0]) > 0:
-            raise Exception(f"Unable to delete user {escaped_user}, please review the command output {results_stdout_lines}.")
+        if self._managed_group is not None:
+            delmanagedgroup_rc = [v for v in results_stdout_lines if f"DELMANAGEDGROUP {self._managed_group} RC=" in v][0].split('=')[1].strip() or None
+            if not delmanagedgroup_rc or int(delmanagedgroup_rc[0]) > 0:
+                raise Exception(f"Unable to delete user {escaped_user}, please review the command output {results_stdout_lines}.")
 
     def _get_random_passwd(self) -> str:
         """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes sanity 2.18 error message: 
ERROR: plugins/module_utils/encode.py:440:27: used-before-assignment: Using variable 'dest_f' before assignment

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
module_utils/encode.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
