### PR TITLE
[1.13.2][Bugfix][zos_copy] Avoid failures when default dir ~/.ansible/tmp/ is not previously created and fix failures when using become in zos_job_submit

### DIFF
--- a/changelogs/fragments/2101-copy-fix-tmp-dir.yml
+++ b/changelogs/fragments/2101-copy-fix-tmp-dir.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - zos_job_submit - Previously, the use of `become` would result in a permissions error
+    while trying to execute a job from a local file. Fix now allows a user to escalate
+    privileges when executing a job transferred from the controller node.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2101)
+  - zos_copy - Previously, when trying to copy into remote and ansible's default temporary directory
+    was not created before execution the copy task would fail. Fix now creates the temporary directory if possible.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2101)

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -341,8 +341,6 @@ class ActionModule(ActionBase):
         _sftp_action = 'put'
         was_user_updated = False
 
-        if is_dir:
-            _sftp_action += ' -r'    # add '-r` to clone the source trees
         temp_path = os.path.join(tempfile.get("path"), os.path.basename(src))
         _src = src.replace("#", "\\#")
         full_temp_path = temp_path

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -243,7 +243,6 @@ class ActionModule(ActionBase):
 
             temp_path = transfer_res.get("temp_path")
             if transfer_res.get("msg"):
-                print(f"transfer res: {transfer_res}")
                 return transfer_res
             display.vvv(u"ibm_zos_copy temp path: {0}".format(transfer_res.get("temp_path")), host=self._play_context.remote_addr)
 
@@ -284,17 +283,17 @@ class ActionModule(ActionBase):
             shutil.rmtree(template_dir, ignore_errors=True)
         # Remove temporary directory from remote
         if self.tmp_dir is not None:
-            print("Removing temp dir")
             path = os.path.normpath(f"{self.tmp_dir}/ansible-zos-copy")
             # If another user created the temporary files, we'll need to run rm
             # with it too, lest we get a permissions issue.
             if self._connection.become:
+                path = os.path.dirname(temp_path)
                 self._connection.set_option('remote_user', self._play_context._become_user)
                 display.vvv(
                     u"ibm_zos_copy SSH cleanup user updated to {0}".format(self._play_context._become_user),
                     host=self._play_context.remote_addr
                 )
