### PR TITLE
[zos_script][zos_copy] Support automatic removal of carriage return characters (CR) when copying files 

### DIFF
--- a/changelogs/fragments/1954-zos_copy-cr-removal-while-copying-file-to-remote.yml
+++ b/changelogs/fragments/1954-zos_copy-cr-removal-while-copying-file-to-remote.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - zos_copy - Carriage return will be removed automatically while copying files to remote server.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1954).

--- a/changelogs/fragments/1954-zos_copy-cr-removal-while-copying-file-to-remote.yml
+++ b/changelogs/fragments/1954-zos_copy-cr-removal-while-copying-file-to-remote.yml
@@ -1,3 +1,7 @@
 minor_changes:
-  - zos_copy - Carriage return will be removed automatically while copying files to remote server.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/1954).
+   - zos_script - Support automatic removal of carriage return line breaks [CR, CRLF] when copying local files to USS.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/1954).
+bugfixes:
+   - zos_copy - the carriage return characters were being removed from only first 1024 bytes of a file. Now fixed that issue to support 
+     removal of the carriage return characters from the complete file content if the file size is more than 1024 bytes.
+      (https://github.com/ansible-collections/ibm_zos_core/pull/1954).

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1485,45 +1485,6 @@ class CopyHandler(object):
                 stderr=to_native(err)
             )
 
