### PR TITLE
reducing the volume size so it can execute on any volume

### DIFF
--- a/tests/functional/modules/test_zos_mount_func.py
+++ b/tests/functional/modules/test_zos_mount_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020, 2024
+# Copyright (c) IBM Corporation 2020, 2025
 # Apache License, Version 2.0 (see https://opensource.org/licenses/Apache-2.0)
 
 from __future__ import absolute_import, division, print_function
@@ -81,7 +81,7 @@ def create_sourcefile(hosts, volume):
     mount_result = hosts.all.shell(
         cmd="zfsadm define -aggregate "
         + thisfile
-        + " -volumes {0} -cylinders 200 1".format(volume),
+        + " -volumes {0} -cylinders 10 1".format(volume),
         executable=SHELL_EXECUTABLE,
         stdin="",
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As the volume size is more than required in the test case,  this PR is to reduce the size of the cylinder.  Initially the volume size is 200 cylinders and we need minimum of 2 cylinders to test the test_basic_mount. We are keeping it to 10 so that the volumes can easily allocated  to the test case.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