-            self._connection.exec_command(f"rm -rf {path}*")
+            rm_res = self._connection.exec_command(f"rm -rf {path}*")
             if self._connection.become:
                 self._connection.set_option('remote_user', self._play_context._remote_user)
                 display.vvv(
@@ -340,7 +339,6 @@ class ActionModule(ActionBase):
         if is_dir:
             _sftp_action += ' -r'    # add '-r` to clone the source trees
         temp_path = path.join(tempfile.get("path"), os.path.basename(src))
-        print(f"This is the temporary dir: {temp_path}")
         _src = src.replace("#", "\\#")
         full_temp_path = temp_path
 

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -291,14 +291,14 @@ class ActionModule(ActionBase):
             if self._connection.become:
                 self._connection.set_option('remote_user', self._play_context._become_user)
                 display.vvv(
-                    u"ibm_zos_fetch SSH cleanup user updated to {0}".format(self._play_context._become_user),
+                    u"ibm_zos_copy SSH cleanup user updated to {0}".format(self._play_context._become_user),
                     host=self._play_context.remote_addr
                 )
             self._connection.exec_command(f"rm -rf {path}*")
             if self._connection.become:
                 self._connection.set_option('remote_user', self._play_context._remote_user)
                 display.vvv(
-                    u"ibm_zos_fetch SSH cleanup user restored to {0}".format(self._play_context._remote_user),
+                    u"ibm_zos_copy SSH cleanup user restored to {0}".format(self._play_context._remote_user),
                     host=self._play_context.remote_addr
                 )
 
@@ -385,7 +385,7 @@ class ActionModule(ActionBase):
                 was_user_updated = True
                 self._connection.set_option('remote_user', self._play_context._become_user)
                 display.vvv(
-                    u"ibm_zos_fetch SSH transfer user updated to {0}".format(self._play_context._become_user),
+                    u"ibm_zos_copy SSH transfer user updated to {0}".format(self._play_context._become_user),
                     host=self._play_context.remote_addr
                 )
             (returncode, stdout, stderr) = self._connection._file_transport_command(_src, temp_path, _sftp_action)
@@ -430,7 +430,7 @@ class ActionModule(ActionBase):
             if was_user_updated:
                 self._connection.set_option('remote_user', self._play_context._remote_user)
                 display.vvv(
-                    u"ibm_zos_fetch SSH transfer user restored to {0}".format(self._play_context._remote_user),
+                    u"ibm_zos_copy SSH transfer user restored to {0}".format(self._play_context._remote_user),
                     host=self._play_context.remote_addr
                 )
 

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -79,13 +79,13 @@ class ActionModule(ActionBase):
             tmp_dir = self._connection._shell._options.get("remote_tmp")
             temp_file_dir = f'zos_job_submit_{datetime.now().strftime("%Y%m%d%S%f")}'
             dest_path = path.join(tmp_dir, temp_file_dir)
-            print(f"This is the preliminary dest path {dest_path}")
             tempfile_args = {"path": dest_path, "state": "directory"}
+            # Reverted this back to using file ansible module so ansible would handle all temporary dirs
+            # creation with correct permissions.
             tempfile = self._execute_module(
                 module_name="file", module_args=tempfile_args, task_vars=task_vars,
             )
             dest_path = tempfile.get("path")
-            print(f"This is the temporary dir: {dest_path}")
             dest_file = path.join(dest_path, path.basename(source))
 
             source_full = None
@@ -130,8 +130,6 @@ class ActionModule(ActionBase):
             copy_module_args = {}
             module_args = self._task.args.copy()
 
-            print(f"this is dest file {dest_file}")
-            print(f"is source dir ?  {os.path.isdir(source_full)}")
             copy_module_args.update(
                 dict(
                     src=source_full,
@@ -157,7 +155,6 @@ class ActionModule(ActionBase):
                 shared_loader_obj=self._shared_loader_obj
             )
             result.update(copy_action.run(task_vars=task_vars))
-            print(f"this is copy action result {result}")
             if result.get("msg") is None:
                 module_args["src"] = dest_file
                 result.update(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2731,6 +2731,8 @@ def cleanup(src_list):
     dir_list = glob.glob(tmp_dir + "/ansible-zos-copy-payload*")
     conv_list = glob.glob(tmp_dir + "/converted*")
     tmp_list = glob.glob(tmp_dir + "/{0}*".format(tmp_prefix))
+    print("zos_copy tmp dirs ")
+    print(dir_list + conv_list + tmp_list + src_list)
 
     for file in (dir_list + conv_list + tmp_list + src_list):
         try:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -2731,8 +2731,6 @@ def cleanup(src_list):
     dir_list = glob.glob(tmp_dir + "/ansible-zos-copy-payload*")
     conv_list = glob.glob(tmp_dir + "/converted*")
     tmp_list = glob.glob(tmp_dir + "/{0}*".format(tmp_prefix))
-    print("zos_copy tmp dirs ")
-    print(dir_list + conv_list + tmp_list + src_list)
 
     for file in (dir_list + conv_list + tmp_list + src_list):
         try:

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -598,6 +598,29 @@ def test_copy_local_file_to_uss_file_convert_encoding(ansible_zos_module):
 
 
 @pytest.mark.uss
+def test_copy_local_file_to_uss_file_with_absent_remote_tmp_dir(ansible_zos_module):
+    hosts = ansible_zos_module
+    dest_path = get_random_file_name(dir=TMP_DIRECTORY) + "/profile"
+    try:
+        hosts.all.shell(cmd="rm -rf ~/.ansible/tmp")
+        copy_res = hosts.all.zos_copy(
+            src="/etc/profile",
+            dest=dest_path,
+            encoding={"from": "ISO8859-1", "to": "IBM-1047"},
+        )
+        stat_res = hosts.all.stat(path=dest_path)
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest_path
+            assert result.get("state") == "file"
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+    finally:
+        hosts.all.file(path=dest_path, state="absent")
+
+
+@pytest.mark.uss
 def test_copy_inline_content_to_uss_dir(ansible_zos_module):
     hosts = ansible_zos_module
     dest = get_random_file_name(dir=TMP_DIRECTORY, suffix='/')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes two issues that were closely related, first, the issue of failing when the remote tmp dir is not present was because it is created once an ansiball is executed on the remote node, so, in our action plugins we were doing calls to that remote folder before giving it the chance to get created. That was fixed by returning to use file module in order to create the remote temporary file, not the remote tmp dir folder, but rather the file that is used by both modules: `zos_job_submit` and `zos_copy`. This automatically creates the remote temporary dir structure needed for the modules.

Another fix is based on #2079 by Alex, basically, we use a different user when creating temporary files and when ensuring the cleanup on the remote folder as well. 

Fixes #2083 
Fixes #2092 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy
zos_job_submit
