### PR TITLE
[Bug][1.13.0] Fix zos_copy failing when copying asa characters into a data set with special chars in their name

### DIFF
--- a/changelogs/fragments/1924-zos_copy-asa-special-char.yml
+++ b/changelogs/fragments/1924-zos_copy-asa-special-char.yml
@@ -1,0 +1,4 @@
+bugfixes:
+   - zos_copy - Previously, if the dataset name included special characters such as ``$`` and ``asa_text`` option is true, the module would fail.
+     Fix now allows the use of special characters in the data set name when ``asa_text`` option is true.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/1924).

--- a/plugins/module_utils/copy.py
+++ b/plugins/module_utils/copy.py
@@ -232,7 +232,10 @@ def copy_asa_uss2mvs(src, dest, tmphlq=None):
     """
 
     module = AnsibleModuleHelper(argument_spec={})
-    oget_cmd = f"tsocmd \" OGET '{src}' '{dest}' \""
+    new_dest = dest.replace('\\', '')
+    new_source = src.replace('\\', '')
+    # Removes escaping to execute this command
+    oget_cmd = f"tsocmd \" OGET '{new_source}' '{new_dest}' \""
     rc, out, err = module.run_command(oget_cmd)
 
     return TSOCmdResponse(rc, out, err)
@@ -261,8 +264,10 @@ def copy_asa_mvs2uss(src, dest, tmphlq=None):
     """
     src = _validate_data_set_name(src)
     dest = _validate_path(dest)
-
-    oput_cmd = "OPUT '{0}' '{1}'".format(src, dest)
+    # Removes escaping to execute this command
+    new_dest = dest.replace('\\', '')
+    new_source = src.replace('\\', '')
+    oput_cmd = "OPUT '{0}' '{1}'".format(new_source, new_dest)
     rc, out, err = ikjeft01(oput_cmd, authorized=True, tmphlq=tmphlq)
 
     return TSOCmdResponse(rc, out, err)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3183,6 +3183,7 @@ def data_set_locked(dataset_name):
     # in the result with a length greater than 4.
     result = dict()
     result["stdout"] = []
+    dataset_name = dataset_name.replace("$", "\\$")
     command_dgrs = "D GRS,RES=(*,{0})".format(dataset_name)
 
     try:

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -1619,7 +1619,8 @@ def test_copy_asa_file_to_asa_sequential(ansible_zos_module):
     hosts = ansible_zos_module
 
     try:
-        dest = get_tmp_ds_name()
+        dest = get_tmp_ds_name(llq_size=4)
+        dest = f"{dest}$#@"
         hosts.all.zos_data_set(name=dest, state="absent")
 
         copy_result = hosts.all.zos_copy(
@@ -1629,8 +1630,12 @@ def test_copy_asa_file_to_asa_sequential(ansible_zos_module):
             asa_text=True
         )
 
+        # We need to escape the data set name because we are using cat, using dcat will
+        # bring the trailing empty spaces according to the data set record length.
+        # We only need to escape $ character in this notation
+        dest_escaped = dest.replace('$', '\\$')
         verify_copy = hosts.all.shell(
-            cmd="cat \"//'{0}'\"".format(dest),
+            cmd="cat \"//'{0}'\"".format(dest_escaped),
             executable=SHELL_EXECUTABLE,
         )
 
@@ -1655,7 +1660,7 @@ def test_copy_asa_file_to_asa_partitioned(ansible_zos_module):
     try:
         dest = get_tmp_ds_name()
         hosts.all.zos_data_set(name=dest, state="absent")
-        full_dest = "{0}(TEST)".format(dest)
+        full_dest = "{0}(TE$@#)".format(dest)
 
         copy_result = hosts.all.zos_copy(
             content=ASA_SAMPLE_CONTENT,
@@ -1664,17 +1669,23 @@ def test_copy_asa_file_to_asa_partitioned(ansible_zos_module):
             asa_text=True
         )
 
