### PR TITLE
Added execution_time param in job response parameters

### DIFF
--- a/changelogs/fragments/1891-zos_job_submit-include-execution_time.yml
+++ b/changelogs/fragments/1891-zos_job_submit-include-execution_time.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - zos_job_submit - Added execution_time param in modules response.
+  - zos_job_query - Added execution_time param in modules response.
+  - zos_job_output - Added execution_time param in modules response.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1891).

--- a/changelogs/fragments/1891-zos_job_submit-include-execution_time.yml
+++ b/changelogs/fragments/1891-zos_job_submit-include-execution_time.yml
@@ -1,5 +1,5 @@
 minor_changes:
-  - zos_job_submit - Added execution_time param in modules response.
-  - zos_job_query - Added execution_time param in modules response.
-  - zos_job_output - Added execution_time param in modules response.
+  - zos_job_submit - Add execution_time return value in the modules response.
+  - zos_job_query - Add execution_time return value in the modules response.
+  - zos_job_output - Add execution_time return value in the modules response.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1891).

--- a/changelogs/fragments/1891-zos_job_submit-include-execution_time.yml
+++ b/changelogs/fragments/1891-zos_job_submit-include-execution_time.yml
@@ -1,5 +1,7 @@
 minor_changes:
   - zos_job_submit - Add execution_time return value in the modules response.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1891).
   - zos_job_query - Add execution_time return value in the modules response.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1891).
   - zos_job_output - Add execution_time return value in the modules response.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1891).

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -374,6 +374,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
             job["ret_code"]["steps"] = []
             job["ddnames"] = []
             job["duration"] = duration
+            job["execution_time"] = entry.execution_time
 
             if dd_scan:
                 # If true, it means the job is not ready for DD queries and the duration and

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -133,7 +133,7 @@ jobs:
       type: str
       sample: "14:15:00"
     execution_time:
-      description: The time the JCL executed for.
+      description: Total duration time of the job execution, if it has finished. If the job is still running, it represents the time elapsed from the job execution start and current time.
       type: str
       sample: 00:00:10
     ddnames:

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -133,7 +133,8 @@ jobs:
       type: str
       sample: "14:15:00"
     execution_time:
-      description: Total duration time of the job execution, if it has finished. If the job is still running, it represents the time elapsed from the job execution start and current time.
+      description: Total duration time of the job execution, if it has finished. If the job is still running,
+      it represents the time elapsed from the job execution start and current time.
       type: str
       sample: 00:00:10
     ddnames:

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -133,7 +133,7 @@ jobs:
       type: str
       sample: "14:15:00"
     execution_time:
-      description: 
+      description:
         Total duration time of the job execution, if it has finished. If the job is still running,
         it represents the time elapsed from the job execution start and current time.
       type: str

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -132,6 +132,10 @@ jobs:
         Time, local to the target system, when the job was created.
       type: str
       sample: "14:15:00"
+    execution_time:
+      description: The time the JCL executed for.
+      type: str
+      sample: 00:00:10
     ddnames:
       description:
          Data definition names.
@@ -390,6 +394,7 @@ jobs:
           }
         ],
         "duration": 0,
+        "execution_time": "00:00:03",
         "job_class": "R",
         "job_id": "JOB00134",
         "job_name": "HELLO",

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -133,8 +133,9 @@ jobs:
       type: str
       sample: "14:15:00"
     execution_time:
-      description: Total duration time of the job execution, if it has finished. If the job is still running,
-      it represents the time elapsed from the job execution start and current time.
+      description: 
+        Total duration time of the job execution, if it has finished. If the job is still running,
+        it represents the time elapsed from the job execution start and current time.
       type: str
       sample: 00:00:10
     ddnames:

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -238,8 +238,9 @@ jobs:
       type: str
       sample: "IEBGENER"
     execution_time:
-      description: Total duration time of the job execution, if it has finished. If the job is still running,
-      it represents the time elapsed from the job execution start and current time.
+      description: 
+        Total duration time of the job execution, if it has finished. If the job is still running,
+        it represents the time elapsed from the job execution start and current time.
       type: str
       sample: 00:00:10
 

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -237,6 +237,10 @@ jobs:
         Returned when Z Open Automation Utilities (ZOAU) is 1.2.4 or later.
       type: str
       sample: "IEBGENER"
