### PR TITLE
[zos_lineinfile]Robust JSON Parsing and Cmd Cleanup 

### DIFF
--- a/changelogs/fragments/2080-zos_lineinfile-fixed-json-parsing.yml
+++ b/changelogs/fragments/2080-zos_lineinfile-fixed-json-parsing.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_lineinfile - Fixed a bug where malformed escape sequences in `zoau` command output 
+    caused JSON parsing to fail the task even when updates had been successfully made. 
+    Added handling to clean escape sequences before parsing to prevent unnecessary task failures.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2080)

--- a/changelogs/fragments/2080-zos_lineinfile-fixed-json-parsing.yml
+++ b/changelogs/fragments/2080-zos_lineinfile-fixed-json-parsing.yml
@@ -1,7 +1,6 @@
 bugfixes:
-  - zos_lineinfile - Fixed an issue where the module fail with a JSON parsing error
-    when using `zoau` commands, even if the updates were successfully applied. The output is now
-    cleaned before parsing, ensuring that tasks only fail when there's an actual problem.
+  - zos_lineinfile - The module would report a false negative when certain special characters 
+    where present in the `line` option. Fix now reports the successful operation.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2080)
 trivial:
   - test_zos_lineinfile_func - added test case to verify insertbefore functionality with regex pattern before Ansible block line.

--- a/changelogs/fragments/2080-zos_lineinfile-fixed-json-parsing.yml
+++ b/changelogs/fragments/2080-zos_lineinfile-fixed-json-parsing.yml
@@ -1,7 +1,7 @@
 bugfixes:
   - zos_lineinfile - The module would report a false negative when certain special characters 
     where present in the `line` option. Fix now reports the successful operation.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/2080)
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2080).
 trivial:
   - test_zos_lineinfile_func - added test case to verify insertbefore functionality with regex pattern before Ansible block line.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/2080
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2080).

--- a/changelogs/fragments/2080-zos_lineinfile-fixed-json-parsing.yml
+++ b/changelogs/fragments/2080-zos_lineinfile-fixed-json-parsing.yml
@@ -1,5 +1,5 @@
 bugfixes:
-  - zos_lineinfile - Fixed a bug where malformed escape sequences in `zoau` command output 
-    caused JSON parsing to fail the task even when updates had been successfully made. 
-    Added handling to clean escape sequences before parsing to prevent unnecessary task failures.
+  - zos_lineinfile - Fixed an issue where the module fail with a JSON parsing error
+    when using `zoau` commands, even if the updates were successfully applied. The output is now
+    cleaned before parsing, ensuring that tasks only fail when there's an actual problem.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2080)

--- a/changelogs/fragments/2080-zos_lineinfile-fixed-json-parsing.yml
+++ b/changelogs/fragments/2080-zos_lineinfile-fixed-json-parsing.yml
@@ -3,3 +3,6 @@ bugfixes:
     when using `zoau` commands, even if the updates were successfully applied. The output is now
     cleaned before parsing, ensuring that tasks only fail when there's an actual problem.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2080)
+trivial:
+  - test_zos_lineinfile_func - added test case to verify insertbefore functionality with regex pattern before Ansible block line.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2080

--- a/plugins/modules/zos_lineinfile.py
+++ b/plugins/modules/zos_lineinfile.py
@@ -789,7 +789,7 @@ def main():
             ret['cmd'] = ret['cmd'].replace('\\"', '"').replace('\\\\', '\\')
             result['cmd'] = ret['cmd']
         result['changed'] = ret.get('changed', False)
-        result['found'] = ret.get('found', None)
+        result['found'] = ret.get('found', 0)
     # Only return 'rc' if stderr is not empty to not fail the playbook run in a nomatch case
     # That information will be given with 'changed' and 'found'
     if len(stderr):

--- a/plugins/modules/zos_lineinfile.py
+++ b/plugins/modules/zos_lineinfile.py
@@ -773,10 +773,10 @@ def main():
                 cleaned_stdout = re.sub(r'\\([^"\\/bfnrtu])', r'\\\\\1', cleaned_stdout)
                 # Try parsing the cleaned string as JSON
                 ret = json.loads(cleaned_stdout)
