### PR TITLE
Update mounts.env

### DIFF
--- a/scripts/mounts.env
+++ b/scripts/mounts.env
@@ -28,20 +28,19 @@
 #   data_set - the z/OS data set containing the binaries to mount
 #   space - must be a space before the closing quote
 # ------------------------------------------------------------------------------
-zoau_mount_list_str="1:1.1.1-ptf1:/zoau/v1.1.1-ptf1:IMSTESTU.ZOAU.V111.PTF1.ZFS "\
-"2:1.2.0:/zoau/v1.2.0:IMSTESTU.ZOAU.V120.ZFS "\
-"3:1.2.1:/zoau/v1.2.1:IMSTESTU.ZOAU.V121.ZFS "\
-"4:1.2.2:/zoau/v1.2.2:IMSTESTU.ZOAU.V122.ZFS "\
-"5:1.2.3:/zoau/v1.2.3:IMSTESTU.ZOAU.V123.ZFS "\
-"6:1.2.4:/zoau/v1.2.4:IMSTESTU.ZOAU.V124.ZFS "\
-"7:1.2.5.8:/zoau/v1.2.5.8:IMSTESTU.ZOAU.V102.GA.ZFS "\
-"8:1.2.5.10:/zoau/v1.2.5.10:IMSTESTU.ZOAU.V103.PTF2.ZFS "\
-"9:1.3.0:/zoau/v1.3.0:IMSTESTU.ZOAU.V103.GA5.ZFS "\
-"10:1.3.1:/zoau/v1.3.1:IMSTESTU.ZOAU.V130.ZFS "\
-"11:1.3.2:/zoau/v1.3.2.0:IMSTESTU.ZOAU.V100.GA.ZFS "\
-"12:1.3.3:/zoau/v1.3.3:IMSTESTU.ZOAU.V101.GA.ZFS "\
-"13:1.3.4:/zoau/v1.3.4:IMSTESTU.ZOAU.V110.GA.ZFS "\
-"14:latest:/zoau/latest:IMSTESTU.ZOAU.LATEST.ZFS "
+zoau_mount_list_str="1:1.2.2:/zoau/v1.2.2:IMSTESTU.ZOAU.V122.ZFS "\
+"2:1.2.3:/zoau/v1.2.3:IMSTESTU.ZOAU.V123.ZFS "\
+"3:1.2.4:/zoau/v1.2.4:IMSTESTU.ZOAU.V124.ZFS "\
+"4:1.2.5.8:/zoau/v1.2.5.8:IMSTESTU.ZOAU.V102.GA.ZFS "\
+"5:1.2.5.10:/zoau/v1.2.5.10:IMSTESTU.ZOAU.V103.PTF2.ZFS "\
+"6:1.3.0:/zoau/v1.3.0:IMSTESTU.ZOAU.V103.GA5.ZFS "\
+"7:1.3.1:/zoau/v1.3.1:IMSTESTU.ZOAU.V130.ZFS "\
+"8:1.3.2:/zoau/v1.3.2.0:IMSTESTU.ZOAU.V100.GA.ZFS "\
+"9:1.3.3:/zoau/v1.3.3:IMSTESTU.ZOAU.V101.GA.ZFS "\
+"10:1.3.4:/zoau/v1.3.4:IMSTESTU.ZOAU.V110.GA.ZFS "\
+"11:1.3.4.1:/zoau/v1.3.4.1:IMSTESTU.ZOAU.V120.ZFS "\
+"12:1.3.5:/zoau/v1.3.5:IMSTESTU.ZOAU.V121.ZFS "\
+"13:latest:/zoau/latest:IMSTESTU.ZOAU.LATEST.ZFS "
 
 # ------------------------------------------------------------------------------
 # PYTHON MOUNT TABLE


### PR DESCRIPTION
removed zoau < 1.2.2 and added 1.3.4.1 and 1.3.5

##### SUMMARY
This is an update to mounts.env to update the 'super share' for zoau.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ac tool

