### PR TITLE
[Documentation][zos_copy] Remove the need of MVS.MCSOPER.ZOAU profile from the docs

### DIFF
--- a/changelogs/fragments/2039-documentation-zos_copy-opercmd.yml
+++ b/changelogs/fragments/2039-documentation-zos_copy-opercmd.yml
@@ -1,0 +1,3 @@
+trivial:
+  - zos_copy - Removed the need of MVS.MCSOPER.ZOAU profile in zos_copy.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2039).

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -563,10 +563,6 @@ notes:
       described as the remote user, configured either for the playbook or
       playbook tasks, who can also obtain escalated privileges to execute as
       root or another user.
-    - To use this module, you must define the RACF FACILITY class profile
-      and allow READ access to RACF FACILITY profile MVS.MCSOPER.ZOAU. If
-      your system uses a different security product, consult that product's
-      documentation to configure the required security classes.
 seealso:
 - module: zos_fetch
 - module: zos_data_set


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The need of `opercmd` was removed in #1917 but no changes to the docs were performed, so now we are removing it from docs.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #2036 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy