### PR TITLE
[1.13.0-beta.1][zos_copy] Test case with managed users was failing trying to remove a non-existent RACF group

### DIFF
--- a/changelogs/fragments/1890-zos_copy-test-suite.yml
+++ b/changelogs/fragments/1890-zos_copy-test-suite.yml
@@ -1,0 +1,3 @@
+trivial:
+  - users.py - Added a code block into an if statement to prevent failing if the test didn't create another managed group.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1890).

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1987,8 +1987,8 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
         src_data_set = data_set_1
         dest_data_set = data_set_2
     try:
-        hosts.all.zos_data_set(name=data_set_1, state="present", type=ds_type, record_length=120, replace=True)
-        hosts.all.zos_data_set(name=data_set_2, state="present", type=ds_type, record_length=140, space_type="m",replace=True)
+        hosts.all.zos_data_set(name=data_set_1, state="present", type=ds_type, replace=True)
+        hosts.all.zos_data_set(name=data_set_2, state="present", type=ds_type, record_type="v",replace=True)
         if ds_type == "pds" or ds_type == "pdse":
             hosts.all.zos_data_set(name=src_data_set, state="present", type="member", replace=True)
             hosts.all.zos_data_set(name=dest_data_set, state="present", type="member", replace=True)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1994,6 +1994,7 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
             hosts.all.zos_data_set(name=dest_data_set, state="present", type="member", replace=True)
         # copy text_in source
         hosts.all.shell(cmd="decho \"{0}\" \"{1}\"".format(DUMMY_DATA, src_data_set))
+        hosts.all.shell(cmd="decho \"content to avoid identical error\" \"{0}\"".format(dest_data_set))
         # copy/compile c program and copy jcl to hold data set lock for n seconds in background(&)
         temp_dir = get_random_file_name(dir=TMP_DIRECTORY)
         hosts.all.zos_copy(content=c_pgm, dest=f'{temp_dir}/pdse-lock.c', force=True)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1988,7 +1988,7 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
         dest_data_set = data_set_2
     try:
         hosts.all.zos_data_set(name=data_set_1, state="present", type=ds_type, replace=True)
-        hosts.all.zos_data_set(name=data_set_2, state="present", type=ds_type, record_type="v",replace=True)
+        hosts.all.zos_data_set(name=data_set_2, state="present", type=ds_type, replace=True)
         if ds_type == "pds" or ds_type == "pdse":
             hosts.all.zos_data_set(name=src_data_set, state="present", type="member", replace=True)
             hosts.all.zos_data_set(name=dest_data_set, state="present", type="member", replace=True)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1987,8 +1987,8 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
         src_data_set = data_set_1
         dest_data_set = data_set_2
     try:
-        hosts.all.zos_data_set(name=data_set_1, state="present", type=ds_type, replace=True)
-        hosts.all.zos_data_set(name=data_set_2, state="present", type=ds_type, replace=True)
+        hosts.all.zos_data_set(name=data_set_1, state="present", type=ds_type, record_length=120, replace=True)
+        hosts.all.zos_data_set(name=data_set_2, state="present", type=ds_type, record_length=140, space_type="m",replace=True)
         if ds_type == "pds" or ds_type == "pdse":
             hosts.all.zos_data_set(name=src_data_set, state="present", type="member", replace=True)
             hosts.all.zos_data_set(name=dest_data_set, state="present", type="member", replace=True)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1994,7 +1994,6 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
             hosts.all.zos_data_set(name=dest_data_set, state="present", type="member", replace=True)
         # copy text_in source
         hosts.all.shell(cmd="decho \"{0}\" \"{1}\"".format(DUMMY_DATA, src_data_set))
-        hosts.all.shell(cmd="decho \"content to avoid identical error\" \"{0}\"".format(dest_data_set))
         # copy/compile c program and copy jcl to hold data set lock for n seconds in background(&)
         temp_dir = get_random_file_name(dir=TMP_DIRECTORY)
         hosts.all.zos_copy(content=c_pgm, dest=f'{temp_dir}/pdse-lock.c', force=True)

--- a/tests/helpers/users.py
+++ b/tests/helpers/users.py
@@ -479,9 +479,10 @@ class ManagedUser:
         if not delgroup_rc or int(delgroup_rc[0]) > 0:
             raise Exception(f"Unable to delete user {escaped_user}, please review the command output {results_stdout_lines}.")
 
-        delmanagedgroup_rc = [v for v in results_stdout_lines if f"DELMANAGEDGROUP {self._managed_group} RC=" in v][0].split('=')[1].strip() or None
-        if not delmanagedgroup_rc or int(delmanagedgroup_rc[0]) > 0:
-            raise Exception(f"Unable to delete user {escaped_user}, please review the command output {results_stdout_lines}.")
+        if self._managed_group is not None:
+            delmanagedgroup_rc = [v for v in results_stdout_lines if f"DELMANAGEDGROUP {self._managed_group} RC=" in v][0].split('=')[1].strip() or None
+            if not delmanagedgroup_rc or int(delmanagedgroup_rc[0]) > 0:
+                raise Exception(f"Unable to delete user {escaped_user}, please review the command output {results_stdout_lines}.")
 
     def _get_random_passwd(self) -> str:
         """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes an issue with testing a test with zos_copy and testing case "test_copy_dest_lock_test_with_no_opercmd_access_pds_without_force_lock" that bug was introduced in PR #1790 because this test suite was not executed, now with this change I tested with all test suites that are linked to the users.py helper utility. This is not automatically discovered by the dependency finder 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
