### PR TITLE
[Sanity] [zos_fetch] Sanity error failing with 2.18

### DIFF
--- a/changelogs/fragments/1866-fix-sanity-2.18-zos_fetch.yml
+++ b/changelogs/fragments/1866-fix-sanity-2.18-zos_fetch.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_fetch - Fixed sanity error sing variable 'rec_total' before assignment.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1866).

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -382,6 +382,7 @@ class FetchHandler:
         max_recl = 80
         # Bytes per cylinder for a 3390 DASD
         bytes_per_cyl = 849960
+        rec_total = 80
 
         listcat_cmd = " LISTCAT ENT('{0}') ALL".format(vsam)
         cmd = "mvscmdauth --pgm=idcams --sysprint=stdout --sysin=stdin"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed error message ERROR: plugins/modules/zos_fetch.py:412:37: used-before-assignment: Using variable 'rec_total' before assignment happening in sanity tests with ansible-core 2.18.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_fetch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
