### PR TITLE
[zos_operator] Update zos_operator test cases with new way to get zoau version

### DIFF
--- a/changelogs/fragments/1956-zoau-version-support-for-test-cases.yml
+++ b/changelogs/fragments/1956-zoau-version-support-for-test-cases.yml
@@ -1,7 +1,7 @@
 trivial:
 
   - tests/functional/modules/test_zos_operator_func.py- test function test_zos_operator_positive_verbose_blocking
-    is enbled and working as expected now. 
+    is enabled and condition to version check is operational now. 
     (https://github.com/ansible-collections/ibm_zos_core/pull/1956).
 
   - tests/functional/modules/test_zos_apf_func.py- version check added for test_add_already_present, 

--- a/changelogs/fragments/1956-zoau-version-support-for-test-cases.yml
+++ b/changelogs/fragments/1956-zoau-version-support-for-test-cases.yml
@@ -1,0 +1,13 @@
+trivial:
+
+  - tests/functional/modules/test_zos_operator_func.py- test function test_zos_operator_positive_verbose_blocking
+    is enbled and working as expected now. 
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1956).
+
+  - tests/functional/modules/test_zos_apf_func.py- version check added for test_add_already_present, 
+    and test_delete_not_present. 
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1956).
+
+  - tests/helpers/version.py- New helper file that supports the version fetch,
+    and operations like validating string and comparing version. 
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1956).

--- a/tests/functional/modules/test_zos_apf_func.py
+++ b/tests/functional/modules/test_zos_apf_func.py
@@ -12,10 +12,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import, division, print_function
-import re
-import pytest
 from ibm_zos_core.tests.helpers.dataset import get_tmp_ds_name
 from ibm_zos_core.tests.helpers.volumes import Volume_Handler
+from ibm_zos_core.tests.helpers.version import get_zoau_version
 
 __metaclass__ = type
 
@@ -405,17 +404,6 @@ def test_operation_list_with_filter(ansible_zos_module, volumes_with_vvds):
 #
 # Negative tests
 #
-def get_zoa_version(ansible_zos_module):
-    cmd_str = "zoaversion"
-    version_results = ansible_zos_module.all.shell(cmd=cmd_str)
-    zoa_version = None        
-    for result in version_results.contacted.values():
-        output = result.get("stdout")
-        if output:
-            match = re.search(r'v(\d+\.\d+\.\d+\.\d+)', output)
-            if match:
-                zoa_version = match.group(1)
-    return zoa_version
 
 def test_add_already_present(ansible_zos_module, volumes_with_vvds):
     try:
@@ -455,7 +443,7 @@ def test_add_already_present(ansible_zos_module, volumes_with_vvds):
             # RC 0 should be allowed for ZOAU >= 1.3.4, 
             # in zoau < 1.3.4 -i is not recognized  in apfadm 
             # Return code 16 if ZOAU < 1.2.0 and RC is 8 if ZOAU >= 1.2.0
-            zoa_version = get_zoa_version(hosts) or "0.0.0.0" 
+            zoa_version = get_zoau_version(hosts) or "0.0.0.0" 
             rc = result.get("rc")            
             if zoa_version >= "1.3.4.0":
                 assert rc == 0
@@ -503,7 +491,7 @@ def test_del_not_present(ansible_zos_module, volumes_with_vvds):
             # RC 0 should be allowed for ZOAU >= 1.3.4, 
             # in zoau < 1.3.4 -i is not recognized  in apfadm 
             # Return code 16 if ZOAU < 1.2.0 and RC is 8 if ZOAU >= 1.2.0
-            zoa_version = get_zoa_version(hosts) or "0.0.0.0" 
+            zoa_version = get_zoau_version(hosts) or "0.0.0.0" 
             rc = result.get("rc")            
             if zoa_version >= "1.3.4.0":
                 assert rc == 0

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -18,11 +18,7 @@ __metaclass__ = type
 import os
 import yaml
 from shellescape import quote
-
-from ibm_zos_core.plugins.module_utils import (
-    zoau_version_checker,
-)
-
+from ibm_zos_core.tests.helpers.version import is_zoau_version_higher_than
 
 __metaclass__ = type
 
@@ -156,8 +152,8 @@ def test_zos_operator_positive_verbose_with_quick_delay(ansible_zos_module):
 
 
 def test_zos_operator_positive_verbose_blocking(ansible_zos_module):