+    execution_time:
+      description: The time the JCL executed for.
+      type: str
+      sample: 00:00:10
 
   sample:
     [
@@ -253,6 +257,7 @@ jobs:
             "creation_date": "2023-05-03",
             "creation_time": "12:13:00",
             "queue_position": 3,
+            "execution_time": "00:00:02"
         },
         {
             "job_name": "LINKCBL",
@@ -267,6 +272,7 @@ jobs:
             "creation_date": "2023-05-03",
             "creation_time": "12:14:00",
             "queue_position": 0,
+            "execution_time": "00:00:03"
         },
     ]
 message:
@@ -443,6 +449,7 @@ def parsing_jobs(jobs_raw):
             "asid": job.get("asid"),
             "creation_date": job.get("creation_date"),
             "creation_time": job.get("creation_time"),
+            "execution_time": job.get("execution_time"),
             "queue_position": job.get("queue_position"),
             "program_name": job.get("program_name"),
         }

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -238,7 +238,7 @@ jobs:
       type: str
       sample: "IEBGENER"
     execution_time:
-      description: The time the JCL executed for.
+      description: Total duration time of the job execution, if it has finished. If the job is still running, it represents the time elapsed from the job execution start and current time.
       type: str
       sample: 00:00:10
 

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -238,7 +238,8 @@ jobs:
       type: str
       sample: "IEBGENER"
     execution_time:
-      description: Total duration time of the job execution, if it has finished. If the job is still running, it represents the time elapsed from the job execution start and current time.
+      description: Total duration time of the job execution, if it has finished. If the job is still running,
+      it represents the time elapsed from the job execution start and current time.
       type: str
       sample: 00:00:10
 

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -238,7 +238,7 @@ jobs:
       type: str
       sample: "IEBGENER"
     execution_time:
-      description: 
+      description:
         Total duration time of the job execution, if it has finished. If the job is still running,
         it represents the time elapsed from the job execution start and current time.
       type: str

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -180,7 +180,7 @@ jobs:
       type: int
       sample: 0
     execution_time:
-      description: The time the JCL executed for.
+      description: Total duration time of the job execution, if it has finished.
       type: str
       sample: 00:00:10
     ddnames:

--- a/plugins/modules/zos_job_submit.py
+++ b/plugins/modules/zos_job_submit.py
@@ -179,6 +179,10 @@ jobs:
       description: The total lapsed time the JCL ran for.
       type: int
       sample: 0
+    execution_time:
+      description: The time the JCL executed for.
+      type: str
+      sample: 00:00:10
     ddnames:
       description:
          Data definition names.
@@ -568,6 +572,7 @@ jobs:
                   ]
               },
               "job_class": "K",
+              "execution_time": "00:00:10",
               "svc_class": "?",
               "priority": 1,
               "program_name": "IEBGENER",
@@ -860,6 +865,7 @@ def build_return_schema(result):
         "job_id": None,
         "job_name": None,
         "duration": None,
