### PR TITLE
Logged the generated template file content when verbosity level 3 is …

### DIFF
--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -125,6 +125,12 @@ class ActionModule(ActionBase):
                     return result
 
                 source_full = rendered_file
+                if os.path.exists(rendered_file):
+                   with open(rendered_file, 'r') as file:
+                      rendered_content = file.read()
+                      display.vvv(u"Full rendered template content for {0}:\n{1}".format(os.path.basename(source), rendered_content), host=self._play_context.remote_addr)
+                else:
+                    display.vvv(u"Rendered template file {0} does not exist.".format(rendered_file))
 
             result = {}
             copy_module_args = {}


### PR DESCRIPTION
…enabled in a module

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Logged the generated template file content when verbosity level 3
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_submit
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


<!--- Paste verbatim command output below, e.g. before and after your change -->
Logged the generated template file content 
``` Full rendered template content for template.jcl:
//HELLO    JOB (T043JM,JM00,1,0,0,0),'HELLO WORLD - JRM',CLASS=R,
//             MSGCLASS=X,MSGLEVEL=1,NOTIFY=S0JM
//STEP0001 EXEC PGM=IEBGENER
//SYSIN    DD DUMMY
//SYSPRINT DD SYSOUT=*
//SYSUT1   DD *
Hello World
/*
//SYSUT2   DD SYSOUT=*
//
```
