### PR TITLE
[Bug] 1839: zos job query was using a wildcard

### DIFF
--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -320,23 +320,17 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
 
     final_entries = []
 
-    with open("/tmp/log.txt", "a") as fh:
-        basic = "\r\nTRACEIN 332: id {}, owner {}, job name{} temp {}\r\n"
-        fmt = basic.format(job_id, owner, job_name, job_id_temp )
-        fh.write( fmt )
-
-
-
     # In 1.3.0, include_extended has to be set to true so we get the program name for a job.
-    entries = jobs.fetch_multiple(job_id=job_id_temp, include_extended=True)
+    # entries = jobs.fetch_multiple(job_id=job_id_temp, include_extended=True)
+
+    # expanding > 1.3.0 of zoau, to include all params
+    entries = jobs.fetch_multiple(job_id=job_id_temp, job_owner=owner, job_name=job_name, include_extended=True)
 
     while ((entries is None or len(entries) == 0) and duration <= timeout):
         current_time = timer()
         duration = round(current_time - start_time)
         sleep(1)
         entries = jobs.fetch_multiple(job_id=job_id_temp, include_extended=True)
-
-    # print( "\r\nTRACEIN 332: id {job_id}, owner {owner}, job name{job_name} temp {job_id_temp}\y\n")
 
     if entries:
         for entry in entries:
@@ -453,8 +447,8 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
                     else:
                         dd["procstep"] = None
 
-                    if "record_length" in single_dd:
-                        dd["byte_count"] = single_dd["record_length"]
+                    if "bytes" in single_dd:
+                        dd["byte_count"] = single_dd["bytes"]
                     else:
                         dd["byte_count"] = 0
 

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -319,18 +319,17 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
 
     final_entries = []
 
-    # In 1.3.0, include_extended has to be set to true so we get the program name for a job.
-    # entries = jobs.fetch_multiple(job_id=job_id_temp, include_extended=True)
+    # In ZOAU>= 1.3.0, include_extended has to be set to true so we get the program name for a job.
+    # Observation shows the job_name parameter is not being used, so we will drop that
 
     # expanding > 1.3.0 of zoau, to include all params
-    entries = jobs.fetch_multiple(job_id=job_id_temp, job_owner=owner, job_name=job_name, include_extended=True)
+    entries = jobs.fetch_multiple(job_id=job_id_temp, job_owner=owner, include_extended=True)
 
     while ((entries is None or len(entries) == 0) and duration <= timeout):
         current_time = timer()
         duration = round(current_time - start_time)
         sleep(1)
-        # entries = jobs.fetch_multiple(job_id=job_id_temp, include_extended=True)
-        entries = jobs.fetch_multiple(job_id=job_id_temp, job_owner=owner, job_name=job_name, include_extended=True)
+        entries = jobs.fetch_multiple(job_id=job_id_temp, job_owner=owner, include_extended=True)
 
     if entries:
         for entry in entries:

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -320,7 +320,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
 
     final_entries = []
 
-    with open("/tmp/log.txt", "wa") as fh:
+    with open("/tmp/log.txt", "a") as fh:
         basic = "\r\nTRACEIN 332: id {}, owner {}, job name{} temp {}\r\n"
         fmt = basic.format(job_id, owner, job_name, job_id_temp )
         fh.write( fmt )

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -34,7 +34,6 @@ try:
 except ImportError:
     exceptions = ZOAUImportError(traceback.format_exc())
 
-
 try:
     # For files that import individual functions from a ZOAU module,
     # we'll replace the imports to instead get the module.
@@ -330,7 +329,8 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
         current_time = timer()
         duration = round(current_time - start_time)
         sleep(1)
-        entries = jobs.fetch_multiple(job_id=job_id_temp, include_extended=True)
+        # entries = jobs.fetch_multiple(job_id=job_id_temp, include_extended=True)
+        entries = jobs.fetch_multiple(job_id=job_id_temp, job_owner=owner, job_name=job_name, include_extended=True)
 
     if entries:
         for entry in entries:

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -320,6 +320,13 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
 
     final_entries = []
 
+    with open("/tmp/log.txt", "wa") as fh:
+        basic = "\r\nTRACEIN 332: id {}, owner {}, job name{} temp {}\r\n"
+        fmt = basic.format(job_id, owner, job_name, job_id_temp )
+        fh.write( fmt )
+
+
+
     # In 1.3.0, include_extended has to be set to true so we get the program name for a job.
     entries = jobs.fetch_multiple(job_id=job_id_temp, include_extended=True)
 
@@ -328,6 +335,8 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
         duration = round(current_time - start_time)
         sleep(1)
         entries = jobs.fetch_multiple(job_id=job_id_temp, include_extended=True)
+
+    # print( "\r\nTRACEIN 332: id {job_id}, owner {owner}, job name{job_name} temp {job_id_temp}\y\n")
 
     if entries:
         for entry in entries:

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2024
+# Copyright (c) IBM Corporation 2019, 2025
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -38,6 +38,8 @@ options:
        - A job name can be up to 8 characters long.
        - The I(job_name) can contain include multiple wildcards.
        - The asterisk (`*`) wildcard will match zero or more specified characters.
+       - Note that using this value will query the system for '*' and then return just matching values
+       - This may lead to security issues if there are read-access limitations on some users or jobs
     type: str
     required: False
     default: "*"


### PR DESCRIPTION
##### SUMMARY
Customer reported issues where a job query would query *, which was against their policy.

Reading through line 300+ in module_utils/job.py showed that two of the parameters were ignored during the request, leading to inefficiency.  If you asked for a job_id, that is all that would return, but if you asked for job_owner or job_name, we asked for *, then filtered out what wasn't needed.  On a large system, this was a time killer.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zos_job_query was the outer-facing module, called by zos_job_submit et al.
The internal was module_utils/job.py


