### PR TITLE
[1.13.0] Post release fixes into staging branch

### DIFF
--- a/changelogs/fragments/1926-fix-beta-branch.yml
+++ b/changelogs/fragments/1926-fix-beta-branch.yml
@@ -1,2 +1,5 @@
 trivial:
-  - lineinfile - add warning when using an empty regexp (https://github.com/ansible-collections/ibm_zos_core/pull/1925).
+  - tests/conftests.py - Removed some duplicated code entries.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1925).
+  - docs/source/release_notes.rst - Updated v1.13.0-beta.1 release notes.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1925).

--- a/changelogs/fragments/1926-fix-beta-branch.yml
+++ b/changelogs/fragments/1926-fix-beta-branch.yml
@@ -1,0 +1,2 @@
+trivial:
+  - lineinfile - add warning when using an empty regexp (https://github.com/ansible-collections/ibm_zos_core/pull/1925).

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,13 +6,12 @@
 Releases
 ========
 
-v1.13.0-beta.1
-==============
+Version 1.13.0-beta.1
+=====================
 
 Minor Changes
 -------------
 
-- ``import_handler`` - When importing a non supported ZOAU version like 1.2.x the module would throw a non user friendly error message. Error message is now explicit about ZOAU not being properly configured for Ansible.
 - ``zos_copy``
 
    - Added new option ``autoescape`` to ``template_parameters``, allowing users to disable autoescaping of common XML/HTML characters when working with Jinja templates.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) IBM Corporation 2019, 2024
+# Copyright (c) IBM Corporation 2019, 2025
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,10 +194,3 @@ def get_config(request):
     """ Call the pytest-ansible plugin to check volumes on the system and work properly a list by session."""
     path = request.config.getoption("--zinventory")
     yield path
-
-
-@pytest.fixture(scope="function")
-def get_config(request):
-    """ Call the pytest-ansible plugin to check volumes on the system and work properly a list by session."""
-    path = request.config.getoption("--zinventory")
-    yield path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 # Copyright (c) IBM Corporation 2019, 2024
-# Copyright (c) IBM Corporation 2019, 2024
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -51,15 +50,7 @@ def pytest_addoption(parser):
         "-Z",
         action="store",
         default=None,
-        default=None,
         help="Absolute path to YAML file containing inventory info for functional testing.",
-    )
-    parser.addoption(
-        "--zinventory-raw",
-        "-R",
-        action="store",
-        default=None,
-        help="Str - dictionary with values {'host': 'ibm.com', 'user': 'root', 'zoau': '/usr/lpp/zoau', 'pyz': '/usr/lpp/IBM/pyz'}",
     )
     parser.addoption(
         "--zinventory-raw",
@@ -73,15 +64,6 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="session")
 def z_python_interpreter(request):
     """ Generate temporary shell wrapper for python interpreter. """
-    src = None
-    helper = None
-    if request.config.getoption("--zinventory"):
-        src = request.config.getoption("--zinventory")
-        helper = ZTestHelper.from_yaml_file(src)
-    elif request.config.getoption("--zinventory-raw"):
-        src = request.config.getoption("--zinventory-raw")
-        helper = ZTestHelper.from_args(src)
-
     src = None
     helper = None
     if request.config.getoption("--zinventory"):
@@ -141,47 +123,8 @@ def ansible_zos_module(request, z_python_interpreter):
     except Exception:
         pass
 
