### PR TITLE
[Documentation] Update zos_fetch documentation to be clear about flat value

### DIFF
--- a/changelogs/fragments/2047-zos_fetch-update-docs.yml
+++ b/changelogs/fragments/2047-zos_fetch-update-docs.yml
@@ -1,0 +1,3 @@
+minor_changes:
+   - zos_fetch - Updated the documentation to correctly state what the default behavior of the module is.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2047).

--- a/plugins/modules/zos_fetch.py
+++ b/plugins/modules/zos_fetch.py
@@ -70,12 +70,12 @@ options:
     type: bool
   flat:
     description:
-      - Override the default behavior of appending hostname/path/to/file to the
-        destination. If set to "true", the file or data set will be fetched to
+      - If set to "true", override the default behavior of appending hostname/path/to/file to the
+        destination, instead the file or data set will be fetched to
         the destination directory without appending remote hostname to the
         destination.
     required: false
-    default: "true"
+    default: "false"
     type: bool
   is_binary:
     description:
@@ -848,7 +848,7 @@ def run_module():
             src=dict(required=True, type="str"),
             dest=dict(required=True, type="path"),
             fail_on_missing=dict(required=False, default=True, type="bool"),
-            flat=dict(required=False, default=True, type="bool"),
+            flat=dict(required=False, default=False, type="bool"),
             is_binary=dict(required=False, default=False, type="bool"),
             use_qualifier=dict(required=False, default=False, type="bool"),
             validate_checksum=dict(required=False, default=True, type="bool"),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updated the documentation in the module about the flat option because it was saying that the default behavior was flat, and in fact the default behavior was creating the whole path for the artifact.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
