### PR TITLE
[Bugfix] [zos_fetch] Fix permission issue when using become and become_user

### DIFF
--- a/changelogs/fragments/2079-become-use-zos_fetch.yml
+++ b/changelogs/fragments/2079-become-use-zos_fetch.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zos_fetch - Previously, the use of `become` would result in a permissions error
+    while trying to fetch a data set or a member. Fix now allows a user to escalate
+    privileges when fetching resources.

--- a/changelogs/fragments/2079-become-use-zos_fetch.yml
+++ b/changelogs/fragments/2079-become-use-zos_fetch.yml
@@ -2,3 +2,4 @@ bugfixes:
   - zos_fetch - Previously, the use of `become` would result in a permissions error
     while trying to fetch a data set or a member. Fix now allows a user to escalate
     privileges when fetching resources.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2079)

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -463,4 +463,21 @@ class ActionModule(ActionBase):
             rm_cmd = "rm -r {0}".format(remote_path)
             if src_type != "PO" and src_type != "GDG":
                 rm_cmd = rm_cmd.replace(" -r", "")
+
+            # If another user created the temporary files, we'll need to run rm
+            # with it too, lest we get a permissions issue.
+            if self._connection.become:
+                self._connection.set_option('remote_user', self._play_context._become_user)
+                display.vvv(
+                    u"ibm_zos_fetch SSH cleanup user updated to {0}".format(self._play_context._become_user),
+                    host=self._play_context.remote_addr
+                )
+
             self._connection.exec_command(rm_cmd)
+
+            if self._connection.become:
+                self._connection.set_option('remote_user', self._play_context._remote_user)
+                display.vvv(
+                    u"ibm_zos_fetch SSH cleanup user restored to {0}".format(self._play_context._remote_user),
+                    host=self._play_context.remote_addr
+                )

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -384,8 +384,7 @@ class ActionModule(ActionBase):
                 display.vvv(u"ibm_zos_fetch SSH transfer method updated from {0} to {1}.".format(user_ssh_transfer_method,
                             sftp_transfer_method), host=self._play_context.remote_addr)
 
-            # TODO: check that this is indeed None when become_user is not present in the task.
-            if self._play_context._become_user:
+            if self._connection.become:
                 was_user_updated = True
                 self._connection.set_option('remote_user', self._play_context._become_user)
                 display.vvv(


### PR DESCRIPTION
##### SUMMARY
Fixes #1660.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
zos_fetch

##### ADDITIONAL INFORMATION
Updates the SSH options inside `_transfer_remote_content` to use the correct user when `become` and `become_user` are used.