### PR TITLE
zos_apf python module port shell commands to python apis

### DIFF
--- a/changelogs/fragments/2055-Zos_apf-shell-commands-to-api.yml
+++ b/changelogs/fragments/2055-Zos_apf-shell-commands-to-api.yml
@@ -1,0 +1,3 @@
+minor_changes:
+   - zos_apf - Updated the module to use the API instead of shell commands. 
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2055).

--- a/changelogs/fragments/2055-Zos_apf-shell-commands-to-api.yml
+++ b/changelogs/fragments/2055-Zos_apf-shell-commands-to-api.yml
@@ -1,3 +1,3 @@
-minor_changes:
+trivial:
    - zos_apf - Updated the module to use the API instead of shell commands. 
      (https://github.com/ansible-collections/ibm_zos_core/pull/2055).

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -319,7 +319,6 @@ import traceback
 
 try:
     from zoautil_py import zsystem
-    from zoautil_py import ztypes
 except Exception:
     zsystem = ZOAUImportError(traceback.format_exc())
     ztypes = ZOAUImportError(traceback.format_exc())
@@ -388,120 +387,6 @@ def backupOper(module, src, backup, tmphlq=None):
         )
 
     return backup_name
-
-
-def make_apf_command(library, opt, volume=None, sms=None, force_dynamic=None, persistent=None):
-    """Returns a string that can run an APF command in a shell.
-
-    Parameters
-    ----------
-    library : str
-        Name of the data set that will be operated on.
-    opt : str
-        APF operation (either add or del)
-    volume : str
-        Volume of library.
-    sms : bool
-        Whether library is managed by SMS.
-    force_dynamic : bool
-        Whether the APF list format should be dynamic.
-    persistent : dict
-        Options for persistent entries that should be modified by APF.
-
-    Returns
-    -------
-    str
-        APF command.
-    """
-    # -i is  available in ZOAU version 1.3.4
-    # before that all versions will not be able to use -i
-    if zoau_version_checker.is_zoau_version_higher_than("1.3.4"):
-        operation = "-i -A" if opt == "add" else "-i -D"
-
-    else:
-        operation = "-A" if opt == "add" else "-D"
-
-    operation_args = library
-
-    if volume:
-        operation_args = f"{operation_args},{volume}"
-    elif sms:
-        operation_args = f"{operation_args},SMS"
-
-    command = f"apfadm {operation} '{operation_args}'"
-
-    if force_dynamic:
-        command = f"{command} -f"
-
-    if persistent:
-        if opt == "add":
-            persistent_args = f""" -P '{persistent.get("addDataset")}' """
-        else:
-            persistent_args = f""" -R '{persistent.get("delDataset")}' """
-
-        if persistent.get("marker"):
-            persistent_args = f""" {persistent_args} -M '{persistent.get("marker")}' """
-
-        command = f"{command} {persistent_args}"
-
-    return command
-
-
-def make_apf_batch_command(batch, force_dynamic=None, persistent=None):
-    """Returns a string that can run an APF command for multiple operations
-    in a shell.
-
-    Parameters
-    ----------
-    batch : list
-        List of dicts containing different APF add/del operations.
-    force_dynamic : bool
-        Whether the APF list format should be dynamic.
-    persistent : dict
-        Options for persistent entries that should be modified by APF.
-
-    Returns
-    -------
-    str
-        APF command.
-    """
-    command = "apfadm"
-
-    for item in batch:
-        if zoau_version_checker.is_zoau_version_higher_than("1.3.4"):
-            operation = "-i -A" if item["opt"] == "add" else "-i -D"
-
-        else:
-            operation = "-A" if item["opt"] == "add" else "-D"
-
-        operation_args = item["dsname"]
-
-        volume = item.get("volume")
-        sms = item.get("sms")
-
-        if volume:
-            operation_args = f"{operation_args},{volume}"
-        elif sms:
-            operation_args = f"{operation_args},SMS"
-
-        command = f"{command} {operation} '{operation_args}'"
-
-    if force_dynamic:
-        command = f"{command} -f"
-
-    if persistent:
-        if persistent.get("addDataset"):
-            persistent_args = f""" -P '{persistent.get("addDataset")}' """
-        else:
-            persistent_args = f""" -R '{persistent.get("delDataset")}' """
-
-        if persistent.get("marker"):
-            persistent_args = f""" {persistent_args} -M '{persistent.get("marker")}' """
-
-        command = f"{command} {persistent_args}"
-
-    return command
-
 
 def main():
     """Initialize the module.
@@ -693,21 +578,15 @@ def main():
                 item['opt'] = opt
                 item['dsname'] = item.get('library')
                 del item['library']
-            # Commenting this line to implement a workaround for names with '$'. ZOAU should
-            # release a fix soon so we can uncomment this Python API call.
-            # ret = zsystem.apf(batch=batch, forceDynamic=force_dynamic, persistent=persistent)
-            apf_command = make_apf_batch_command(batch, force_dynamic=force_dynamic, persistent=persistent)
-            rc, out, err = module.run_command(apf_command)
-            ret = ztypes.ZOAUResponse(rc, out, err, apf_command, 'utf-8')
+            # ignore=true is added so that it's ignoring in case of addition if already present
+            # ignore=true is added so that it's ignoring in case the file is not in apf list while deletion
+            ret = zsystem.apf(batch=batch, forceDynamic=force_dynamic, persistent=persistent,ignore=True)
         else:
             if not library:
                 module.fail_json(msg='library is required')
-            # Commenting this line to implement a workaround for names with '$'. ZOAU should
-            # release a fix soon so we can uncomment this Python API call.
-            # ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent)
-            apf_command = make_apf_command(library, opt, volume=volume, sms=sms, force_dynamic=force_dynamic, persistent=persistent)
-            rc, out, err = module.run_command(apf_command)
-            ret = ztypes.ZOAUResponse(rc, out, err, apf_command, 'utf-8')
+            # ignore=true is added so that it's ignoring in case of addition if already present
+            # ignore=true is added so that it's ignoring in case the file is not in apf list while deletion
+            ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent,ignore=True)
 
     operOut = ret.stdout_response
     operErr = ret.stderr_response

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -310,7 +310,7 @@ import json
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
-    better_arg_parser, data_set, backup as Backup)
+    better_arg_parser, zoau_version_checker, data_set, backup as Backup)
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
     ZOAUImportError,
@@ -581,13 +581,19 @@ def main():
                 del item['library']
             # ignore=true is added so that it's ignoring in case of addition if already present
             # ignore=true is added so that it's ignoring in case the file is not in apf list while deletion
-            ret = zsystem.apf(batch=batch, forceDynamic=force_dynamic, persistent=persistent, ignore=True)
+            if zoau_version_checker.is_zoau_version_higher_than("1.3.4"):
+                ret = zsystem.apf(batch=batch, forceDynamic=force_dynamic, persistent=persistent, ignore=True)
+            else:
+                ret = zsystem.apf(batch=batch, forceDynamic=force_dynamic, persistent=persistent)
         else:
             if not library:
                 module.fail_json(msg='library is required')
             # ignore=true is added so that it's ignoring in case of addition if already present
             # ignore=true is added so that it's ignoring in case the file is not in apf list while deletion
-            ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent, ignore=True)
+            if zoau_version_checker.is_zoau_version_higher_than("1.3.4"):
+                ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent, ignore=True)
+            else:
+                ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent)
 
     operOut = ret.stdout_response
     operErr = ret.stderr_response

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -321,7 +321,6 @@ try:
     from zoautil_py import zsystem
 except Exception:
     zsystem = ZOAUImportError(traceback.format_exc())
-    ztypes = ZOAUImportError(traceback.format_exc())
 
 
 # supported data set types

--- a/plugins/modules/zos_apf.py
+++ b/plugins/modules/zos_apf.py
@@ -310,7 +310,7 @@ import json
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
-    better_arg_parser, zoau_version_checker, data_set, backup as Backup)
+    better_arg_parser, data_set, backup as Backup)
 
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.import_handler import (
     ZOAUImportError,
@@ -387,6 +387,7 @@ def backupOper(module, src, backup, tmphlq=None):
         )
 
     return backup_name
+
 
 def main():
     """Initialize the module.
