### PR TITLE
[Bugfix][1.12.1][1898][zos_copy]Fix zos_copy failing when force_lock is true and data set name contains a special character

### DIFF
--- a/changelogs/fragments/1917-wrong_behaviour_force_lock_parameter.yml
+++ b/changelogs/fragments/1917-wrong_behaviour_force_lock_parameter.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - zos_copy: Previously if the dataset name includes special characters such as $ fail when force_lock is false
+  - zos_copy - Previously if the dataset name includes special characters such as $ fail when force_lock is false
       in the validation. Change now allow the use of special characters.
       (https://github.com/ansible-collections/ibm_zos_core/pull/1907)

--- a/changelogs/fragments/1917-wrong_behaviour_force_lock_parameter.yml
+++ b/changelogs/fragments/1917-wrong_behaviour_force_lock_parameter.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - zos_copy - Previously if the dataset name includes special characters such as $ fail when force_lock is false
-      in the validation. Change now allow the use of special characters.
+  - zos_copy - Previously, if the dataset name included special characters such as $, validation would fail when force_lock was false.
+      This has been changed to allow the use of special characters when force_lock option is false.
       (https://github.com/ansible-collections/ibm_zos_core/pull/1907)

--- a/changelogs/fragments/1917-wrong_behaviour_force_lock_parameter.yml
+++ b/changelogs/fragments/1917-wrong_behaviour_force_lock_parameter.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zos_copy: Previously if the dataset name includes special characters such as $ fail when force_lock is false
+      in the validation. Change now allow the use of special characters.
+      (https://github.com/ansible-collections/ibm_zos_core/pull/1907)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3184,6 +3184,7 @@ def data_set_locked(dataset_name):
     # in the result with a length greater than 4.
     result = dict()
     result["stdout"] = []
+    dataset_name = data_set.DataSet.escape_data_set_name(name=dataset_name)
     command_dgrs = "D GRS,RES=(*,{0})".format(dataset_name)
 
     try:
@@ -3547,7 +3548,7 @@ def run_module(module, arg_def):
     # ********************************************************************
     if dest_exists and dest_ds_type != "USS":
         if not force_lock:
-            is_dest_lock = data_set_locked(data_set.DataSet.escape_data_set_name(name=dest_name))
+            is_dest_lock = data_set_locked(dataset_name=dest_name)
             if is_dest_lock:
                 module.fail_json(
                     msg="Unable to write to dest '{0}' because a task is accessing the data set.".format(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3547,7 +3547,7 @@ def run_module(module, arg_def):
     # ********************************************************************
     if dest_exists and dest_ds_type != "USS":
         if not force_lock:
-            is_dest_lock = data_set_locked(dest_name)
+            is_dest_lock = data_set_locked(data_set.DataSet.escape_data_set_name(name=dest_name))
             if is_dest_lock:
                 module.fail_json(
                     msg="Unable to write to dest '{0}' because a task is accessing the data set.".format(

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1975,8 +1975,8 @@ def test_ensure_copy_file_does_not_change_permission_on_dest(ansible_zos_module,
 ])
 def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
     hosts = ansible_zos_module
-    data_set_1 = get_tmp_ds_name()
-    data_set_2 = get_tmp_ds_name()
+    data_set_1 = get_tmp_ds_name(symbols=True)
+    data_set_2 = get_tmp_ds_name(symbols=True)
     member_1 = "MEM1"
     if ds_type == "pds" or ds_type == "pdse":
         src_data_set = data_set_1 + "({0})".format(member_1)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1975,7 +1975,7 @@ def test_ensure_copy_file_does_not_change_permission_on_dest(ansible_zos_module,
 ])
 def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
     hosts = ansible_zos_module
-    data_set_1 = get_tmp_ds_name(symbols=True)
+    data_set_1 = get_tmp_ds_name()
     data_set_2 = get_tmp_ds_name(symbols=True)
     member_1 = "MEM1"
     if ds_type == "pds" or ds_type == "pdse":
@@ -2019,13 +2019,13 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
                 assert result.get("msg") is None
                 # verify that the content is the same
                 verify_copy = hosts.all.shell(
-                    cmd="dcat \"{0}\"".format(dest_data_set),
+                    cmd="dcat \'{0}\'".format(dest_data_set),
                     executable=SHELL_EXECUTABLE,
                 )
                 for vp_result in verify_copy.contacted.values():
                     print(vp_result)
                     verify_copy_2 = hosts.all.shell(
-                        cmd="dcat \"{0}\"".format(src_data_set),
+                        cmd="dcat \'{0}\'".format(src_data_set),
                         executable=SHELL_EXECUTABLE,
                     )
                     for vp_result_2 in verify_copy_2.contacted.values():

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1976,7 +1976,8 @@ def test_ensure_copy_file_does_not_change_permission_on_dest(ansible_zos_module,
 def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
     hosts = ansible_zos_module
     data_set_1 = get_tmp_ds_name()
-    data_set_2 = get_tmp_ds_name(symbols=True)
+    data_set_2 = get_tmp_ds_name(llq_size=4)
+    data_set_2 = f"{data_set_2}$#@"
     member_1 = "MEM1"
     if ds_type == "pds" or ds_type == "pdse":
         src_data_set = data_set_1 + "({0})".format(member_1)


### PR DESCRIPTION
##### SUMMARY
When force_lock option is set to False (Default) use function to validate if the data set is locked, when the dataset name include special characters it fails. Change now escape special characters.

Fixer #1898 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Escape dataset name and add simple quotes for calls on the shell for test suite.

<img width="1562" alt="Captura de pantalla 2025-02-05 a la(s) 2 01 26 p m" src="https://github.com/user-attachments/assets/c9f1d11f-c12b-4300-8190-b8683516d85a" />
<img width="630" alt="Captura de pantalla 2025-02-05 a la(s) 2 01 40 p m" src="https://github.com/user-attachments/assets/8a08cbe5-304f-46e4-b4bb-63dce8dc1ee7" />
<img width="1361" alt="Captura de pantalla 2025-02-05 a la(s) 2 35 40 p m" src="https://github.com/user-attachments/assets/94af028a-3072-41a7-ac87-5f725bba4b18" />