+        # We need to escape the data set name because we are using cat, using dcat will
+        # bring the trailing empty spaces according to the data set record length.
+        # We only need to escape $ character in this notation
+        dest_escaped = full_dest.replace('$', '\\$')
         verify_copy = hosts.all.shell(
-            cmd="cat \"//'{0}'\"".format(full_dest),
+            cmd="cat \"//'{0}'\"".format(dest_escaped),
             executable=SHELL_EXECUTABLE,
         )
 
         for cp_res in copy_result.contacted.values():
+            print(cp_res)
             assert cp_res.get("msg") is None
             assert cp_res.get("changed") is True
             assert cp_res.get("dest") == full_dest
             assert cp_res.get("dest_created") is True
         for v_cp in verify_copy.contacted.values():
+            print(v_cp)
             assert v_cp.get("rc") == 0
             assert v_cp.get("stdout") == ASA_SAMPLE_RETURN
     finally:
@@ -1687,7 +1698,8 @@ def test_copy_seq_data_set_to_seq_asa(ansible_zos_module):
     hosts = ansible_zos_module
 
     try:
-        src = get_tmp_ds_name()
+        src = get_tmp_ds_name(llq_size=4)
+        src = f"{src}$#@"
         hosts.all.zos_data_set(
             name=src,
             state="present",
@@ -1695,7 +1707,8 @@ def test_copy_seq_data_set_to_seq_asa(ansible_zos_module):
             replace=True
         )
 
-        dest = get_tmp_ds_name()
+        dest = get_tmp_ds_name(llq_size=4)
+        dest = f"{dest}$#@"
         hosts.all.zos_data_set(name=dest, state="absent")
 
         hosts.all.zos_copy(
@@ -1711,8 +1724,12 @@ def test_copy_seq_data_set_to_seq_asa(ansible_zos_module):
             asa_text=True
         )
 
+        # We need to escape the data set name because we are using cat, using dcat will
+        # bring the trailing empty spaces according to the data set record length.
+        # We only need to escape $ character in this notation
+        dest_escaped = dest.replace('$', '\\$')
         verify_copy = hosts.all.shell(
-            cmd="cat \"//'{0}'\"".format(dest),
+            cmd="cat \"//'{0}'\"".format(dest_escaped),
             executable=SHELL_EXECUTABLE,
         )
 
@@ -1736,7 +1753,8 @@ def test_copy_seq_data_set_to_partitioned_asa(ansible_zos_module):
     hosts = ansible_zos_module
 
     try:
-        src = get_tmp_ds_name()
+        src = get_tmp_ds_name(llq_size=4)
+        src = f"{src}$#@"
         hosts.all.zos_data_set(
             name=src,
             state="present",
@@ -1744,8 +1762,9 @@ def test_copy_seq_data_set_to_partitioned_asa(ansible_zos_module):
             replace=True
         )
 
-        dest = get_tmp_ds_name()
-        full_dest = "{0}(MEMBER)".format(dest)
+        dest = get_tmp_ds_name(llq_size=4)
+        dest = f"{dest}$#@"
+        full_dest = "{0}(MEMB$#@)".format(dest)
         hosts.all.zos_data_set(name=dest, state="absent")
 
         hosts.all.zos_copy(
@@ -1761,8 +1780,12 @@ def test_copy_seq_data_set_to_partitioned_asa(ansible_zos_module):
             asa_text=True
         )
 
+        # We need to escape the data set name because we are using cat, using dcat will
+        # bring the trailing empty spaces according to the data set record length.
+        # We only need to escape $ character in this notation
+        dest_escaped = full_dest.replace('$', '\\$')
         verify_copy = hosts.all.shell(
-            cmd="cat \"//'{0}'\"".format(full_dest),
+            cmd="cat \"//'{0}'\"".format(dest_escaped),
             executable=SHELL_EXECUTABLE,
         )
 
@@ -1786,8 +1809,9 @@ def test_copy_partitioned_data_set_to_seq_asa(ansible_zos_module):
     hosts = ansible_zos_module
 
     try:
-        src = get_tmp_ds_name()
-        full_src = "{0}(MEMBER)".format(src)
+        src = get_tmp_ds_name(llq_size=4)
+        src = f"{src}$#@"
+        full_src = "{0}(MEM$#@)".format(src)
         hosts.all.zos_data_set(
             name=src,
             state="present",
@@ -1795,7 +1819,8 @@ def test_copy_partitioned_data_set_to_seq_asa(ansible_zos_module):
             replace=True
         )
 
-        dest = get_tmp_ds_name()
+        dest = get_tmp_ds_name(llq_size=4)
+        dest = f"{dest}$#@"
         hosts.all.zos_data_set(name=dest, state="absent")
 
         hosts.all.zos_copy(
@@ -1811,8 +1836,12 @@ def test_copy_partitioned_data_set_to_seq_asa(ansible_zos_module):
             asa_text=True
         )
 
+        # We need to escape the data set name because we are using cat, using dcat will
+        # bring the trailing empty spaces according to the data set record length.
+        # We only need to escape $ character in this notation
+        dest_escaped = dest.replace('$', '\\$')
         verify_copy = hosts.all.shell(
-            cmd="cat \"//'{0}'\"".format(dest),
+            cmd="cat \"//'{0}'\"".format(dest_escaped),
             executable=SHELL_EXECUTABLE,
         )
 
@@ -1836,7 +1865,8 @@ def test_copy_partitioned_data_set_to_partitioned_asa(ansible_zos_module):
     hosts = ansible_zos_module
 
     try:
-        src = get_tmp_ds_name()
+        src = get_tmp_ds_name(llq_size=4)
+        src = f"{src}$#@"
         full_src = "{0}(MEMBER)".format(src)
         hosts.all.zos_data_set(
             name=src,
@@ -1845,8 +1875,9 @@ def test_copy_partitioned_data_set_to_partitioned_asa(ansible_zos_module):
             replace=True
         )
 
-        dest = get_tmp_ds_name()
-        full_dest = "{0}(MEMBER)".format(dest)
+        dest = get_tmp_ds_name(llq_size=4)
+        dest = f"{dest}$#@"
+        full_dest = "{0}(MEM$#@)".format(dest)
         hosts.all.zos_data_set(name=dest, state="absent")
 
         hosts.all.zos_copy(
@@ -1862,8 +1893,12 @@ def test_copy_partitioned_data_set_to_partitioned_asa(ansible_zos_module):
             asa_text=True
         )
 
+        # We need to escape the data set name because we are using cat, using dcat will
+        # bring the trailing empty spaces according to the data set record length.
+        # We only need to escape $ character in this notation
+        dest_escaped = full_dest.replace('$', '\\$')
         verify_copy = hosts.all.shell(
-            cmd="cat \"//'{0}'\"".format(full_dest),
+            cmd="cat \"//'{0}'\"".format(dest_escaped),
             executable=SHELL_EXECUTABLE,
         )
 
@@ -1887,7 +1922,8 @@ def test_copy_asa_data_set_to_text_file(ansible_zos_module):
     hosts = ansible_zos_module
 
     try:
-        src = get_tmp_ds_name()
+        src = get_tmp_ds_name(llq_size=4)
+        src = f"{src}$#@"
         hosts.all.zos_data_set(
             name=src,
             state="present",
@@ -1904,6 +1940,7 @@ def test_copy_asa_data_set_to_text_file(ansible_zos_module):
         )
 
         dest = get_random_file_name(dir=TMP_DIRECTORY)
+        dest = f"{dest}$#@"
 
         copy_result = hosts.all.zos_copy(
             src=src,
@@ -1913,7 +1950,7 @@ def test_copy_asa_data_set_to_text_file(ansible_zos_module):
         )
 
         verify_copy = hosts.all.shell(
-            cmd="cat {0}".format(dest),
+            cmd="cat '{0}'".format(dest),
             executable=SHELL_EXECUTABLE,
         )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This fix is the same as https://github.com/ansible-collections/ibm_zos_core/pull/1904 but now forward ported into dev.

Fixes zos_copy failing when copying asa text into a data set with special characters in their name. Fix removes any escaping in both source and dest before issuing either OGET or OPUT commands.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1921 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