-    # Call of the class by the class ls_Volume (volumes.py file) as many times needed
-    # one time the array is filled
-@pytest.fixture(scope="session")
-def volumes_on_systems(ansible_zos_module, request):
-    """ Call the pytest-ansible plugin to check volumes on the system and work properly a list by session."""
-    path = request.config.getoption("--zinventory")
-    list_volumes = None
-
-    # If path is None, check if zinventory-raw is used instead and if so, extract the
-    # volumes dictionary and pass it along.
-    if path is None:
-        src = request.config.getoption("--zinventory-raw")
-        helper = ZTestHelper.from_args(src)
-        list_volumes = helper.get_volumes_list()
-    else:
-        list_volumes = get_volumes(ansible_zos_module, path)
-    yield list_volumes
-
-
-@pytest.fixture(scope="session")
-def volumes_with_vvds(ansible_zos_module, request):
-    """ Return a list of volumes that have a VVDS. If no volume has a VVDS
-    then it will try to create one for each volume found and return volumes only
-    if a VVDS was successfully created for it."""
-    path = request.config.getoption("--zinventory")
-    list_volumes = None
-
-    # If path is None, check if zinventory-raw is used instead and if so, extract the
-    # volumes dictionary and pass it along.
-    if path is None:
-        src = request.config.getoption("--zinventory-raw")
-        helper = ZTestHelper.from_args(src)
-        list_volumes = helper.get_volumes_list()
-    else:
-        list_volumes = get_volumes(ansible_zos_module, path)
-
-    volumes_with_vvds = get_volumes_with_vvds(ansible_zos_module, list_volumes)
-    yield volumes_with_vvds
-
-    # Call of the class by the class ls_Volume (volumes.py file) as many times needed
-    # one time the array is filled
+# Call of the class by the class ls_Volume (volumes.py file) as many times needed
+# one time the array is filled
 @pytest.fixture(scope="session")
 def volumes_on_systems(ansible_zos_module, request):
     """ Call the pytest-ansible plugin to check volumes on the system and work properly a list by session."""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There were a couple of misses in the release notes that we fixed when publishing the docs, now I'm including these to the staging branch so once we publish this GA these are included.

Also, a piece of code was duplicated in the contest.py file, apparently this happens because the main branch and dev branch are too different and git compares both based on commits and not diffs when doing a pull request. We will probably need to change how we handle the `main` branch and not squash merges into there, but rather let it be a copy of `dev`.

With these changes now the test suite can be executed: 

```shell
(venv-2.18) python3 -m pytest --host-pattern=all --zinventory=/Users/fernandoflores/test_config.yml tests/functional/modules/test_zos_script_func.py -x -vvv -k test_rexx_script_with_args
INFO:pytest_ansible.units:Looking for collection info in /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/galaxy.yml
INFO:pytest_ansible.units:Collection namespace: ibm
INFO:pytest_ansible.units:Collection name: ibm_zos_core
INFO:pytest_ansible.units:Not in collection tree
INFO:pytest_ansible.units:Additional Collections Paths: [PosixPath('/Users/fernandoflores/.ansible/collections')]
INFO:pytest_ansible.units:Setting ANSIBLE_COLLECTIONS_PATH to /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/collections:/Users/fernandoflores/.ansible/collections
================================================================= test session starts =================================================================
platform darwin -- Python 3.12.7, pytest-8.3.4, pluggy-1.5.0 -- /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/venv/venv-2.18/bin/python3
cachedir: .pytest_cache
ansible: 2.18.1
rootdir: /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/tests
configfile: pytest.ini
plugins: ansible-25.1.0, mock-3.14.0
collected 11 items / 10 deselected / 1 selected                                                                                                       

tests/functional/modules/test_zos_script_func.py::test_rexx_script_with_args PASSED                                                             [100%]

================================================================== warnings summary ===================================================================
functional/modules/test_zos_script_func.py::test_rexx_script_with_args
functional/modules/test_zos_script_func.py::test_rexx_script_with_args
functional/modules/test_zos_script_func.py::test_rexx_script_with_args
  /Users/fernandoflores/Documents/IBM/Repos/ibm_zos_core/venv/venv-2.18/lib/python3.12/site-packages/ansible/plugins/loader.py:1486: UserWarning: AnsibleCollectionFinder has already been configured
    warnings.warn('AnsibleCollectionFinder has already been configured')

functional/modules/test_zos_script_func.py::test_rexx_script_with_args
functional/modules/test_zos_script_func.py::test_rexx_script_with_args
functional/modules/test_zos_script_func.py::test_rexx_script_with_args
functional/modules/test_zos_script_func.py::test_rexx_script_with_args
  /opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=54970) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 1 passed, 10 deselected, 7 warnings in 24.13s ====================================================

```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request