### PR TITLE
Enabler/1903/zos volume init

### DIFF
--- a/tests/functional/modules/test_zos_volume_init_func.py
+++ b/tests/functional/modules/test_zos_volume_init_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2023, 2024
+# Copyright (c) IBM Corporation 2023, 2025
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -16,46 +16,36 @@ import pytest
 
 __metaclass__ = type
 
-from ibm_zos_core.tests.helpers.volumes import Volume_Handler
-from ibm_zos_core.tests.helpers.dataset import get_tmp_ds_name
-
-# To run the test suite is a recommendation to use the volumes in order
-# 'USER02', '01A2'
-# new list of similar volumes will be added in next iteration
+TEST_VOL_ADDR = '01A2'
+TEST_VOL_SER = 'USER02'
 
 INDEX_CREATION_SUCCESS_MSG = 'VTOC INDEX CREATION SUCCESSFUL'
 VTOC_LOC_MSG = "ICK01314I VTOC IS LOCATED AT CCHH=X'0000 0001' AND IS  {:4d} TRACKS."
 
-def clear_volume(hosts, volume):
-    datasets_in_volume = hosts.all.shell(cmd="vtocls {0}".format(volume))
-    for dataset in datasets_in_volume.contacted.values():
-        datasets = str(dataset.get("stdout")).split("\n")
-    for dataset in datasets:
-        dataset_t_del = dataset.split(' ', 1)[0]
-        hosts.all.shell(cmd="""drm "{0}" """.format(dataset_t_del))
 
 # Guard Rail to prevent unintentional initialization of targeted volume.
 # If this test fails, either reset target volume serial to match
 # verify_volid below or change value to match current volume serial on
 # target.
 
-def test_guard_rail_and_setup(ansible_zos_module, volumes_on_systems):
+def test_guard_rail_and_setup(ansible_zos_module):
     hosts = ansible_zos_module
