### PR TITLE
[Enabler][ac] Update test config entry in venv.sh so that when running ac-test it will get written into config.yml

### DIFF
--- a/scripts/venv.sh
+++ b/scripts/venv.sh
@@ -786,6 +786,8 @@ if [ "${volumes}" ]; then
     done
 fi
 
+CONFIG=${CONFIG}"ssh_key: ~/.ssh/id_rsa\\n"
+
 echo -e $CONFIG>$managed_venv_path/config.yml
 }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some tests need the ssh_key entry. THIS IS NOT A KEY but rather the location of it in the controller node, this was originally missing in the config.yml created by the ac tool.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ac tool

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