-    if zoau_version_checker.is_zoau_version_higher_than("1.2.4.5"):
-        hosts = ansible_zos_module
+    hosts = ansible_zos_module
+    if is_zoau_version_higher_than(hosts,"1.2.4.5"):
         wait_time_s=5
         results = hosts.all.zos_operator(
             cmd="d u,all", verbose=True, wait_time_s=wait_time_s

--- a/tests/helpers/version.py
+++ b/tests/helpers/version.py
@@ -66,7 +66,7 @@ def is_zoau_version_higher_than(ansible_zos_module,min_version_str):
     """
     if is_valid_version_string(min_version_str):
         # check zoau version on system (already a list)
-        system_version_list = get_zoau_version(ansible_zos_module)
+        system_version_list = get_zoau_version_str(ansible_zos_module)
 
         # convert input to list format
         min_version_list = min_version_str.split('.')
@@ -133,3 +133,19 @@ def is_valid_version_string(version_str):
             return False
 
     return True
+
+def get_zoau_version_str(ansible_zos_module):
+    """Attempts to call zoaversion on target and parses out version string.
+
+    Returns
+    -------
+    Union[int, int, int]
+        ZOAU version found in format [#,#,#]. There is a
+        provision for a 4th level eg "v1.2.0.1".
+    """
+    ZOAU_API_VERSION = get_zoau_version(ansible_zos_module)
+    version_list = (
+        ZOAU_API_VERSION.split('.')
+    )
+
+    return version_list

--- a/tests/helpers/version.py
+++ b/tests/helpers/version.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) IBM Corporation 2022, 2025
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import absolute_import, division, print_function
+
+import re
+
+__metaclass__ = type
+
+
+def get_zoau_version(ansible_zos_module):
+    """
+    Fetches the current ZOAU version from the z/OS system using the `zoaversion` command.
+
+    This function runs the `zoaversion` command on the z/OS system and parses the output 
+    to extract the version number in the format `vX.Y.Z.W`, where X, Y, Z, and W are numerical digits.
+
+    Parameters
+    ----------
+    ansible_zos_module : ansible.module_utils.basic.AnsibleModule
+        The Ansible z/OS module that provides the `all.shell()` method to run shell commands.
+
+    Returns
+    -------
+    str
+        The ZOAU version number (e.g., "1.2.3.4") extracted from the command output.
+        Returns `"1.2.0"` if no valid version is found.
+    """
+    cmd_str = "zoaversion"
+    version_results = ansible_zos_module.all.shell(cmd=cmd_str)
+    zoa_version = "0.0.0"  # Default version if not found
+
+    # Iterate through all contacted hosts and check the result output
+    for result in version_results.contacted.values():
+        output = result.get("stdout")
+        if output:
+            # Search for the version in the format "vX.Y.Z.W"
+            match = re.search(r'v?(\d+\.\d+\.\d+(?:\.\d+)?)', output)
+            if match:
+                zoa_version = match.group(1)
+
+    return zoa_version
+
+def is_zoau_version_higher_than(ansible_zos_module,min_version_str):
+    """Reports back if ZOAU version is high enough.
+
+    Parameters
+    ---------- 
+    min_version_str : str
+        The minimal desired ZOAU version '#.#.#'.
+
+    Returns
+    -------
+    bool
+        Whether ZOAU version found was high enough.
+    """
+    if is_valid_version_string(min_version_str):
+        # check zoau version on system (already a list)
+        system_version_list = get_zoau_version(ansible_zos_module)
+
+        # convert input to list format
+        min_version_list = min_version_str.split('.')
+
+        # convert list of strs to list of ints
+        system_version_list = [int(i) for i in system_version_list]
+        min_version_list = [int(i) for i in min_version_list]
+
+        # compare major
+        if system_version_list[0] > min_version_list[0]:
+            return True
+        if system_version_list[0] < min_version_list[0]:
+            return False
+
+        # majors are equal, compare minor
+        if system_version_list[1] > min_version_list[1]:
+            return True
+        if system_version_list[1] < min_version_list[1]:
+            return False
+
+        # majors and minors are equal, compare patch
+        if system_version_list[2] > min_version_list[2]:
+            return True
+        if system_version_list[2] < min_version_list[2]:
+            return False
+
+        # check for a 4th level if system and min_version provided it
+        if len(system_version_list) < 4:
+            system_version_list.append(0)
+        if len(min_version_list) < 4:
+            min_version_list.append(0)
+
+        #  return result of comparison of 4th levels.
+        return system_version_list[3] >= min_version_list[3]
+
+    # invalid version string
+    return False
+
+
+def is_valid_version_string(version_str):
+    """Reports back if string is in proper version format. Expected format is a
+        series of numbers (major) followed by a dot(.) followed by another
+        series of numbers (minor) followed by another dot(.) followed by a
+        series of numbers (patch) i.e. "#.#.#" where '#' can be any integer.
+        There is a provision for a 4th level to this eg "v1.2.0.1".
+
+    Parameters
+    ----------
+    min_version_str : str
+        String to be verified is in correct format.
+
+    Returns
+    -------
+    bool
+        Whether provided str is in correct format.
+    """
+
+    # split string into [major, minor, patch]
+    version_list = version_str.split('.')
+
+    # check each element in list isnumeric()
+    for ver in version_list:
+        if not ver.isnumeric():
+            return False
+
+    return True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Test_zos_operator_func.py and test_zos_apf_func.py need the zoau version for a few test cases. 
As the test cases run locally and it does not have access to the zoautil_py module we can not use the zoau_version_checker.py included in the plugins/modue_utils to execute the test cases as well. 
A new helper is defined in the tests names version.py. Similar to the zoau_version_checker.py but it uses the command zoaversion to fetch the version info rather than the zoautil_py module. 
It help in local and pipeline testing. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- test_zos_apf_func.py
- test_zos_operator_func.py
- tests/helpers/version.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