+    print("running the new cases i mean old duh ")
+
     # remove all data sets from target volume. Expected to be the following 3
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-    clear_volume(hosts, volume_1)
+    hosts.all.zos_data_set(name="IMSTESTL.IMS01.SPOOL1", state="absent")
+    hosts.all.zos_data_set(name="IMSTESTL.IMS01.SPOOL2", state="absent")
+    hosts.all.zos_data_set(name="IMSTESTL.IMS01.SPOOL3", state="absent")
 
     params = {
-        "address":volume_2,
+        "address":TEST_VOL_ADDR,
         "verify_offline":False,
-        "volid":volume_1,
-        "verify_volid":volume_1
+        "volid":TEST_VOL_SER,
+        "verify_volid":'USER02'
     }
 
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
 
     results = hosts.all.zos_volume_init(
         address=params['address'],
@@ -69,25 +59,33 @@ def test_guard_rail_and_setup(ansible_zos_module, volumes_on_systems):
         assert result['rc'] == 0
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
 
 
-def test_index_param_index(ansible_zos_module, volumes_on_systems):
+@pytest.mark.parametrize(
+    "params", [
+        # min params test with index : true
+        ({
+            'address': TEST_VOL_ADDR,
+            'verify_offline': False,
+            'volid': TEST_VOL_SER,
+            'index' : True
+        }),
+        # min params test with index : false
+        ({
+            'address': TEST_VOL_ADDR,
+            'verify_offline': False,
+            'volid': TEST_VOL_SER,
+            'index' : False,
+            'sms_managed' : False # default is True, which cannot be with no index.
+        }),
+    ]
+)
+def test_index_param(ansible_zos_module, params):
     hosts = ansible_zos_module
 
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
-
-    params = {
-        "address": volume_2,
-        "verify_offline": False,
-        "volid": volume_1,
-        "index" : True
-    }
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
@@ -101,62 +99,26 @@ def test_index_param_index(ansible_zos_module, volumes_on_systems):
             assert INDEX_CREATION_SUCCESS_MSG not in content_str
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
-
-
-def test_index_param_index_sms_false(ansible_zos_module, volumes_on_systems):
-    hosts = ansible_zos_module
-
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
-    # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
-
-    params = {
-        "address": volume_2,
-        "verify_offline": False,
-        "volid": volume_1,
-        "index" : True,
-        "sms_managed" : False
-    }
-
-    results = hosts.all.zos_volume_init(**params)
-
-    for result in results.contacted.values():
-        assert result.get("changed") is True
-        assert result.get('rc') == 0
-        content_str = ''.join(result.get("content"))
-        if params['index']:
-            assert INDEX_CREATION_SUCCESS_MSG in content_str
-        else:
-            assert INDEX_CREATION_SUCCESS_MSG not in content_str
-
-    # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
 
 
 # check that correct volume_addr is assigned to correct volid
-def test_volid_address_assigned_correctly(ansible_zos_module, volumes_on_systems):
+def test_volid_address_assigned_correctly(ansible_zos_module):
     hosts = ansible_zos_module
-
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
+    print(f"running the new cases i mean old duh ")
 
     params = {
-        'address': volume_2,
+        'address': TEST_VOL_ADDR,
         'verify_offline': False,
-        'volid': volume_1,
+        'volid': TEST_VOL_SER,
     }
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
 
     for result in results.contacted.values():
         assert result.get("changed") is True
@@ -176,62 +138,55 @@ def test_volid_address_assigned_correctly(ansible_zos_module, volumes_on_systems
 
     # Display command to print device status, volser and addr should correspond
     display_cmd_output = list(
-        hosts.all.zos_operator(cmd=f"D U,VOL={volume_1}").contacted.values()
+        hosts.all.zos_operator(cmd=f"D U,VOL={TEST_VOL_SER}").contacted.values()
     )[0]
 
     # zos_operator output contains the command as well, only the last line of
     # the output is relevant for the needs of this test case.
     display_cmd_output = display_cmd_output.get('content')[-1]
 
-    assert volume_1 in display_cmd_output
+    assert TEST_VOL_SER in display_cmd_output
 
-def test_no_index_sms_managed_mutually_exclusive(ansible_zos_module, volumes_on_systems):
+def test_no_index_sms_managed_mutually_exclusive(ansible_zos_module):
     hosts = ansible_zos_module
 
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
     params = {
-        'address': volume_2,
+        'address': TEST_VOL_ADDR,
         'verify_offline': False,
-        'volid': volume_1,
+        'volid': TEST_VOL_SER,
         'index' : False,
         'sms_managed' : True
     }
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
 
     for result in results.contacted.values():
         assert result.get("changed") is False
         assert "'Index' cannot be False" in result.get("msg")
 
-
-def test_vtoc_size_parm(ansible_zos_module, volumes_on_systems):
+def test_vtoc_size_parm(ansible_zos_module):
     hosts = ansible_zos_module
+    print(f"running the new cases i mean old duh  test_vtoc size ")
 
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
     params = {
-        'address': volume_2,
+        'address': TEST_VOL_ADDR,
         'verify_offline': False,
-        'volid': volume_1,
+        'volid': TEST_VOL_SER,
         'vtoc_size' : 8
         # 'vtoc_size' : 11 # test to test that this test handles 2 digit vtoc_index
     }
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
 
     for result in results.contacted.values():
         assert result.get("changed") is True
@@ -239,21 +194,37 @@ def test_vtoc_size_parm(ansible_zos_module, volumes_on_systems):
         content_str = ''.join(result.get("content"))
         assert VTOC_LOC_MSG.format(params.get('vtoc_size')) in content_str
 
+@pytest.mark.parametrize(
+    "params", [
+        # min params test; also sets up with expected attrs (eg existing volid)
+        ({
+            'address': TEST_VOL_ADDR,
+            'verify_offline': False,
+            'volid': TEST_VOL_SER,
+        }),
+        # verify_volid check - volid is known b/c previous test set it up.
+        ({
+            'address': TEST_VOL_ADDR,
+            'verify_offline': False,
+            'volid': TEST_VOL_SER,
+            'verify_volid' : TEST_VOL_SER
+        }),
+        # verify_volume_empty check - no data sets on vol is known b/c previous test set it up.
+        ({
+            'address': TEST_VOL_ADDR,
+            'verify_offline': False,
+            'volid': TEST_VOL_SER,
+            'verify_volume_empty' : True
+        }),
+    ]
+)
 
-def test_good_param_values_only_volid(ansible_zos_module, volumes_on_systems):
+
+def test_good_param_values(ansible_zos_module, params):
     hosts = ansible_zos_module
 
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
-    params = {
-        'address': volume_2,
-        'verify_offline': False,
-        'volid': volume_1,
-    }
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
@@ -262,77 +233,61 @@ def test_good_param_values_only_volid(ansible_zos_module, volumes_on_systems):
         assert result.get('rc') == 0
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
 
 
-def test_good_param_values_volid_n_verify_volid(ansible_zos_module, volumes_on_systems):
+@pytest.mark.parametrize(
+    "params,expected_rc", [
+        # address not hexadecimal
+        ({
+            'address': 'XYZ',
+            'verify_offline': False,
+            'volid': TEST_VOL_SER
+        }, 12),
+        # address length too short
+        ({
+            'address': '01',
+            'verify_offline': False,
+            'volid': TEST_VOL_SER
+        }, 12),
+        # address specified is not accesible to current
+        ({
+            'address': '0000',
+            'verify_offline': False,
+            'volid': TEST_VOL_SER
+        }, 12),
+        # negative value for vtoc_size
+        ({
+            'address': TEST_VOL_ADDR,
+            'verify_offline': False,
+            'volid': TEST_VOL_SER,
+            'vtoc_size': -10
+        }, 12),
+        # note - "'vtoc_size': 0" gets treated as vtoc_size wasn't defined
+        # and invokes default behavior.
+        # volid check - incorrect existing volid
+        ({
+            'address': TEST_VOL_ADDR,
+            'verify_offline': False,
+            'volid': TEST_VOL_SER,
+            'verify_volid': '000000'
+        }, 12),
+        # volid value too long
+        ({
+            'address': 'ABCDEFGHIJK',
+            'verify_offline': False,
+            'volid': TEST_VOL_SER,
+        }, 12),
+        # ({}, 0)
+
+    ]
+)
+
+def test_bad_param_values(ansible_zos_module, params, expected_rc):
     hosts = ansible_zos_module
 
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
-    params = {
-        'address': volume_2,
-        'verify_offline': False,
-        'volid': volume_1,
-        'verify_volid' : volume_1
-    }
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
-
-    results = hosts.all.zos_volume_init(**params)
-
-    for result in results.contacted.values():
-        assert result.get("changed") is True
-        assert result.get('rc') == 0
-
-    # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
-
-
-def test_good_param_values_volid_n_verify_volume_empty(ansible_zos_module, volumes_on_systems):
-    hosts = ansible_zos_module
-
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
-    params = {
-        'address': volume_2,
-        'verify_offline': False,
-        'volid': volume_1,
-        'verify_volume_empty' : True
-    }
-    # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
-
-    results = hosts.all.zos_volume_init(**params)
-
-    for result in results.contacted.values():
-        assert result.get("changed") is True
-        assert result.get('rc') == 0
-
-    # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
-
-
-def test_bad_param_values_address_not_hexadecimal(ansible_zos_module, volumes_on_systems):
-    hosts = ansible_zos_module
-
-    expected_rc = 12
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
-    params = {
-        "address": 'XYZ',
-        "verify_offline": False,
-        "volid": volume_1
-    }
-
-    # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
@@ -342,149 +297,7 @@ def test_bad_param_values_address_not_hexadecimal(ansible_zos_module, volumes_on
         assert result.get('rc') == expected_rc
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
-
-
-def test_bad_param_values_address_length_too_short(ansible_zos_module, volumes_on_systems):
-    hosts = ansible_zos_module
-
-    expected_rc = 12
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
-    params = {
-        "address": '01',
-        "verify_offline": False,
-        "volid": volume_1
-    }
-
-    # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
-
-    results = hosts.all.zos_volume_init(**params)
-
-    for result in results.contacted.values():
-        assert result.get("changed") is False
-        assert result.get('failed') is True
-        assert result.get('rc') == expected_rc
-
-    # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
-
-
-def test_bad_param_values_address_specified_is_not_accesible_to_current(ansible_zos_module, volumes_on_systems):
-    hosts = ansible_zos_module
-
-    expected_rc = 12
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
-    params = {
-        "address": '0000',
-        "verify_offline": False,
-        "volid": volume_1
-    }
-
-    # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
-
-    results = hosts.all.zos_volume_init(**params)
-
-    for result in results.contacted.values():
-        assert result.get("changed") is False
-        assert result.get('failed') is True
-        assert result.get('rc') == expected_rc
-
-    # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
-
-
-def test_bad_param_values_negative_value_for_vtoc_size(ansible_zos_module, volumes_on_systems):
-    hosts = ansible_zos_module
-
-    expected_rc = 12
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
-    params = {
-        "address": volume_2,
-        "verify_offline": False,
-        "volid": volume_1,
-        "vtoc_size": -10
-    }
-
-    # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
-
-    results = hosts.all.zos_volume_init(**params)
-
-    for result in results.contacted.values():
-        assert result.get("changed") is False
-        assert result.get('failed') is True
-        assert result.get('rc') == expected_rc
-
-    # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
-
-
-def test_bad_param_incorrect_existing_volid(ansible_zos_module, volumes_on_systems):
-    hosts = ansible_zos_module
-
-    expected_rc = 12
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
-    params = {
-        "address": volume_2,
-        "verify_offline": False,
-        "volid": volume_1,
-        "verify_volid": '000000'
-    }
-
-    # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
-
-    results = hosts.all.zos_volume_init(**params)
-
-    for result in results.contacted.values():
-        assert result.get("changed") is False
-        assert result.get('failed') is True
-        assert result.get('rc') == expected_rc
-
-    # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
-
-
-def test_bad_param_volid_value_too_long(ansible_zos_module, volumes_on_systems):
-    hosts = ansible_zos_module
-
-    expected_rc = 12
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
-    params = {
-        "address": 'ABCDEFGHIJK',
-        "verify_offline": False,
-        "volid": volume_1,
-    }
-
-    # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
-
-    results = hosts.all.zos_volume_init(**params)
-
-    for result in results.contacted.values():
-        assert result.get("changed") is False
-        assert result.get('failed') is True
-        assert result.get('rc') == expected_rc
-
-    # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
 
 
 # Note - volume needs to be sms managed for zos_data_set to work. Possible
@@ -495,42 +308,37 @@ def test_bad_param_volid_value_too_long(ansible_zos_module, volumes_on_systems):
 #        If there is a data set remaining on the volume, that would interfere
 #        with other tests!
 
-def test_no_existing_data_sets_check(ansible_zos_module, volumes_on_systems):
+def test_no_existing_data_sets_check(ansible_zos_module):
     hosts = ansible_zos_module
-    dataset = get_tmp_ds_name()
-
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
 
     setup_params = {
-        'address': volume_2,
+        'address': TEST_VOL_ADDR,
         'verify_offline': False,
-        'volid': volume_1,
+        'volid': TEST_VOL_SER,
         'sms_managed': False # need non-sms managed to add data set on ECs
     }
     test_params = {
-        'address': volume_2,
+        'address': TEST_VOL_ADDR,
         'verify_offline': False,
-        'volid': volume_1,
+        'volid': TEST_VOL_SER,
         'verify_volume_empty': True,
     }
 
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
 
     try:
         # set up/initialize volume properly so a data set can be added
         hosts.all.zos_volume_init(**setup_params)
 
         # bring volume back online
-        hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+        hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
 
         # allocate data set to volume
-        hosts.all.zos_data_set(name=dataset, type='pds', volumes=volume_1)
+        hosts.all.zos_data_set(name="USER.PRIVATE.TESTDS", type='pds', volumes=TEST_VOL_SER)
 
         # take volume back offline
-        hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+        hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
 
         # run vol_init against vol with data set on it.
         results = hosts.all.zos_volume_init(**test_params)
@@ -544,10 +352,10 @@ def test_no_existing_data_sets_check(ansible_zos_module, volumes_on_systems):
     # tests. Not sure what to do for DatasetDeleteError
     finally:
         # bring volume back online
-        hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+        hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
 
         # remove data set
-        hosts.all.zos_data_set(name=dataset, state='absent')
+        hosts.all.zos_data_set(name="USER.PRIVATE.TESTDS", state='absent')
 
 
 # Note - technically verify_offline is not REQUIRED but it defaults to True
@@ -555,21 +363,17 @@ def test_no_existing_data_sets_check(ansible_zos_module, volumes_on_systems):
 #        Therefore, while testing against the EC machines, the verify_offline
 #        check needs to be skipped in order for ickdsf to be invoked.
 
-def test_minimal_params(ansible_zos_module, volumes_on_systems):
+def test_minimal_params(ansible_zos_module):
     hosts = ansible_zos_module
 
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-
     params = {
-        "address":volume_2,
+        "address":TEST_VOL_ADDR,
         "verify_offline":False,
-        "volid":volume_1
+        "volid":TEST_VOL_SER
     }
 
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
 
     results = hosts.all.zos_volume_init(
         address=params['address'],
@@ -582,4 +386,4 @@ def test_minimal_params(ansible_zos_module, volumes_on_systems):
         assert result['rc'] == 0
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")

--- a/tests/functional/modules/test_zos_volume_init_func.py
+++ b/tests/functional/modules/test_zos_volume_init_func.py
@@ -18,10 +18,23 @@ __metaclass__ = type
 
 TEST_VOL_ADDR = '01A2'
 TEST_VOL_SER = 'USER02'
+from ibm_zos_core.tests.helpers.volumes import Volume_Handler
+from ibm_zos_core.tests.helpers.dataset import get_tmp_ds_name
+
+# To run the test suite is a recommendation to use the volumes in order
+# 'USER02', '01A2'
+# new list of similar volumes will be added in next iteration
 
 INDEX_CREATION_SUCCESS_MSG = 'VTOC INDEX CREATION SUCCESSFUL'
 VTOC_LOC_MSG = "ICK01314I VTOC IS LOCATED AT CCHH=X'0000 0001' AND IS  {:4d} TRACKS."
 
+def clear_volume(hosts, volume):
+    datasets_in_volume = hosts.all.shell(cmd="vtocls {0}".format(volume))
+    for dataset in datasets_in_volume.contacted.values():
+        datasets = str(dataset.get("stdout")).split("\n")
+    for dataset in datasets:
+        dataset_t_del = dataset.split(' ', 1)[0]
+        hosts.all.shell(cmd="""drm "{0}" """.format(dataset_t_del))
 
 # Guard Rail to prevent unintentional initialization of targeted volume.
 # If this test fails, either reset target volume serial to match
@@ -30,22 +43,24 @@ VTOC_LOC_MSG = "ICK01314I VTOC IS LOCATED AT CCHH=X'0000 0001' AND IS  {:4d} TRA
 
 def test_guard_rail_and_setup(ansible_zos_module):
     hosts = ansible_zos_module
-    print("running the new cases i mean old duh ")
-
     # remove all data sets from target volume. Expected to be the following 3
-    hosts.all.zos_data_set(name="IMSTESTL.IMS01.SPOOL1", state="absent")
-    hosts.all.zos_data_set(name="IMSTESTL.IMS01.SPOOL2", state="absent")
-    hosts.all.zos_data_set(name="IMSTESTL.IMS01.SPOOL3", state="absent")
+
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+    print("volume 1 is ",volume_1)
+    print("volume 2 is ",volume_2)
+
+    clear_volume(hosts, volume_1)
 
     params = {
-        "address":TEST_VOL_ADDR,
+        "address":volume_2,
         "verify_offline":False,
-        "volid":TEST_VOL_SER,
-        "verify_volid":'USER02'
+        "volid":volume_1,
+        "verify_volid":volume_1
     }
 
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
 
     results = hosts.all.zos_volume_init(
         address=params['address'],
@@ -59,33 +74,26 @@ def test_guard_rail_and_setup(ansible_zos_module):
         assert result['rc'] == 0
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
 
 
-@pytest.mark.parametrize(
-    "params", [
-        # min params test with index : true
-        ({
-            'address': TEST_VOL_ADDR,
-            'verify_offline': False,
-            'volid': TEST_VOL_SER,
-            'index' : True
-        }),
-        # min params test with index : false
-        ({
-            'address': TEST_VOL_ADDR,
-            'verify_offline': False,
-            'volid': TEST_VOL_SER,
-            'index' : False,
-            'sms_managed' : False # default is True, which cannot be with no index.
-        }),
-    ]
-)
-def test_index_param(ansible_zos_module, params):
+def test_index_param_index(ansible_zos_module):
     hosts = ansible_zos_module
 
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+    print("volume 1 is ",volume_1)
+    print("volume 2 is ",volume_2)
+
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+
+    params = {
+        "address": volume_2,
+        "verify_offline": False,
+        "volid": volume_1,
+        "index" : True
+    }
 
     results = hosts.all.zos_volume_init(**params)
 
@@ -99,26 +107,64 @@ def test_index_param(ansible_zos_module, params):
             assert INDEX_CREATION_SUCCESS_MSG not in content_str
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+
+
+def test_index_param_index_sms_false(ansible_zos_module):
+    hosts = ansible_zos_module
+
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+    print("volume 1 is ",volume_1)
+    print("volume 2 is ",volume_2)
+
+    # take volume offline
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+
+    params = {
+        "address": volume_2,
+        "verify_offline": False,
+        "volid": volume_1,
+        "index" : True,
+        "sms_managed" : False
+    }
+
+    results = hosts.all.zos_volume_init(**params)
+
+    for result in results.contacted.values():
+        assert result.get("changed") is True
+        assert result.get('rc') == 0
+        content_str = ''.join(result.get("content"))
+        if params['index']:
+            assert INDEX_CREATION_SUCCESS_MSG in content_str
+        else:
+            assert INDEX_CREATION_SUCCESS_MSG not in content_str
+
+    # bring volume back online
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
 
 
 # check that correct volume_addr is assigned to correct volid
 def test_volid_address_assigned_correctly(ansible_zos_module):
     hosts = ansible_zos_module
-    print(f"running the new cases i mean old duh ")
+
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+    print("volume 1 is ",volume_1)
+    print("volume 2 is ",volume_2)
 
     params = {
-        'address': TEST_VOL_ADDR,
+        'address': volume_2,
         'verify_offline': False,
-        'volid': TEST_VOL_SER,
+        'volid': volume_1,
     }
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
 
     for result in results.contacted.values():
         assert result.get("changed") is True
@@ -138,55 +184,61 @@ def test_volid_address_assigned_correctly(ansible_zos_module):
 
     # Display command to print device status, volser and addr should correspond
     display_cmd_output = list(
-        hosts.all.zos_operator(cmd=f"D U,VOL={TEST_VOL_SER}").contacted.values()
+        hosts.all.zos_operator(cmd=f"D U,VOL={volume_1}").contacted.values()
     )[0]
 
     # zos_operator output contains the command as well, only the last line of
     # the output is relevant for the needs of this test case.
     display_cmd_output = display_cmd_output.get('content')[-1]
 
-    assert TEST_VOL_SER in display_cmd_output
+    assert volume_1 in display_cmd_output
 
 def test_no_index_sms_managed_mutually_exclusive(ansible_zos_module):
     hosts = ansible_zos_module
 
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+
+
     params = {
-        'address': TEST_VOL_ADDR,
+        'address': volume_2,
         'verify_offline': False,
-        'volid': TEST_VOL_SER,
+        'volid': volume_1,
         'index' : False,
         'sms_managed' : True
     }
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
 
     for result in results.contacted.values():
         assert result.get("changed") is False
         assert "'Index' cannot be False" in result.get("msg")
 
+
 def test_vtoc_size_parm(ansible_zos_module):
     hosts = ansible_zos_module
-    print(f"running the new cases i mean old duh  test_vtoc size ")
 
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
     params = {
-        'address': TEST_VOL_ADDR,
+        'address': volume_2,
         'verify_offline': False,
-        'volid': TEST_VOL_SER,
+        'volid': volume_1,
         'vtoc_size' : 8
         # 'vtoc_size' : 11 # test to test that this test handles 2 digit vtoc_index
     }
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
 
     for result in results.contacted.values():
         assert result.get("changed") is True
@@ -194,37 +246,20 @@ def test_vtoc_size_parm(ansible_zos_module):
         content_str = ''.join(result.get("content"))
         assert VTOC_LOC_MSG.format(params.get('vtoc_size')) in content_str
 
-@pytest.mark.parametrize(
-    "params", [
-        # min params test; also sets up with expected attrs (eg existing volid)
-        ({
-            'address': TEST_VOL_ADDR,
-            'verify_offline': False,
-            'volid': TEST_VOL_SER,
-        }),
-        # verify_volid check - volid is known b/c previous test set it up.
-        ({
-            'address': TEST_VOL_ADDR,
-            'verify_offline': False,
-            'volid': TEST_VOL_SER,
-            'verify_volid' : TEST_VOL_SER
-        }),
-        # verify_volume_empty check - no data sets on vol is known b/c previous test set it up.
-        ({
-            'address': TEST_VOL_ADDR,
-            'verify_offline': False,
-            'volid': TEST_VOL_SER,
-            'verify_volume_empty' : True
-        }),
-    ]
-)
 
-
-def test_good_param_values(ansible_zos_module, params):
+def test_good_param_values_only_volid(ansible_zos_module):
     hosts = ansible_zos_module
 
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+
+    params = {
+        'address': volume_2,
+        'verify_offline': False,
+        'volid': volume_1,
+    }
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
@@ -233,61 +268,74 @@ def test_good_param_values(ansible_zos_module, params):
         assert result.get('rc') == 0
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
 
 
-@pytest.mark.parametrize(
-    "params,expected_rc", [
-        # address not hexadecimal
-        ({
-            'address': 'XYZ',
-            'verify_offline': False,
-            'volid': TEST_VOL_SER
-        }, 12),
-        # address length too short
-        ({
-            'address': '01',
-            'verify_offline': False,
-            'volid': TEST_VOL_SER
-        }, 12),
-        # address specified is not accesible to current
-        ({
-            'address': '0000',
-            'verify_offline': False,
-            'volid': TEST_VOL_SER
-        }, 12),
-        # negative value for vtoc_size
-        ({
-            'address': TEST_VOL_ADDR,
-            'verify_offline': False,
-            'volid': TEST_VOL_SER,
-            'vtoc_size': -10
-        }, 12),
-        # note - "'vtoc_size': 0" gets treated as vtoc_size wasn't defined
-        # and invokes default behavior.
-        # volid check - incorrect existing volid
-        ({
-            'address': TEST_VOL_ADDR,
-            'verify_offline': False,
-            'volid': TEST_VOL_SER,
-            'verify_volid': '000000'
-        }, 12),
-        # volid value too long
-        ({
-            'address': 'ABCDEFGHIJK',
-            'verify_offline': False,
-            'volid': TEST_VOL_SER,
-        }, 12),
-        # ({}, 0)
-
-    ]
-)
-
-def test_bad_param_values(ansible_zos_module, params, expected_rc):
+def test_good_param_values_volid_n_verify_volid(ansible_zos_module):
     hosts = ansible_zos_module
 
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+
+    params = {
+        'address': volume_2,
+        'verify_offline': False,
+        'volid': volume_1,
+        'verify_volid' : volume_1
+    }
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+
+    results = hosts.all.zos_volume_init(**params)
+
+    for result in results.contacted.values():
+        assert result.get("changed") is True
+        assert result.get('rc') == 0
+
+    # bring volume back online
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+
+
+def test_good_param_values_volid_n_verify_volume_empty(ansible_zos_module):
+    hosts = ansible_zos_module
+
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+
+    params = {
+        'address': volume_2,
+        'verify_offline': False,
+        'volid': volume_1,
+        'verify_volume_empty' : True
+    }
+    # take volume offline
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+
+    results = hosts.all.zos_volume_init(**params)
+
+    for result in results.contacted.values():
+        assert result.get("changed") is True
+        assert result.get('rc') == 0
+
+    # bring volume back online
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+
+
+def test_bad_param_values_address_not_hexadecimal(ansible_zos_module):
+    hosts = ansible_zos_module
+
+    expected_rc = 12
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+
+    params = {
+        "address": 'XYZ',
+        "verify_offline": False,
+        "volid": volume_1
+    }
+
+    # take volume offline
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
 
     results = hosts.all.zos_volume_init(**params)
 
@@ -297,7 +345,143 @@ def test_bad_param_values(ansible_zos_module, params, expected_rc):
         assert result.get('rc') == expected_rc
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+
+
+def test_bad_param_values_address_length_too_short(ansible_zos_module):
+    hosts = ansible_zos_module
+
+    expected_rc = 12
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+
+    params = {
+        "address": '01',
+        "verify_offline": False,
+        "volid": volume_1
+    }
+
+    # take volume offline
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+
+    results = hosts.all.zos_volume_init(**params)
+
+    for result in results.contacted.values():
+        assert result.get("changed") is False
+        assert result.get('failed') is True
+        assert result.get('rc') == expected_rc
+
+    # bring volume back online
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+
+
+def test_bad_param_values_address_specified_is_not_accesible_to_current(ansible_zos_module):
+    hosts = ansible_zos_module
+
+    expected_rc = 12
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+    params = {
+        "address": '0000',
+        "verify_offline": False,
+        "volid": volume_1
+    }
+
+    # take volume offline
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+
+    results = hosts.all.zos_volume_init(**params)
+
+    for result in results.contacted.values():
+        assert result.get("changed") is False
+        assert result.get('failed') is True
+        assert result.get('rc') == expected_rc
+
+    # bring volume back online
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+
+
+def test_bad_param_values_negative_value_for_vtoc_size(ansible_zos_module):
+    hosts = ansible_zos_module
+
+    expected_rc = 12
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+
+    params = {
+        "address": volume_2,
+        "verify_offline": False,
+        "volid": volume_1,
+        "vtoc_size": -10
+    }
+
+    # take volume offline
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+
+    results = hosts.all.zos_volume_init(**params)
+
+    for result in results.contacted.values():
+        assert result.get("changed") is False
+        assert result.get('failed') is True
+        assert result.get('rc') == expected_rc
+
+    # bring volume back online
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+
+
+def test_bad_param_incorrect_existing_volid(ansible_zos_module):
+    hosts = ansible_zos_module
+
+    expected_rc = 12
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+
+    params = {
+        "address": volume_2,
+        "verify_offline": False,
+        "volid": volume_1,
+        "verify_volid": '000000'
+    }
+
+    # take volume offline
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+
+    results = hosts.all.zos_volume_init(**params)
+
+    for result in results.contacted.values():
+        assert result.get("changed") is False
+        assert result.get('failed') is True
+        assert result.get('rc') == expected_rc
+
+    # bring volume back online
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
+
+
+def test_bad_param_volid_value_too_long(ansible_zos_module):
+    hosts = ansible_zos_module
+
+    expected_rc = 12
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+
+    params = {
+        "address": 'ABCDEFGHIJK',
+        "verify_offline": False,
+        "volid": volume_1,
+    }
+
+    # take volume offline
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
+
+    results = hosts.all.zos_volume_init(**params)
+
+    for result in results.contacted.values():
+        assert result.get("changed") is False
+        assert result.get('failed') is True
+        assert result.get('rc') == expected_rc
+
+    # bring volume back online
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")
 
 
 # Note - volume needs to be sms managed for zos_data_set to work. Possible
@@ -310,35 +494,39 @@ def test_bad_param_values(ansible_zos_module, params, expected_rc):
 
 def test_no_existing_data_sets_check(ansible_zos_module):
     hosts = ansible_zos_module
+    dataset = get_tmp_ds_name()
+
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
 
     setup_params = {
-        'address': TEST_VOL_ADDR,
+        'address': volume_2,
         'verify_offline': False,
-        'volid': TEST_VOL_SER,
+        'volid': volume_1,
         'sms_managed': False # need non-sms managed to add data set on ECs
     }
     test_params = {
-        'address': TEST_VOL_ADDR,
+        'address': volume_2,
         'verify_offline': False,
-        'volid': TEST_VOL_SER,
+        'volid': volume_1,
         'verify_volume_empty': True,
     }
 
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
 
     try:
         # set up/initialize volume properly so a data set can be added
         hosts.all.zos_volume_init(**setup_params)
 
         # bring volume back online
-        hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
+        hosts.all.zos_operator(cmd=f"vary {volume_2},online")
 
         # allocate data set to volume
-        hosts.all.zos_data_set(name="USER.PRIVATE.TESTDS", type='pds', volumes=TEST_VOL_SER)
+        hosts.all.zos_data_set(name=dataset, type='pds', volumes=volume_1)
 
         # take volume back offline
-        hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
+        hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
 
         # run vol_init against vol with data set on it.
         results = hosts.all.zos_volume_init(**test_params)
@@ -352,10 +540,10 @@ def test_no_existing_data_sets_check(ansible_zos_module):
     # tests. Not sure what to do for DatasetDeleteError
     finally:
         # bring volume back online
-        hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
+        hosts.all.zos_operator(cmd=f"vary {volume_2},online")
 
         # remove data set
-        hosts.all.zos_data_set(name="USER.PRIVATE.TESTDS", state='absent')
+        hosts.all.zos_data_set(name=dataset, state='absent')
 
 
 # Note - technically verify_offline is not REQUIRED but it defaults to True
@@ -366,14 +554,17 @@ def test_no_existing_data_sets_check(ansible_zos_module):
 def test_minimal_params(ansible_zos_module):
     hosts = ansible_zos_module
 
+    volume_1 = TEST_VOL_SER
+    volume_2 = TEST_VOL_ADDR
+
     params = {
-        "address":TEST_VOL_ADDR,
+        "address":volume_2,
         "verify_offline":False,
-        "volid":TEST_VOL_SER
+        "volid":volume_1
     }
 
     # take volume offline
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},offline")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
 
     results = hosts.all.zos_volume_init(
         address=params['address'],
@@ -386,4 +577,4 @@ def test_minimal_params(ansible_zos_module):
         assert result['rc'] == 0
 
     # bring volume back online
-    hosts.all.zos_operator(cmd=f"vary {TEST_VOL_ADDR},online")
+    hosts.all.zos_operator(cmd=f"vary {volume_2},online")

--- a/tests/functional/modules/test_zos_volume_init_func.py
+++ b/tests/functional/modules/test_zos_volume_init_func.py
@@ -47,8 +47,6 @@ def test_guard_rail_and_setup(ansible_zos_module):
 
     volume_1 = TEST_VOL_SER
     volume_2 = TEST_VOL_ADDR
-    print("volume 1 is ",volume_1)
-    print("volume 2 is ",volume_2)
 
     clear_volume(hosts, volume_1)
 
@@ -82,8 +80,6 @@ def test_index_param_index(ansible_zos_module):
 
     volume_1 = TEST_VOL_SER
     volume_2 = TEST_VOL_ADDR
-    print("volume 1 is ",volume_1)
-    print("volume 2 is ",volume_2)
 
     # take volume offline
     hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
@@ -115,8 +111,6 @@ def test_index_param_index_sms_false(ansible_zos_module):
 
     volume_1 = TEST_VOL_SER
     volume_2 = TEST_VOL_ADDR
-    print("volume 1 is ",volume_1)
-    print("volume 2 is ",volume_2)
 
     # take volume offline
     hosts.all.zos_operator(cmd=f"vary {volume_2},offline")
@@ -150,8 +144,6 @@ def test_volid_address_assigned_correctly(ansible_zos_module):
 
     volume_1 = TEST_VOL_SER
     volume_2 = TEST_VOL_ADDR
-    print("volume 1 is ",volume_1)
-    print("volume 2 is ",volume_2)
 
     params = {
         'address': volume_2,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When we are executing the volume test cases in each test case we need to manually add the volumes either  in the test case or the pipeline variables. 
The fix now hardcodes the volumes into the test cases itself so we don't need to pass it either in pipeline or while executing test cases. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test_zos_volume_init_function.py 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<img width="1020" alt="Screenshot 2025-02-24 at 5 39 51 PM" src="https://github.com/user-attachments/assets/e5509aba-8d27-4136-9654-980cc1734c3e" />
Pipeline hardcoding was required earlier It is now resolved. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