-            except Exception:
+            except Exception as e:
                 # If still failing, report failure with useful debug info
                 messageDict = dict(
-                    msg="dsed return content is NOT in json format",
+                    msg=f"Failed while parsing command output {str(e)} ",
                     stdout=str(stdout),
                     stderr=str(stderr),
                     rc=rc

--- a/plugins/modules/zos_lineinfile.py
+++ b/plugins/modules/zos_lineinfile.py
@@ -757,7 +757,7 @@ def main():
         if ins_bef:
             stdout = stdout.replace(ins_bef, quotedString(ins_bef))
         try:
-          # Attempt to parse stdout content directly as JSON
+            # Attempt to parse stdout content directly as JSON
             ret = json.loads(stdout)
         except json.JSONDecodeError:
             try:

--- a/tests/functional/modules/test_zos_lineinfile_func.py
+++ b/tests/functional/modules/test_zos_lineinfile_func.py
@@ -73,6 +73,19 @@ export ZOAU_ROOT
 export _BPXK_AUTOCVT
 /*  End Ansible Block Insert */"""
 
+EXPECTED_TEST_PARSING_CONTENT = """if [ -z STEPLIB ] && tty -s;
+then
+    export STEPLIB=none
+    exec -a 0 SHELL
+fi
+PATH=/usr/lpp/zoautil/v100/bin:/usr/lpp/rsusr/ported/bin:/bin:/var/bin
+export PATH
+ZOAU_ROOT=/usr/lpp/zoautil/v100
+export ZOAU_ROOT
+export _BPXK_AUTOCVT
+SYMDEF(&IPVSRV1='IPL')
+/*  End Ansible Block Insert */"""
+
 TEST_CONTENT_ADVANCED_REGULAR_EXPRESSION="""if [ -z STEPLIB ] && tty -s;
 then
     D160882
@@ -717,21 +730,9 @@ def test_ds_line_insert_before_ansible_block(ansible_zos_module, dstype):
         results = hosts.all.zos_lineinfile(**params)
         for result in results.contacted.values():
             assert result.get("changed") == 1
-        read_results = hosts.all.zos_fetch(src=ds_full_name, dest=temp_file, flat=True)
-        for fetch_result in read_results.contacted.values():
-            with open(temp_file, "r") as f:
-                file_content = f.read()
-                assert params["line"] in file_content, f"Expected line '{params['line']}' not found."
-
-                #  Verify it appears before the marker
-                insert_pos = file_content.find(params["line"])
-                marker_pos = file_content.find("/*  End Ansible Block Insert */")
-                assert 0 <= insert_pos < marker_pos, "Inserted line not before 'End Ansible Block Insert' marker."
-
-                #  Verify proper escaping via regex match
-                escaped_line = re.escape(params["line"])
-                assert re.search(escaped_line, file_content), f"Escaped line pattern '{escaped_line}' not matched."
-    
+        results = hosts.all.shell(cmd="cat \"//'{0}'\" ".format(params["path"]))
+        for result in results.contacted.values():
+            assert result.get("stdout") == EXPECTED_TEST_PARSING_CONTENT
     finally:
         remove_ds_environment(ansible_zos_module, ds_name)
 

--- a/tests/functional/modules/test_zos_lineinfile_func.py
+++ b/tests/functional/modules/test_zos_lineinfile_func.py
@@ -706,7 +706,6 @@ def test_ds_line_insertafter_regex(ansible_zos_module, dstype):
     finally:
         remove_ds_environment(ansible_zos_module, ds_name)
 
-import re
 @pytest.mark.ds
 @pytest.mark.parametrize("dstype", ds_type)
 def test_ds_line_insert_before_ansible_block(ansible_zos_module, dstype):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enhanced JSON parsing logic for zos_lineinfile.
Added fallback cleaning of invalid escape sequences if initial parse fails.
Ensured cmd, changed, and found keys are reliably captured in results.
Prevented task failure on bad JSON when an update still occurs.
Rationale:
Fixes task failures from malformed escape sequences in zoau output.
Improves module robustness and accuracy of result reporting.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#1088 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_lineinfile
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yml
SK [Check and insert line in dataset] *******************************************************************************************************************
changed: [zvm]

TASK [Print the result of zos_lineinfile] *****************************************************************************************************************
ok: [zvm] => {
    "insert_result": {
        "changed": true,
        "cmd": "dsedhelper -d -c IBM-1047 -s -e //\\*  End Ansible Block Insert \\*//i\\SYMDEF(&IPVSRV1='IPL')/$ -e $ a\\SYMDEF(&IPVSRV1='IPL') SOME.TEST.TEST.MULTI.TEST ",
        "failed": false,
        "found": 1
    }
}

PLAY RECAP ************************************************************************************************************************************************
zvm                        : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
