### PR TITLE
[Enabler] [zos_job_submit] [zos_fetch] Fix invalid escape sequence that results in DeprecationWarning 

### DIFF
--- a/changelogs/fragments/1925-Deprecation-warning-zos-fetch-and-zos-job-submit.yml
+++ b/changelogs/fragments/1925-Deprecation-warning-zos-fetch-and-zos-job-submit.yml
@@ -1,0 +1,5 @@
+trivial:
+  -  tests/functional/modules/test_zos_fetch_func.py- Fixed deprecation warning invalid escape sequence using '\\c\' instead of '\c\'.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1925).
+  -  tests/functional/modules/test_zos_job_submit_func.py- Fixed deprecation warning invalid escape sequence using '\\$' instead of '\$'.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1925).

--- a/changelogs/fragments/1925-Deprecation-warning-zos-fetch-and-zos-job-submit.yml
+++ b/changelogs/fragments/1925-Deprecation-warning-zos-fetch-and-zos-job-submit.yml
@@ -1,5 +1,5 @@
 trivial:
-  -  tests/functional/modules/test_zos_fetch_func.py- Fixed deprecation warning invalid escape sequence using '\\c\' instead of '\c\'.
+  - tests/functional/modules/test_zos_fetch_func.py- Fixed deprecation warning invalid escape sequence using '\\c\' instead of '\c\'.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1925).
-  -  tests/functional/modules/test_zos_job_submit_func.py- Fixed deprecation warning invalid escape sequence using '\\$' instead of '\$'.
+  - tests/functional/modules/test_zos_job_submit_func.py- Fixed deprecation warning invalid escape sequence using '\\$' instead of '\$'.
     (https://github.com/ansible-collections/ibm_zos_core/pull/1925).

--- a/tests/functional/modules/test_zos_fetch_func.py
+++ b/tests/functional/modules/test_zos_fetch_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020, 2024
+# Copyright (c) IBM Corporation 2020, 2025
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -331,7 +331,7 @@ def test_fetch_vsam_data_set(ansible_zos_module, volumes_on_systems):
         hosts.all.zos_job_submit(
             src=f"{temp_jcl_path}/SAMPLE", location="uss", wait_time_s=30
         )
-        hosts.all.shell(cmd=f"echo \"{TEST_DATA}\c\" > {uss_file}")
+        hosts.all.shell(cmd=f"echo \"{TEST_DATA}\\c\" > {uss_file}")
         hosts.all.zos_encode(
             src=uss_file,
             dest=test_vsam,

--- a/tests/functional/modules/test_zos_fetch_func.py
+++ b/tests/functional/modules/test_zos_fetch_func.py
@@ -331,7 +331,7 @@ def test_fetch_vsam_data_set(ansible_zos_module, volumes_on_systems):
         hosts.all.zos_job_submit(
             src=f"{temp_jcl_path}/SAMPLE", location="uss", wait_time_s=30
         )
-        hosts.all.shell(cmd=rf"echo \"{TEST_DATA}\c\" > {uss_file}")
+        hosts.all.shell(cmd=f"echo \"{TEST_DATA}\\c\" > {uss_file}")
         hosts.all.zos_encode(
             src=uss_file,
             dest=test_vsam,

--- a/tests/functional/modules/test_zos_fetch_func.py
+++ b/tests/functional/modules/test_zos_fetch_func.py
@@ -331,7 +331,7 @@ def test_fetch_vsam_data_set(ansible_zos_module, volumes_on_systems):
         hosts.all.zos_job_submit(
             src=f"{temp_jcl_path}/SAMPLE", location="uss", wait_time_s=30
         )
-        hosts.all.shell(cmd=f"echo \"{TEST_DATA}\\c\" > {uss_file}")
+        hosts.all.shell(cmd=rf"echo \"{TEST_DATA}\c\" > {uss_file}")
         hosts.all.zos_encode(
             src=uss_file,
             dest=test_vsam,

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -608,17 +608,17 @@ def test_job_submit_local_extra_r(ansible_zos_module):
         assert result.get("changed") is True
 
 
-def test_job_submit_local_badjcl(ansible_zos_module):
-    tmp_file = tempfile.NamedTemporaryFile(delete=True)
-    with open(tmp_file.name, "w",encoding="utf-8") as f:
-        f.write(JCL_FILE_CONTENTS_BAD)
-    hosts = ansible_zos_module
-    results = hosts.all.zos_job_submit(src=tmp_file.name, location="local", wait_time_s=10)
+# def test_job_submit_local_badjcl(ansible_zos_module):
+#     tmp_file = tempfile.NamedTemporaryFile(delete=True)
+#     with open(tmp_file.name, "w",encoding="utf-8") as f:
+#         f.write(JCL_FILE_CONTENTS_BAD)
+#     hosts = ansible_zos_module
+#     results = hosts.all.zos_job_submit(src=tmp_file.name, location="local", wait_time_s=10)
 
-    for result in results.contacted.values():
-        # Expecting: The job completion code (CC) was not in the job log....."
-        assert result.get("changed") is False
-        assert re.search(r'completion code', repr(result.get("msg")))
+#     for result in results.contacted.values():
+#         # Expecting: The job completion code (CC) was not in the job log....."
+#         assert result.get("changed") is False
+#         assert re.search(r'completion code', repr(result.get("msg")))
 
 
 def test_job_submit_pds_volume(ansible_zos_module, volumes_on_systems):

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -504,7 +504,7 @@ def test_job_submit_pds_special_characters(ansible_zos_module):
         )
         hosts.all.shell(
             cmd="cp {0}/SAMPLE \"//'{1}(SAMPLE)'\"".format(
-                temp_path, data_set_name_special_chars.replace('$', r'\$')
+                temp_path, data_set_name_special_chars.replace('$', '\\$')
             )
         )
         results = hosts.all.zos_job_submit(

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2024
+# Copyright (c) IBM Corporation 2019, 2025
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -504,7 +504,7 @@ def test_job_submit_pds_special_characters(ansible_zos_module):
         )
         hosts.all.shell(
             cmd="cp {0}/SAMPLE \"//'{1}(SAMPLE)'\"".format(
-                temp_path, data_set_name_special_chars.replace('$', '\$')
+                temp_path, data_set_name_special_chars.replace('$', r'\$')
             )
         )
         results = hosts.all.zos_job_submit(

--- a/tests/functional/modules/test_zos_job_submit_func.py
+++ b/tests/functional/modules/test_zos_job_submit_func.py
@@ -608,17 +608,17 @@ def test_job_submit_local_extra_r(ansible_zos_module):
         assert result.get("changed") is True
 
 
-# def test_job_submit_local_badjcl(ansible_zos_module):
-#     tmp_file = tempfile.NamedTemporaryFile(delete=True)
-#     with open(tmp_file.name, "w",encoding="utf-8") as f:
-#         f.write(JCL_FILE_CONTENTS_BAD)
-#     hosts = ansible_zos_module
-#     results = hosts.all.zos_job_submit(src=tmp_file.name, location="local", wait_time_s=10)
+def test_job_submit_local_badjcl(ansible_zos_module):
+    tmp_file = tempfile.NamedTemporaryFile(delete=True)
+    with open(tmp_file.name, "w",encoding="utf-8") as f:
+        f.write(JCL_FILE_CONTENTS_BAD)
+    hosts = ansible_zos_module
+    results = hosts.all.zos_job_submit(src=tmp_file.name, location="local", wait_time_s=10)
 
-#     for result in results.contacted.values():
-#         # Expecting: The job completion code (CC) was not in the job log....."
-#         assert result.get("changed") is False
-#         assert re.search(r'completion code', repr(result.get("msg")))
+    for result in results.contacted.values():
+        # Expecting: The job completion code (CC) was not in the job log....."
+        assert result.get("changed") is False
+        assert re.search(r'completion code', repr(result.get("msg")))
 
 
 def test_job_submit_pds_volume(ansible_zos_module, volumes_on_systems):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As the existing function was giving the Deprecation warning  in the escape sequence in the two functions. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test_zos_fetch_func.py
test_zos_job_submit_func.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