+        "execution_time": None,
         "ddnames": {
             "ddname": None,
             "record_count": None,
@@ -1069,6 +1075,7 @@ def run_module():
             # being an immutable type can not be changed and must be returned or accessed from the job.py.
             if job_output is not None:
                 duration = job_output_txt[0].get("duration") if not None else duration
+                result["execution_time"] = job_output_txt[0].get("execution_time")
 
             result["duration"] = duration
 

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -139,7 +139,6 @@ def test_zos_job_output_job_exists_with_filtered_ddname(ansible_zos_module):
             for job in result.get("jobs"):
                 assert len(job.get("ddnames")) == 1
                 assert job.get("ddnames")[0].get("ddname") == dd_name
-                assert job.get("execution_time") is not None
     finally:
         hosts.all.file(path=TEMP_PATH, state="absent")
 

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -115,6 +115,7 @@ def test_zos_job_output_job_exists(ansible_zos_module):
             assert result.get("jobs")[0].get("ret_code").get("steps") is not None
             assert result.get("jobs")[0].get("ret_code").get("steps")[0].get("step_name") == "STEP0001"
             assert result.get("jobs")[0].get("content_type") == "JOB"
+            assert result.get("jobs")[0].get("execution_time") is not None
     finally:
         hosts.all.file(path=TEMP_PATH, state="absent")
 
@@ -138,6 +139,7 @@ def test_zos_job_output_job_exists_with_filtered_ddname(ansible_zos_module):
             for job in result.get("jobs"):
                 assert len(job.get("ddnames")) == 1
                 assert job.get("ddnames")[0].get("ddname") == dd_name
+                assert job.get("execution_time") is not None
     finally:
         hosts.all.file(path=TEMP_PATH, state="absent")
 

--- a/tests/functional/modules/test_zos_job_query_func.py
+++ b/tests/functional/modules/test_zos_job_query_func.py
@@ -95,6 +95,7 @@ def test_zos_job_id_query_multi_wildcards_func(ansible_zos_module):
                 assert qresult.get("jobs") is not None
                 assert qresult.get("jobs")[0].get("system") is not None
                 assert qresult.get("jobs")[0].get("subsystem") is not None
+                assert qresult.get("jobs")[0].get("execution_time") is not None
 
     finally:
         hosts.all.file(path=temp_path, state="absent")
@@ -128,6 +129,7 @@ def test_zos_job_name_query_multi_wildcards_func(ansible_zos_module):
             qresults = hosts.all.zos_job_query(job_name=jobname, owner="*")
             for qresult in qresults.contacted.values():
                 assert qresult.get("jobs") is not None
+                assert qresult.get("jobs")[0].get("execution_time") is not None
 
     finally:
         hosts.all.file(path=temp_path, state="absent")

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -557,6 +557,7 @@ def test_job_submit_and_forget_uss(ansible_zos_module):
             assert len(result.get("jobs")) == 0
             assert result.get("job_name") is None
             assert result.get("duration") is None
+            assert result.get("execution_time") is None
             assert result.get("ddnames") is not None
             assert result.get("ddnames").get("ddname") is None
             assert result.get("ddnames").get("record_count") is None
@@ -688,6 +689,7 @@ def test_job_submit_pds_5_sec_job_wait_15(ansible_zos_module):
             assert result.get("jobs")[0].get("ret_code").get("code") == 0
             assert result.get('changed') is True
             assert result.get('duration') <= wait_time_s
+            assert result.get('execution_time') is not None
     finally:
         hosts.all.file(path=temp_path, state="absent")
         hosts.all.zos_data_set(name=data_set_name, state="absent")
@@ -722,6 +724,7 @@ def test_job_submit_pds_30_sec_job_wait_60(ansible_zos_module):
             assert result.get("jobs")[0].get("ret_code").get("code") == 0
             assert result.get('changed') is True
             assert result.get('duration') <= wait_time_s
+            assert result.get('execution_time') is not None
     finally:
         hosts.all.file(path=temp_path, state="absent")
         hosts.all.zos_data_set(name=data_set_name, state="absent")
@@ -757,6 +760,7 @@ def test_job_submit_pds_30_sec_job_wait_10_negative(ansible_zos_module):
             assert result.get('duration') >= wait_time_s
             # expecting at least "long running job that exceeded its maximum wait"
             assert re.search(r'exceeded', repr(result.get("msg")))
+            assert result.get('execution_time') is not None
     finally:
         hosts.all.file(path=temp_path, state="absent")
         hosts.all.zos_data_set(name=data_set_name, state="absent")


### PR DESCRIPTION
##### SUMMARY
Including jobs execution_time in the modules results #1637

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
zos_job_submit, zos_job_query, zos_job_output

##### ADDITIONAL INFORMATION

zos_job_submit module response 
```
ok: [zos_host] => {
    "msg": {
        "asid": null,
        "changed": true,
        "creation_date": null,
        "ddnames": {
            "byte_count": null,
            "content": [],
            "ddname": null,
            "id": null,
            "procstep": null,
            "record_count": null,
            "stepname": null
        },
        "dest": "/.ansible/tmp/zos_job_submit_202501221760/test.jcl",
        "duration": 4,
        "execution_time": "00:00:02",
        "failed": false,
        "gid": 0,
        .....................
```

zos_job_output module response
```
          ...........
                "duration": 0,
                "execution_time": "00:00:02",
                "job_class": "R",
                "job_id": "JOB00112",
                "job_name": "SLEEP",
                "owner": "OMVSADM",
                "priority": 1,
                "program_name": "BPXBATCH",
                "queue_position": 7,
                "ret_code": {
                    "code": 0,
                    "msg": "CC",
                    "msg_code": "0000",
          .............
```

zos_job_query module response
```
      ..........
                "content_type": "JOB",
                "creation_date": "2025-01-21",
                "creation_time": "0:46:49",
                "execution_time": "00:00:02",
                "job_class": "R",
                "job_id": "JOB00112",
                "job_name": "SLEEP",
      ...........
```