@@ -580,13 +581,13 @@ def main():
                 del item['library']
             # ignore=true is added so that it's ignoring in case of addition if already present
             # ignore=true is added so that it's ignoring in case the file is not in apf list while deletion
-            ret = zsystem.apf(batch=batch, forceDynamic=force_dynamic, persistent=persistent,ignore=True)
+            ret = zsystem.apf(batch=batch, forceDynamic=force_dynamic, persistent=persistent, ignore=True)
         else:
             if not library:
                 module.fail_json(msg='library is required')
             # ignore=true is added so that it's ignoring in case of addition if already present
             # ignore=true is added so that it's ignoring in case the file is not in apf list while deletion
-            ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent,ignore=True)
+            ret = zsystem.apf(opt=opt, dsname=library, volume=volume, sms=sms, forceDynamic=force_dynamic, persistent=persistent, ignore=True)
 
     operOut = ret.stdout_response
     operErr = ret.stderr_response


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We were previously using the apfadm command to add or remove datasets from the APF list.
Now that the Python API is working and the issue with datasets containing a $ in their names has been resolved, we are reverting to using the API instead of shell commands.   
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Test results of sample playbook tested post changes
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
(venv-2.18) ansible-playbook -i inventories/ apf.yml

PLAY [zos_host] ***********************************************************************************************************

