### PR TITLE
[Bug] [zos_data_set] Ensure Dataset Volume Validation

### DIFF
--- a/changelogs/fragments/2057-zos_data_set&data_set-Ensure-Dataset-Volume-Validation.yml
+++ b/changelogs/fragments/2057-zos_data_set&data_set-Ensure-Dataset-Volume-Validation.yml
@@ -7,5 +7,9 @@ bugfixes:
      (https://github.com/ansible-collections/ibm_zos_core/pull/2057).
 trivial:     
    - data_set - added validation logic to compare requested volumes against
-     cataloged volumes.  
+     cataloged volumes.
+     Improved error messaging when volume conflicts occur during data set creation on
+     different volume.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2057).
+   - zos_data_set - Added documentation about potential false positive scenarios.
      (https://github.com/ansible-collections/ibm_zos_core/pull/2057).

--- a/changelogs/fragments/2057-zos_data_set&data_set-Ensure-Dataset-Volume-Validation.yml
+++ b/changelogs/fragments/2057-zos_data_set&data_set-Ensure-Dataset-Volume-Validation.yml
@@ -1,8 +1,11 @@
 bugfixes:
-   - zos_data_set - Added validation to check existing cataloged volumes 
-     against requested volumes.
+   - zos_data_set - Attempting to create a data set with the same name on a 
+     different volume did not work, nor did it report a failure. 
+     The fix now informs the user that if the data set is cataloged on a 
+     different volume and it needs to be uncataloged before using the data 
+     set module to create a new data set on a different volume.
      (https://github.com/ansible-collections/ibm_zos_core/pull/2057).
 trivial:     
-   - data_set - added validation logic to compare rwquested volumes against
+   - data_set - added validation logic to compare requested volumes against
      cataloged volumes.  
      (https://github.com/ansible-collections/ibm_zos_core/pull/2057).

--- a/changelogs/fragments/2057-zos_data_set&data_set-Ensure-Dataset-Volume-Validation.yml
+++ b/changelogs/fragments/2057-zos_data_set&data_set-Ensure-Dataset-Volume-Validation.yml
@@ -2,7 +2,7 @@ bugfixes:
    - zos_data_set - Attempting to create a data set with the same name on a 
      different volume did not work, nor did it report a failure. 
      The fix now informs the user that if the data set is cataloged on a 
-     different volume and it needs to be uncataloged before using the data 
+     different volume, it needs to be uncataloged before using the data 
      set module to create a new data set on a different volume.
      (https://github.com/ansible-collections/ibm_zos_core/pull/2057).
 trivial:     

--- a/changelogs/fragments/2057-zos_data_set&data_set-Ensure-Dataset-Volume-Validation.yml
+++ b/changelogs/fragments/2057-zos_data_set&data_set-Ensure-Dataset-Volume-Validation.yml
@@ -1,0 +1,8 @@
+bugfixes:
+   - zos_data_set - Added validation to check existing cataloged volumes 
+     against requested volumes.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2057).
+trivial:     
+   - data_set - added validation logic to compare rwquested volumes against
+     cataloged volumes.  
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2057).

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -203,6 +203,17 @@ class DataSet(object):
         changed = False
         if DataSet.data_set_cataloged(name, tmphlq=tmp_hlq):
             present = True
+        if present and not replace and volumes:
+            cataloged_volumes = DataSet.data_set_cataloged_volume_list(name, tmphlq=tmp_hlq)
+            requested_volumes = [v.upper() for v in volumes]
+        
+        # Check if ANY requested volume matches cataloged volumes
+            if not any(vol.upper() in requested_volumes for vol in cataloged_volumes):
+                raise DatasetCatalogedOnDifferentVolumeError(
+                    name=name,
+                    existing_volumes=cataloged_volumes,
+                    requested_volumes=volumes
+                )
 
         if not present:
             try:

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -206,7 +206,7 @@ class DataSet(object):
         if present and not replace and volumes:
             cataloged_volumes = DataSet.data_set_cataloged_volume_list(name, tmphlq=tmp_hlq)
             requested_volumes = [v.upper() for v in volumes]
-        #Check if ANY requested volume matches cataloged volumes
+         # Check if ANY requested volume matches cataloged volumes
             if not any(vol.upper() in requested_volumes for vol in cataloged_volumes):
                 raise DatasetCatalogedOnDifferentVolumeError(
                     name=name,

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -206,8 +206,7 @@ class DataSet(object):
         if present and not replace and volumes:
             cataloged_volumes = DataSet.data_set_cataloged_volume_list(name, tmphlq=tmp_hlq)
             requested_volumes = [v.upper() for v in volumes]
-        
-        # Check if ANY requested volume matches cataloged volumes
+        #Check if ANY requested volume matches cataloged volumes
             if not any(vol.upper() in requested_volumes for vol in cataloged_volumes):
                 raise DatasetCatalogedOnDifferentVolumeError(
                     name=name,
@@ -3130,6 +3129,7 @@ class DatasetCatalogError(Exception):
             data_set, ", ".join(volumes), rc, message
         )
         super().__init__(self.msg)
+
 
 class DatasetCatalogedOnDifferentVolumeError(Exception):
     def __init__(self, name, existing_volumes, requested_volumes):

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -3120,6 +3120,16 @@ class DatasetCatalogError(Exception):
         )
         super().__init__(self.msg)
 
+class DatasetCatalogedOnDifferentVolumeError(Exception):
+    def __init__(self, name, existing_volumes, requested_volumes):
+        existing_vol_str = ", ".join(existing_volumes) if existing_volumes else "none"
+        requested_vol_str = ", ".join(requested_volumes) if requested_volumes else "none"
+        self.msg = (
+            "Data set {0} is cataloged with volume {1}, if you want to create data set {0} "
+            "in volume {2} uncatalog the data set first and then create it."
+        ).format(name, existing_vol_str, requested_vol_str)
+        super().__init__(self.msg)
+
 
 class DatasetUncatalogError(Exception):
     def __init__(self, data_set, rc):

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -205,7 +205,7 @@ class DataSet(object):
             present = True
         if present and not replace and volumes:
             cataloged_volumes = DataSet.data_set_cataloged_volume_list(name, tmphlq=tmp_hlq)
-            requested_volumes = [v.upper() for v in volumes]
+            requested_volumes = [vol.upper() for vol in volumes]
             if not any(vol.upper() in requested_volumes for vol in cataloged_volumes):
                 raise DatasetCatalogedOnDifferentVolumeError(
                     name=name,

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -203,6 +203,10 @@ class DataSet(object):
         changed = False
         if DataSet.data_set_cataloged(name, tmphlq=tmp_hlq):
             present = True
+        # Validate volume conflicts when:
+        # 1. Dataset exists in catalog (present=True).
+        # 2. User hasn't requested replacement (replace=False).
+        # 3. Specific volumes were requested (volumes parameter provided).
         if present and not replace and volumes:
             cataloged_volumes = DataSet.data_set_cataloged_volume_list(name, tmphlq=tmp_hlq)
             requested_volumes = [vol.upper() for vol in volumes]

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -206,7 +206,6 @@ class DataSet(object):
         if present and not replace and volumes:
             cataloged_volumes = DataSet.data_set_cataloged_volume_list(name, tmphlq=tmp_hlq)
             requested_volumes = [v.upper() for v in volumes]
-         # Check if ANY requested volume matches cataloged volumes
             if not any(vol.upper() in requested_volumes for vol in cataloged_volumes):
                 raise DatasetCatalogedOnDifferentVolumeError(
                     name=name,

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -802,7 +802,7 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.better_arg_parser
     BetterArgParser,
 )
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.data_set import (
-    DatasetCatalogedOnDifferentVolumeError, DataSet, GenerationDataGroup, MVSDataSet, Member
+    DataSet, GenerationDataGroup, MVSDataSet, Member
 )
 from ansible.module_utils.basic import AnsibleModule
 
@@ -1915,8 +1915,6 @@ def run_module():
                 result["changed"] = result["changed"] or current_changed
         except Exception as e:
             module.fail_json(msg=str(e), **result)
-        except Exception as e:
-            module.fail_json(msg=repr(e), **result)
     if module.params.get("replace"):
         result["changed"] = True
     module.exit_json(**result)

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1914,7 +1914,8 @@ def run_module():
                 )
                 result["changed"] = result["changed"] or current_changed
         except Exception as e:
-            module.fail_json(msg=str(e), **result)
+            #module.fail_json(msg=str(e), **result)
+            module.fail_json(msg=repr(e), **result)
     if module.params.get("replace"):
         result["changed"] = True
     module.exit_json(**result)

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1913,11 +1913,14 @@ def run_module():
                     force=data_set_params.get("force"),
                 )
                 result["changed"] = result["changed"] or current_changed
-        except DatasetCatalogedOnDifferentVolumeError as e:
-            module.fail_json(msg=str(e), changed=False)
+        except Exception as e:
+            module.fail_json(msg=str(e), **result)
         except Exception as e:
             module.fail_json(msg=repr(e), **result)
-        module.exit_json(**result)
+
+    if module.params.get("replace"):
+        result["changed"] = True        
+    module.exit_json(**result)
 
 
 def main():

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1918,7 +1918,7 @@ def run_module():
         except Exception as e:
             module.fail_json(msg=repr(e), **result)
     if module.params.get("replace"):
-        result["changed"] = True        
+        result["changed"] = True
     module.exit_json(**result)
 
 

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -106,8 +106,8 @@ options:
         module completes successfully with I(changed=True).
         - >
         If I(state=present), the data set is already cataloged and I(volumes) is provided,
-        the module will compare the volumes where it is cataloged against the provided I(volumes). 
-        If they don't match, the module will fail with an error indicating the data set is cataloged 
+        the module will compare the volumes where it is cataloged against the provided I(volumes).
+        If they don't match, the module will fail with an error indicating the data set is cataloged
         on a different volume.
         To resolve this, you must first uncatalog the data set before creating it on the new volume.
       - >

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1917,7 +1917,6 @@ def run_module():
             module.fail_json(msg=str(e), **result)
         except Exception as e:
             module.fail_json(msg=repr(e), **result)
-
     if module.params.get("replace"):
         result["changed"] = True        
     module.exit_json(**result)

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -105,12 +105,13 @@ options:
         If I(state=uncataloged) and the data set is found, the data set is uncataloged,
         module completes successfully with I(changed=True).
         - >
-        If I(state=present) and the data set is already cataloged and I(volumes) is provided,
-        the module will compare the cataloged volumes with the provided I(volumes). If they don't match,
-        the module will fail with an error indicating the data set is cataloged on a different volume.
+        If I(state=present), the data set is already cataloged and I(volumes) is provided,
+        the module will compare the volumes where it is cataloged against the provided I(volumes). 
+        If they don't match, the module will fail with an error indicating the data set is cataloged 
+        on a different volume.
         To resolve this, you must first uncatalog the data set before creating it on the new volume.
       - >
-        If I(state=present) and the data set is already cataloged and I(volumes) is provided,
+        If I(state=present), the data set is already cataloged, I(volumes) is provided,
         and the volumes match exactly, no action is taken and the module completes successfully
         with I(changed=False).
     required: false

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -104,7 +104,7 @@ options:
       - >
         If I(state=uncataloged) and the data set is found, the data set is uncataloged,
         module completes successfully with I(changed=True).
-        - >
+      - >
         If I(state=present), the data set is already cataloged and I(volumes) is provided,
         the module will compare the volumes where it is cataloged against the provided I(volumes).
         If they don't match, the module will fail with an error indicating the data set is cataloged

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -1914,7 +1914,6 @@ def run_module():
                 )
                 result["changed"] = result["changed"] or current_changed
         except Exception as e:
-            #module.fail_json(msg=str(e), **result)
             module.fail_json(msg=repr(e), **result)
     if module.params.get("replace"):
         result["changed"] = True

--- a/plugins/modules/zos_data_set.py
+++ b/plugins/modules/zos_data_set.py
@@ -104,6 +104,15 @@ options:
       - >
         If I(state=uncataloged) and the data set is found, the data set is uncataloged,
         module completes successfully with I(changed=True).
+        - >
+        If I(state=present) and the data set is already cataloged and I(volumes) is provided,
+        the module will compare the cataloged volumes with the provided I(volumes). If they don't match,
+        the module will fail with an error indicating the data set is cataloged on a different volume.
+        To resolve this, you must first uncatalog the data set before creating it on the new volume.
+      - >
+        If I(state=present) and the data set is already cataloged and I(volumes) is provided,
+        and the volumes match exactly, no action is taken and the module completes successfully
+        with I(changed=False).
     required: false
     type: str
     default: present

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -788,45 +788,36 @@ def test_multi_volume_creation_uncatalog_and_catalog_vsam(ansible_zos_module, vo
     finally:
         hosts.all.zos_data_set(name=default_data_set_name, state="absent")
 
-def test_create_dataset_with_different_volume_than_cataloged(ansible_zos_module, volumes_on_systems):
-    """Test error when creating a dataset with a different volume than cataloged."""
+def test_creation_conflict_same_name_diff_volume(ansible_zos_module, volumes_on_systems):
     volumes = Volume_Handler(volumes_on_systems)
     volume_1 = volumes.get_available_vol()
     volume_2 = volumes.get_available_vol()
-    
-    if volume_1 == volume_2:
-        pytest.skip("Test requires two different volumes")
-    
+    assert volume_1 != volume_2, "Need two different volumes for this test"
+
     hosts = ansible_zos_module
-    dataset = get_tmp_ds_name(2, 2)
-    
+    data_set_name = get_tmp_ds_name()
     try:
-        # First create the dataset on volume_1
-        create_results = hosts.all.zos_data_set(
-            name=dataset,
-            state="present",
-            type="seq",
-            volumes=volume_1
-        )
-        
-        for result in create_results.contacted.values():
-            assert result.get("changed") is True
-        
-        # Attempt to create the same dataset on volume_2 (should fail)
+        # Step 1: Create PDS on volume_1
         results = hosts.all.zos_data_set(
-            name=dataset,
+            name=data_set_name,
             state="present",
-            type="seq",
-            volumes=volume_2
+            type="pds",
+            volumes=[volume_1]
         )
-        
+        for result in results.contacted.values():
+            assert result.get("changed") is True
+        results = hosts.all.zos_data_set(
+            name=data_set_name,
+            state="present",
+            type="pds",
+            volumes=[volume_2]
+        )
         for result in results.contacted.values():
             assert result.get("failed") is True
-            assert "DatasetCatalogedOnDifferentVolumeError" in result.get("msg")
-
+            assert "datasetcatalogedondifferentvolumeerror" in result.get("msg", "").lower()
     finally:
         # Cleanup
-        hosts.all.zos_data_set(name=dataset, state="absent", volumes=[volume_1, volume_2])
+        hosts.all.zos_data_set(name=data_set_name, state="absent")
 
 def test_data_set_temp_data_set_name(ansible_zos_module):
     try:

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -788,6 +788,45 @@ def test_multi_volume_creation_uncatalog_and_catalog_vsam(ansible_zos_module, vo
     finally:
         hosts.all.zos_data_set(name=default_data_set_name, state="absent")
 
+def test_create_dataset_with_different_volume_than_cataloged(ansible_zos_module, volumes_on_systems):
+    """Test error when creating a dataset with a different volume than cataloged."""
+    volumes = Volume_Handler(volumes_on_systems)
+    volume_1 = volumes.get_available_vol()
+    volume_2 = volumes.get_available_vol()
+    
+    if volume_1 == volume_2:
+        pytest.skip("Test requires two different volumes")
+    
+    hosts = ansible_zos_module
+    dataset = get_tmp_ds_name(2, 2)
+    
+    try:
+        # First create the dataset on volume_1
+        create_results = hosts.all.zos_data_set(
+            name=dataset,
+            state="present",
+            type="seq",
+            volumes=volume_1
+        )
+        
+        for result in create_results.contacted.values():
+            assert result.get("changed") is True
+        
+        # Attempt to create the same dataset on volume_2 (should fail)
+        results = hosts.all.zos_data_set(
+            name=dataset,
+            state="present",
+            type="seq",
+            volumes=volume_2
+        )
+        
+        for result in results.contacted.values():
+            assert result.get("failed") is True
+            assert "DatasetCatalogedOnDifferentVolumeError" in result.get("msg")
+
+    finally:
+        # Cleanup
+        hosts.all.zos_data_set(name=dataset, state="absent", volumes=[volume_1, volume_2])
 
 def test_data_set_temp_data_set_name(ansible_zos_module):
     try:

--- a/tests/functional/modules/test_zos_data_set_func.py
+++ b/tests/functional/modules/test_zos_data_set_func.py
@@ -751,56 +751,6 @@ def test_multi_volume_creation_uncatalog_and_catalog_nonvsam(ansible_zos_module,
     finally:
         hosts.all.zos_data_set(name=default_data_set_name, state="absent")
 
-def test_create_dataset_with_different_volume_than_cataloged(ansible_zos_module, volumes_on_systems):
-    """Test that attempting to create a dataset with a different volume than
-    it's currently cataloged with fails with an appropriate error message.
-    """
-    volumes = Volume_Handler(volumes_on_systems)
-    volume_1 = volumes.get_available_vol()
-    volume_2 = volumes.get_available_vol()
-    
-    # Ensure we have two different volumes
-    if volume_1 == volume_2:
-        pytest.skip("Test requires two different volumes")
-    
-    hosts = ansible_zos_module
-    dataset = get_tmp_ds_name(2, 2)
-    
-    try:
-        # First create the dataset on volume_1
-        create_results = hosts.all.zos_data_set(
-            name=dataset,
-            state="present",
-            type="seq",
-            volumes=volume_1
-        )
-        
-        for result in create_results.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("module_stderr") is None
-        
-        # Now try to create the same dataset but with volume_2
-        results = hosts.all.zos_data_set(
-            name=dataset,
-            state="present",
-            type="seq",
-            volumes=volume_2
-        )
-        
-        # Verify the error message
-        for result in results.contacted.values():
-            assert result.get("failed") is True
-            assert "is cataloged with volume" in result.get("msg", "")
-            assert volume_1 in result.get("msg", "")
-            assert volume_2 in result.get("msg", "")
-            assert "uncatalog the data set first" in result.get("msg", "")
-            assert dataset in result.get("names", [])
-            
-    finally:
-        # Clean up
-        hosts.all.zos_data_set(name=dataset, state="absent", volumes=[volume_1, volume_2])
-
-
 def test_multi_volume_creation_uncatalog_and_catalog_vsam(ansible_zos_module, volumes_on_systems):
     volumes = Volume_Handler(volumes_on_systems)
     volume_1 = volumes.get_available_vol()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enhanced the dataset creation logic to fail explicitly when a dataset already exists on a different volume than requested 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1269 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_data_set, data_set
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yml
- hosts: zvm
  collections:
    - ibm.ibm_zos_core
  gather_facts: False
  #vars:
    #ZOAU: "/zoau/v1.3.4"
    #PYZ: "/allpython/3.13/usr/lpp/IBM/cyp/v3r13/pyz"
  environment: "{{ environment_vars }}"
  tasks:
    - name: create data set on some volume
      zos_data_set:
       name: MY.MIN.SIZE.TEST62.DATASET
       state: present
       volumes:
        - "000000"

    - name: create data set on a different volume
      zos_data_set:
       name: MY.MIN.SIZE.TEST62.DATASET
       state: present
       volumes:
        - "222222"

(venv-2.18) ansible-playbook -i inventories/ attempt_data.yml 

PLAY [zvm] *********************************************************************

TASK [create data set on some volume] ******************************************
changed: [zvm]

TASK [create data set on a different volume] ***********************************
fatal: [zvm]: FAILED! => {"changed": false, "msg": "Data set MY.MIN.SIZE.TEST62.DATASET is cataloged with volume 000000, if you want to create data set MY.MIN.SIZE.TEST62.DATASET in volume 222222 uncatalog the data set first and then create it."}

PLAY RECAP *********************************************************************
zvm                        : ok=1    changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```
