### PR TITLE
[zos_data_set] GDG creation failing when using replace option

### DIFF
--- a/changelogs/fragments/1964-zos_data_test-fixing-gdg-replace-issue
+++ b/changelogs/fragments/1964-zos_data_test-fixing-gdg-replace-issue
@@ -1,3 +1,3 @@
 bugfixes:
-    - zos_data_set - Fixed the TypeError which is occuring when replacing a GDG.
+    - zos_data_set - Module would fail with TypeError when trying to replace an existing GDG. Fix now allows to replacing a GDG.
       https://github.com/ansible-collections/ibm_zos_core/pull/1964

--- a/changelogs/fragments/1964-zos_data_test-fixing-gdg-replace-issue
+++ b/changelogs/fragments/1964-zos_data_test-fixing-gdg-replace-issue
@@ -1,0 +1,3 @@
+bugfixes:
+    - zos_data_set - Fixed the TypeError which is occuring when replacing a GDG.
+      https://github.com/ansible-collections/ibm_zos_core/pull/1964

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -2433,7 +2433,7 @@ class GenerationDataGroup():
         else:
             if not replace:
                 return changed
-            changed = self.ensure_absent()
+            changed = self.ensure_absent(True)
             gdg = gdgs.create(**arguments)
         if isinstance(gdg, gdgs.GenerationDataGroupView):
             changed = True

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -1110,12 +1110,10 @@ def test_gdg_create_and_replace(ansible_zos_module):
         data_set_name = get_tmp_ds_name()
         results = hosts.all.zos_data_set(name=data_set_name, empty=False, force=True, record_format="u", record_length=0, replace=True, space_primary=5, space_secondary=3, space_type="cyl", state="present", type="gdg", limit=3)
         for result in results.contacted.values():
-            print(result)
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
         results = hosts.all.zos_data_set(name=data_set_name, empty=False, force=True, record_format="u", record_length=0, replace=True, space_primary=5, space_secondary=3, space_type="cyl", state="present", type="gdg", limit=3)
         for result in results.contacted.values():
-            print(result)
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
     finally:

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -1108,11 +1108,15 @@ def test_gdg_create_and_replace(ansible_zos_module):
     try:
         hosts = ansible_zos_module
         data_set_name = get_tmp_ds_name()
-        results = hosts.all.zos_data_set(name=data_set_name, empty=False, force=True, record_format="u", record_length=0, replace=True, space_primary=5, space_secondary=3, space_type="cyl", state="present", type="gdg", limit=3)
+        results = hosts.all.zos_data_set(name=data_set_name, empty=False, force=True, record_format="u", 
+                                         record_length=0, replace=True, space_primary=5, space_secondary=3, 
+                                         space_type="cyl", state="present", type="gdg", limit=3)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
-        results = hosts.all.zos_data_set(name=data_set_name, empty=False, force=True, record_format="u", record_length=0, replace=True, space_primary=5, space_secondary=3, space_type="cyl", state="present", type="gdg", limit=3)
+        results = hosts.all.zos_data_set(name=data_set_name, empty=False, force=True, record_format="u", 
+                                         record_length=0, replace=True, space_primary=5, space_secondary=3, 
+                                         space_type="cyl", state="present", type="gdg", limit=3)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -1103,3 +1103,20 @@ def test_create_member_special_chars(ansible_zos_module):
     finally:
         hosts.all.zos_data_set(name=data_set_name, state="absent")
 
+
+def test_gdg_create_and_replace(ansible_zos_module):
+    try:
+        hosts = ansible_zos_module
+        data_set_name = get_tmp_ds_name()
+        results = hosts.all.zos_data_set(name=data_set_name, empty=False, force=True, record_format="u", record_length=0, replace=True, space_primary=5, space_secondary=3, space_type="cyl", state="present", type="gdg", limit=3)
+        for result in results.contacted.values():
+            print(result)
+            assert result.get("changed") is True
+            assert result.get("module_stderr") is None
+        results = hosts.all.zos_data_set(name=data_set_name, empty=False, force=True, record_format="u", record_length=0, replace=True, space_primary=5, space_secondary=3, space_type="cyl", state="present", type="gdg", limit=3)
+        for result in results.contacted.values():
+            print(result)
+            assert result.get("changed") is True
+            assert result.get("module_stderr") is None
+    finally:
+        hosts.all.zos_data_set(name=data_set_name, state="absent", force=True, type="gdg")


### PR DESCRIPTION
##### SUMMARY
Replacing a GDG is failing with TypeError #1958

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zos_data_set

##### ADDITIONAL INFORMATION
As part of replacing GDG, existing GDG need to be deleted first and after new GDG need to be added. Force removal of existing GDG should be done but instead currently direct removal without force is throwing TypeError. So fixed this issue by passing Force=True when deleting existing GDG as part of replace functionality.

Test results:
Before fixing the issue...
<img width="1448" alt="Screenshot 2025-03-04 at 2 00 56 PM" src="https://github.com/user-attachments/assets/2bb6b577-7803-4dca-9f82-b3f27e2c1465" />

After fixing the issue....
<img width="1447" alt="Screenshot 2025-03-04 at 2 03 23 PM" src="https://github.com/user-attachments/assets/aa6769dd-a611-46f1-9988-9c8921785edb" />

