### PR TITLE
Fix Contest after duplicated code was mistakenly inserted

### DIFF
--- a/changelogs/fragments/1915-fix-conftest.yml
+++ b/changelogs/fragments/1915-fix-conftest.yml
@@ -1,0 +1,3 @@
+trivial:
+  - tests/conftest.py - Removed duplicated code that was mistakenly introduced.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1915).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,25 +40,12 @@ def pytest_addoption(parser):
     Note: Set the default to to None, otherwise when evaluating with `request.config.getoption("--zinventory"):`
     will always return true because a default will be returned.
     """
-    """
-    Add CLI options and modify options for pytest-ansible where needed.
-    Note: Set the default to to None, otherwise when evaluating with `request.config.getoption("--zinventory"):`
-    will always return true because a default will be returned.
-    """
     parser.addoption(
         "--zinventory",
         "-Z",
         action="store",
         default=None,
-        default=None,
         help="Absolute path to YAML file containing inventory info for functional testing.",
-    )
-    parser.addoption(
-        "--zinventory-raw",
-        "-R",
-        action="store",
-        default=None,
-        help="Str - dictionary with values {'host': 'ibm.com', 'user': 'root', 'zoau': '/usr/lpp/zoau', 'pyz': '/usr/lpp/IBM/pyz'}",
     )
     parser.addoption(
         "--zinventory-raw",
@@ -72,15 +59,6 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="session")
 def z_python_interpreter(request):
     """ Generate temporary shell wrapper for python interpreter. """
-    src = None
-    helper = None
-    if request.config.getoption("--zinventory"):
-        src = request.config.getoption("--zinventory")
-        helper = ZTestHelper.from_yaml_file(src)
-    elif request.config.getoption("--zinventory-raw"):
-        src = request.config.getoption("--zinventory-raw")
-        helper = ZTestHelper.from_args(src)
-
     src = None
     helper = None
     if request.config.getoption("--zinventory"):
@@ -179,44 +157,6 @@ def volumes_with_vvds(ansible_zos_module, request):
     volumes_with_vvds = get_volumes_with_vvds(ansible_zos_module, list_volumes)
     yield volumes_with_vvds
 
-    # Call of the class by the class ls_Volume (volumes.py file) as many times needed
-    # one time the array is filled
-@pytest.fixture(scope="session")
-def volumes_on_systems(ansible_zos_module, request):
-    """ Call the pytest-ansible plugin to check volumes on the system and work properly a list by session."""
-    path = request.config.getoption("--zinventory")
-    list_volumes = None
-
-    # If path is None, check if zinventory-raw is used instead and if so, extract the
-    # volumes dictionary and pass it along.
-    if path is None:
-        src = request.config.getoption("--zinventory-raw")
-        helper = ZTestHelper.from_args(src)
-        list_volumes = helper.get_volumes_list()
-    else:
-        list_volumes = get_volumes(ansible_zos_module, path)
-    yield list_volumes
-
-
-@pytest.fixture(scope="session")
-def volumes_with_vvds(ansible_zos_module, request):
-    """ Return a list of volumes that have a VVDS. If no volume has a VVDS
-    then it will try to create one for each volume found and return volumes only
-    if a VVDS was successfully created for it."""
-    path = request.config.getoption("--zinventory")
-    list_volumes = None
-
-    # If path is None, check if zinventory-raw is used instead and if so, extract the
-    # volumes dictionary and pass it along.
-    if path is None:
-        src = request.config.getoption("--zinventory-raw")
-        helper = ZTestHelper.from_args(src)
-        list_volumes = helper.get_volumes_list()
-    else:
-        list_volumes = get_volumes(ansible_zos_module, path)
-
-    volumes_with_vvds = get_volumes_with_vvds(ansible_zos_module, list_volumes)
-    yield volumes_with_vvds
 
 
 # * We no longer edit sys.modules directly to add zoautil_py mock
@@ -243,13 +183,6 @@ def zos_import_mocker(mocker):
         return newimp
 
     yield (mocker, perform_imports)
-
-
-@pytest.fixture(scope="function")
-def get_config(request):
-    """ Call the pytest-ansible plugin to check volumes on the system and work properly a list by session."""
-    path = request.config.getoption("--zinventory")
-    yield path
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Looks like PR #1912 inserted some duplicated code into tests/conftest.py rendering the tests unusable. Fixed the issue by removing the duplicated code.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/conftest.py
