### PR TITLE
[Enabler][zos_blockinfile]Add_documentation_of_false_negatives_and_ensure_proper_testing

### DIFF
--- a/changelogs/fragments/2025-Add_documentation_of_false_negatives_and_ensure_proper_testing.yml
+++ b/changelogs/fragments/2025-Add_documentation_of_false_negatives_and_ensure_proper_testing.yml
@@ -1,0 +1,4 @@
+trivial:
+  - zos_blockinfile - Updated documentation on zos_blockinfile to notify about false positive
+    and add test cases to avoid extra cases of false positives.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2025).

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -202,6 +202,8 @@ notes:
     the block will be overwritten on each iteration.
   - When more then one block should be handled in a file you must change
     the I(marker) per task.
+  - When working with a backup of a sequential dataset to avoid false positive
+    backup name should be a sequential dataset too, not a member of pds or pdse.
 seealso:
 - module: zos_data_set
 '''

--- a/plugins/modules/zos_blockinfile.py
+++ b/plugins/modules/zos_blockinfile.py
@@ -202,8 +202,8 @@ notes:
     the block will be overwritten on each iteration.
   - When more then one block should be handled in a file you must change
     the I(marker) per task.
-  - When working with a backup of a sequential dataset to avoid false positive
-    backup name should be a sequential dataset too, not a member of pds or pdse.
+  - When working with a backup of a sequential dataset, the backup name should also be a sequential dataset.
+    This will avoid the false positive and error condition during backup.
 seealso:
 - module: zos_data_set
 '''


### PR DESCRIPTION
##### SUMMARY
Previous we have some false positives cases with backup, to avoid false positives and verify the proper work of the module is required to add the backup validation, fixing #629, but open a new issue been #2024 to work on a specific problem of backups, if the backup required to be same time as the original MVS or could be SEQ with PDS, meanwhile, add to the documentation how avoid false positives.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request

##### COMPONENT NAME
Verify the type of backup is use and verify the content of the backup.
<img width="1382" alt="Captura de pantalla 2025-03-25 a la(s) 4 04 10 p m" src="https://github.com/user-attachments/assets/693ee127-39e3-4ca6-8901-344fb23b879b" />
<img width="833" alt="Captura de pantalla 2025-03-25 a la(s) 4 04 22 p m" src="https://github.com/user-attachments/assets/bd880631-649a-41bb-bce2-78f453980be2" />