TASK [Add library to APF list 1st time] ***********************************************************************************
changed: [zos_host]

TASK [Debug 1st addition] *************************************************************************************************
ok: [zos_host] => {
    "add1st": {
        "changed": true,
        "failed": false,
        "rc": 0,
        "stderr": "",
        "stderr_lines": [],
        "stdout": "EC01248A   2025106  10:36:11.00             ISF031I CONSOLE OMVS0000 ACTIVATED\nEC01248A   2025106  10:36:11.00            -SETPROG APF,ADD,DSNAME=OMVSADM.TEST.TUE,VOLUME=0 \nEC01248A   2025106  10:36:11.00             CSV410I DATA SET OMVSADM.TEST.TUE ON VOLUME 0 ADDED TO APF LIST\n",
        "stdout_lines": [
            "EC01248A   2025106  10:36:11.00             ISF031I CONSOLE OMVS0000 ACTIVATED",
            "EC01248A   2025106  10:36:11.00            -SETPROG APF,ADD,DSNAME=OMVSADM.TEST.TUE,VOLUME=0 ",
            "EC01248A   2025106  10:36:11.00             CSV410I DATA SET OMVSADM.TEST.TUE ON VOLUME 0 ADDED TO APF LIST"
        ]
    }
}

TASK [Add library to APF list 2nd time] ***********************************************************************************
ok: [zos_host]

TASK [Debug 2nd addition] *************************************************************************************************
ok: [zos_host] => {
    "add2nd": {
        "changed": false,
        "failed": false,
        "rc": 0,
        "stderr": "BGYSC4710E Add error: Dataset OMVSADM.TEST.TUE on volume 0 is already present in APF list.\n",
        "stderr_lines": [
            "BGYSC4710E Add error: Dataset OMVSADM.TEST.TUE on volume 0 is already present in APF list."
        ],
        "stdout": "",
        "stdout_lines": []
    }
}

TASK [Delete library from APF list] ***************************************************************************************
changed: [zos_host]

TASK [Debug 1st Deletion] *************************************************************************************************
ok: [zos_host] => {
    "del1st": {
        "changed": true,
        "failed": false,
        "rc": 0,
        "stderr": "",
        "stderr_lines": [],
        "stdout": "EC01248A   2025106  10:36:28.00             ISF031I CONSOLE OMVS0000 ACTIVATED\nEC01248A   2025106  10:36:28.00            -SETPROG APF,DELETE,DSNAME=OMVSADM.TEST.TUE,VOLUME=0 \nEC01248A   2025106  10:36:28.00             CSV410I DATA SET OMVSADM.TEST.TUE ON VOLUME 0 DELETED FROM APF LIST\n",
        "stdout_lines": [
            "EC01248A   2025106  10:36:28.00             ISF031I CONSOLE OMVS0000 ACTIVATED",
            "EC01248A   2025106  10:36:28.00            -SETPROG APF,DELETE,DSNAME=OMVSADM.TEST.TUE,VOLUME=0 ",
            "EC01248A   2025106  10:36:28.00             CSV410I DATA SET OMVSADM.TEST.TUE ON VOLUME 0 DELETED FROM APF LIST"
        ]
    }
}

TASK [Delete library from APF list 2nd time] ******************************************************************************
ok: [zos_host]

TASK [Debug 2nd Deletion] *************************************************************************************************
ok: [zos_host] => {
    "del2nd": {
        "changed": false,
        "failed": false,
        "rc": 0,
        "stderr": "BGYSC4711E Delete error: Dataset OMVSADM.TEST.TUE on volume 0 is not present in APF list.\n",
        "stderr_lines": [
            "BGYSC4711E Delete error: Dataset OMVSADM.TEST.TUE on volume 0 is not present in APF list."
        ],
        "stdout": "",
        "stdout_lines": []
    }
}

PLAY RECAP ****************************************************************************************************************
zos_host                   : ok=8    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```
