### PR TITLE
[Documentation][zos_copy] Document copy behavior of 'SOME.TEST.PDS(*)' as source

### DIFF
--- a/changelogs/fragments/1970-update-zos_copy-wildcard.yml
+++ b/changelogs/fragments/1970-update-zos_copy-wildcard.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_copy - Document copy behavior of 'SOME.TEST.PDS(*)' in zos_copy.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/1970).

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -316,13 +316,14 @@ options:
         into the root of C(dest). If it doesn't end with "/", the directory itself
         will be copied.
       - If C(src) is a directory or a file, file names will be truncated and/or modified
-        to ensure a valid name for a data set or member.
+        to ensure a valid name for a data set or member
       - If C(src) is a VSAM data set, C(dest) must also be a VSAM.
       - If C(src) is a generation data set (GDS), it must be a previously allocated one.
       - If C(src) is a generation data group (GDG), C(dest) can be another GDG or a USS
         directory.
       - Wildcards can be used to copy multiple PDS/PDSE members to another
-        PDS/PDSE.
+        PDS/PDSE. i.e. Using SOME.TEST.PDS(*) will copy all members from one PDS/E
+        to another without removing the destination PDS/E.
       - Required unless using C(content).
     type: str
   validate:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -316,7 +316,7 @@ options:
         into the root of C(dest). If it doesn't end with "/", the directory itself
         will be copied.
       - If C(src) is a directory or a file, file names will be truncated and/or modified
-        to ensure a valid name for a data set or member
+        to ensure a valid name for a data set or member.
       - If C(src) is a VSAM data set, C(dest) must also be a VSAM.
       - If C(src) is a generation data set (GDS), it must be a previously allocated one.
       - If C(src) is a generation data group (GDG), C(dest) can be another GDG or a USS


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Document copy behavior of 'SOME.TEST.PDS(*)' in zos_copy, as stated we can use wildcards to copy members, but this option allows to copy all members from source without replacing destination PDS.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1950 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