-    def remove_cr_endings(self, src):
-        """Creates a temporary file with the same content as src but without
-        carriage returns.
-
-        Parameters
-        ----------
-        src : str
-            Path to a USS source file.
-
-        Returns
-        -------
-        str
-            Path to the temporary file created.
-
-        Raises
-        ------
-        CopyOperationError
-            If the conversion fails.
-        """
-        try:
-            fd, converted_src = tempfile.mkstemp(dir=os.environ['TMPDIR'])
-            os.close(fd)
-            #defining 32 MB chunk size for reading large files efficiently
-            chunk_size = 32 * 1024 * 1024
-            with open(converted_src, "wb") as converted_file:
-                with open(src, "rb") as src_file:
-                    chunk = src_file.read(chunk_size)
-                    while chunk:
-                        # In IBM-037, \r is the byte 0d.
-                        converted_file.write(chunk.replace(b'\x0d', b''))
-                        chunk = src_file.read(chunk_size)
-
-            return converted_src
-        except Exception as err:
-            raise CopyOperationError(
-                msg="Error while trying to convert EOL sequence for source.",
-                stderr=to_native(err)
-            )
-
 
 class USSCopyHandler(CopyHandler):
     def __init__(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3766,7 +3766,7 @@ def run_module(module, arg_def):
             if src_ds_type == "USS" and not is_binary and not executable:
                 new_src = conv_path or src
                 if os.path.isfile(new_src):
-                    conv_path = copy_handler.remove_cr_endings(new_src)
+                    conv_path = copy_handler.create_temp_with_lf_endings(new_src)
             uss_copy_handler = USSCopyHandler(
                 module,
                 is_binary=is_binary,

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3725,7 +3725,8 @@ def run_module(module, arg_def):
             # Normalizing encodings to IBM-037 and removing carriage return
             if src_ds_type == "USS" and not is_binary:
                 new_src = conv_path or src
-                conv_path = copy_handler.create_temp_with_lf_endings(new_src)
+                if os.path.isfile(new_src):
+                    conv_path = normalize_line_endings(new_src, encoding)
             uss_copy_handler = USSCopyHandler(
                 module,
                 is_binary=is_binary,

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3761,7 +3761,7 @@ def run_module(module, arg_def):
         # ---------------------------------------------------------------------
         if is_uss:
             # Normalizing encodings to IBM-037 and removing carriage return
-            if src_ds_type == "USS" and not is_binary:
+            if src_ds_type == "USS" and not is_binary and not executable:
                 new_src = conv_path or src
                 if os.path.isfile(new_src):
                     conv_path = copy_handler.remove_cr_endings(new_src)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1506,10 +1506,11 @@ class CopyHandler(object):
         try:
             fd, converted_src = tempfile.mkstemp(dir=os.environ['TMPDIR'])
             os.close(fd)
-
+            #defining 32 MB chunk size for reading large files efficiently
+            chunk_size = 32 * 1024 * 1024
             with open(converted_src, "wb") as converted_file:
                 with open(src, "rb") as src_file:
-                    chunk = src_file.read(1024)
+                    chunk = src_file.read(chunk_size)
                     while chunk:
                         # In IBM-037, \r is the byte 0d.
                         converted_file.write(chunk.replace(b'\x0d', b''))

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1466,7 +1466,7 @@ class CopyHandler(object):
         try:
             fd, converted_src = tempfile.mkstemp(dir=os.environ['TMPDIR'])
             os.close(fd)
-            #defining 32 MB chunk size for reading large files efficiently
+            # defining 32 MB chunk size for reading large files efficiently
             chunk_size = 32 * 1024 * 1024
             with open(converted_src, "wb") as converted_file:
                 with open(src, "rb") as src_file:
@@ -1507,7 +1507,7 @@ class CopyHandler(object):
         try:
             fd, converted_src = tempfile.mkstemp(dir=os.environ['TMPDIR'])
             os.close(fd)
-            #defining 32 MB chunk size for reading large files efficiently
+            # defining 32 MB chunk size for reading large files efficiently
             chunk_size = 32 * 1024 * 1024
             with open(converted_src, "wb") as converted_file:
                 with open(src, "rb") as src_file:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1484,6 +1484,44 @@ class CopyHandler(object):
                 stderr=to_native(err)
             )
 
+    def remove_cr_endings(self, src):
+        """Creates a temporary file with the same content as src but without
+        carriage returns.
+
+        Parameters
+        ----------
+        src : str
+            Path to a USS source file.
+
+        Returns
+        -------
+        str
+            Path to the temporary file created.
+
+        Raises
+        ------
+        CopyOperationError
+            If the conversion fails.
+        """
+        try:
+            fd, converted_src = tempfile.mkstemp(dir=os.environ['TMPDIR'])
+            os.close(fd)
+
+            with open(converted_src, "wb") as converted_file:
+                with open(src, "rb") as src_file:
+                    chunk = src_file.read(1024)
+                    while chunk:
+                        # In IBM-037, \r is the byte 0d.
+                        converted_file.write(chunk.replace(b'\x0d', b''))
+                        chunk = src_file.read(1024)
+
+            return converted_src
+        except Exception as err:
+            raise CopyOperationError(
+                msg="Error while trying to convert EOL sequence for source.",
+                stderr=to_native(err)
+            )
+
 
 class USSCopyHandler(CopyHandler):
     def __init__(
@@ -3726,7 +3764,7 @@ def run_module(module, arg_def):
             if src_ds_type == "USS" and not is_binary:
                 new_src = conv_path or src
                 if os.path.isfile(new_src):
-                    conv_path = normalize_line_endings(new_src, encoding)
+                    conv_path = copy_handler.remove_cr_endings(new_src)
             uss_copy_handler = USSCopyHandler(
                 module,
                 is_binary=is_binary,

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3760,7 +3760,7 @@ def run_module(module, arg_def):
         # Copy to USS file or directory
         # ---------------------------------------------------------------------
         if is_uss:
-            # Normalizing encodings to IBM-037 and removing carriage return
+            # Removing carriage return
             if src_ds_type == "USS" and not is_binary and not executable:
                 new_src = conv_path or src
                 if os.path.isfile(new_src):

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1466,10 +1466,11 @@ class CopyHandler(object):
         try:
             fd, converted_src = tempfile.mkstemp(dir=os.environ['TMPDIR'])
             os.close(fd)
-
+            #defining 32 MB chunk size for reading large files efficiently
+            chunk_size = 32 * 1024 * 1024
             with open(converted_src, "wb") as converted_file:
                 with open(src, "rb") as src_file:
-                    chunk = src_file.read(1024)
+                    chunk = src_file.read(chunk_size)
                     while chunk:
                         # In IBM-037, \r is the byte 0d.
                         converted_file.write(chunk.replace(b'\x0d', b''))
@@ -3761,7 +3762,7 @@ def run_module(module, arg_def):
         # Copy to USS file or directory
         # ---------------------------------------------------------------------
         if is_uss:
-            # Removing carriage return
+            # Removing the carriage return characters
             if src_ds_type == "USS" and not is_binary and not executable:
                 new_src = conv_path or src
                 if os.path.isfile(new_src):

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1474,7 +1474,7 @@ class CopyHandler(object):
                     while chunk:
                         # In IBM-037, \r is the byte 0d.
                         converted_file.write(chunk.replace(b'\x0d', b''))
-                        chunk = src_file.read(1024)
+                        chunk = src_file.read(chunk_size)
 
             self._tag_file_encoding(converted_src, "IBM-037")
 
@@ -1515,7 +1515,7 @@ class CopyHandler(object):
                     while chunk:
                         # In IBM-037, \r is the byte 0d.
                         converted_file.write(chunk.replace(b'\x0d', b''))
-                        chunk = src_file.read(1024)
+                        chunk = src_file.read(chunk_size)
 
             return converted_src
         except Exception as err:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3725,7 +3725,7 @@ def run_module(module, arg_def):
             # Normalizing encodings to IBM-037 and removing carriage return
             if src_ds_type == "USS" and not is_binary:
                 new_src = conv_path or src
-                conv_path = normalize_line_endings(new_src, encoding)
+                conv_path = copy_handler.create_temp_with_lf_endings(new_src)
             uss_copy_handler = USSCopyHandler(
                 module,
                 is_binary=is_binary,

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2040,9 +2040,11 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
             dest=f'{temp_dir}/call_c_pgm.jcl',
             force=True
         )
-        hosts.all.shell(cmd="xlc -o pdse-lock pdse-lock.c", chdir=f"{temp_dir}/")
+        res1=hosts.all.shell(cmd="xlc -o pdse-lock pdse-lock.c", chdir=f"{temp_dir}/")
+        print(res1.contacted.values())
         # submit jcl
-        hosts.all.shell(cmd="submit call_c_pgm.jcl", chdir=f"{temp_dir}/")
+        res2=hosts.all.shell(cmd="submit call_c_pgm.jcl", chdir=f"{temp_dir}/")
+        print(res2.contacted.values())
         # pause to ensure c code acquires lock
         time.sleep(5)
         results = hosts.all.zos_copy(
@@ -2083,10 +2085,10 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
         pid = list(ps_list_res.contacted.values())[0].get('stdout').strip().split(' ')[0]
         hosts.all.shell(cmd="kill 9 {0}".format(pid.strip()))
         # clean up c code/object/executable files, jcl
-        hosts.all.shell(cmd=f'rm -r {temp_dir}')
-        # remove pdse
-        hosts.all.zos_data_set(name=data_set_1, state="absent")
-        hosts.all.zos_data_set(name=data_set_2, state="absent")
+        # hosts.all.shell(cmd=f'rm -r {temp_dir}')
+        # # remove pdse
+        # hosts.all.zos_data_set(name=data_set_1, state="absent")
+        # hosts.all.zos_data_set(name=data_set_2, state="absent")
 
 
 def test_copy_dest_lock_test_with_no_opercmd_access_pds_without_force_lock(ansible_zos_module, z_python_interpreter):

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2016,7 +2016,7 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
     hosts = ansible_zos_module
     data_set_1 = get_tmp_ds_name()
     data_set_2 = get_tmp_ds_name(llq_size=4)
-    data_set_2 = f"{data_set_2}TST"
+    data_set_2 = f"{data_set_2}$#@"
     member_1 = "MEM1"
     if ds_type == "pds" or ds_type == "pdse":
         src_data_set = data_set_1 + "({0})".format(member_1)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2016,7 +2016,7 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
     hosts = ansible_zos_module
     data_set_1 = get_tmp_ds_name()
     data_set_2 = get_tmp_ds_name(llq_size=4)
-    data_set_2 = f"{data_set_2}$#@"
+    data_set_2 = f"{data_set_2}TST"
     member_1 = "MEM1"
     if ds_type == "pds" or ds_type == "pdse":
         src_data_set = data_set_1 + "({0})".format(member_1)

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2040,11 +2040,9 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
             dest=f'{temp_dir}/call_c_pgm.jcl',
             force=True
         )
-        res1=hosts.all.shell(cmd="xlc -o pdse-lock pdse-lock.c", chdir=f"{temp_dir}/")
-        print(res1.contacted.values())
+        hosts.all.shell(cmd="xlc -o pdse-lock pdse-lock.c", chdir=f"{temp_dir}/")
         # submit jcl
-        res2=hosts.all.shell(cmd="submit call_c_pgm.jcl", chdir=f"{temp_dir}/")
-        print(res2.contacted.values())
+        hosts.all.shell(cmd="submit call_c_pgm.jcl", chdir=f"{temp_dir}/")
         # pause to ensure c code acquires lock
         time.sleep(5)
         results = hosts.all.zos_copy(
@@ -2085,10 +2083,10 @@ def test_copy_dest_lock(ansible_zos_module, ds_type, f_lock ):
         pid = list(ps_list_res.contacted.values())[0].get('stdout').strip().split(' ')[0]
         hosts.all.shell(cmd="kill 9 {0}".format(pid.strip()))
         # clean up c code/object/executable files, jcl
-        # hosts.all.shell(cmd=f'rm -r {temp_dir}')
-        # # remove pdse
-        # hosts.all.zos_data_set(name=data_set_1, state="absent")
-        # hosts.all.zos_data_set(name=data_set_2, state="absent")
+        hosts.all.shell(cmd=f'rm -r {temp_dir}')
+        # remove pdse
+        hosts.all.zos_data_set(name=data_set_1, state="absent")
+        hosts.all.zos_data_set(name=data_set_2, state="absent")
 
 
 def test_copy_dest_lock_test_with_no_opercmd_access_pds_without_force_lock(ansible_zos_module, z_python_interpreter):

--- a/tests/functional/modules/test_zos_script_func.py
+++ b/tests/functional/modules/test_zos_script_func.py
@@ -574,6 +574,8 @@ def test_rexx_script_with_args_remote_src(ansible_zos_module):
             os.remove(script_path)
         if os.path.exists(local_script):
             os.remove(local_script)
+
+
 def test_rexx_script_with_args_and_carriagereturn(ansible_zos_module):
     hosts = ansible_zos_module
     script_path = ''

--- a/tests/functional/modules/test_zos_script_func.py
+++ b/tests/functional/modules/test_zos_script_func.py
@@ -647,7 +647,6 @@ def test_rexx_script_with_args_and_carriagereturn(ansible_zos_module):
     finally:
         if os.path.exists(script_path):
             os.remove(script_path)
-        hosts.all.file(path=script_path, state="absent")
 
 
 def test_job_script_async(get_config):


### PR DESCRIPTION
##### SUMMARY
automatic removal of line breaks(CR) while copying files using zos copy #1692


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
zos_copy, zos_script

##### ADDITIONAL INFORMATION
-> Implemented logic to remove CR while copying a file to remote directory.
-> Fixed issue related to the carriage return characters were being removed from only first 1KB of a file.
-> Added new test case in zos_script test cases for this use case.

