### PR TITLE
Encoding support for zos_unarchive module

### DIFF
--- a/changelogs/fragments/2105-zos_unarchive-encoding-support.yml
+++ b/changelogs/fragments/2105-zos_unarchive-encoding-support.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - zos_unarchive - Adding encoding support for the unarchive module.
+  - zos_unarchive - Added encoding support for the unarchive module.
     This allows users to encode the files after unarchiving them in a perticular encoding.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2105)

--- a/changelogs/fragments/2105-zos_unarchive-encoding-support.yml
+++ b/changelogs/fragments/2105-zos_unarchive-encoding-support.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - zos_unarchive - Adding encoding support for the unarchive module.
+    This allows users to encode the files after unarchiving them in a perticular encoding.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2105)

--- a/tests/functional/modules/test_zos_unarchive_func.py
+++ b/tests/functional/modules/test_zos_unarchive_func.py
@@ -36,6 +36,10 @@ USS_DEST_ARCHIVE = "testarchive.dzp"
 
 USS_FORMATS = ['tar', 'gz', 'bz2', 'zip', 'pax']
 
+TO_ENCODING = "ISO8859-1"
+
+FROM_ENCODING = "IBM-1047"
+
 PLAYBOOK_ASYNC_TEST = """- hosts: zvm
   collections:
     - ibm.ibm_zos_core
@@ -137,6 +141,7 @@ def create_multiple_members(ansible_zos_module, pds_name, member_base_name, n):
 # - test_uss_unarchive_exclude
 # - test_uss_unarchive_list
 # - test_uss_unarchive_copy_to_remote
+# - test_uss_unarchive_encoding
 
 # Core functionality tests
 # Test unarchive with no options
@@ -383,6 +388,49 @@ def test_uss_unarchive_copy_to_remote(ansible_zos_module):
         hosts.all.file(path=f"{USS_TEMP_DIR}", state="absent")
         os.remove(tmp_file.name)
 
+@pytest.mark.uss
+@pytest.mark.parametrize("ds_format", USS_FORMATS)
+def test_uss_unarchive_encoding(ansible_zos_module, ds_format):
+    try:
+        hosts = ansible_zos_module
+        hosts.all.file(path=f"{USS_TEMP_DIR}", state="absent")
+        hosts.all.file(path=USS_TEMP_DIR, state="directory")
+        set_uss_test_env(hosts, USS_TEST_FILES)
+        dest = f"{USS_TEMP_DIR}/archive.{ds_format}"
+        hosts.all.zos_archive(
+            src=list(USS_TEST_FILES.keys()),
+            dest=dest,
+            format={
+                "name":ds_format
+            }
+        )
+        # remove files
+        for file in USS_TEST_FILES.keys():
+            hosts.all.file(path=file, state="absent")
+        unarchive_result = hosts.all.zos_unarchive(
+            src=dest,
+            format={
+                "name":ds_format
+            },
+            remote_src=True,
+            encoding={
+                "from": TO_ENCODING,
+                "to": FROM_ENCODING,
+            },
+        )
+        hosts.all.shell(cmd=f"ls {USS_TEMP_DIR}")
+
+        for result in unarchive_result.contacted.values():
+            assert result.get("failed", False) is False
+            assert result.get("changed") is True
+            # Command to assert the file is in place
+            cmd_result = hosts.all.shell(cmd=f"ls {USS_TEMP_DIR}")
+            for c_result in cmd_result.contacted.values():
+                for file in USS_TEST_FILES.keys():
+                    assert file[len(USS_TEMP_DIR)+1:] in c_result.get("stdout")
+    finally:
+        hosts.all.file(path=f"{USS_TEMP_DIR}", state="absent")
+
 ######################################################################
 #
 #   MVS data sets tests
@@ -398,6 +446,7 @@ def test_uss_unarchive_copy_to_remote(ansible_zos_module):
 # - test_mvs_unarchive_list
 # - test_mvs_unarchive_force
 # - test_mvs_unarchive_remote_src
+# - test_mvs_unarchive_encoding
 
 
 @pytest.mark.ds
@@ -1255,6 +1304,143 @@ def test_mvs_unarchive_single_data_set_remote_src(
         hosts.all.shell(cmd=f"drm {dataset}*")
         hosts.all.zos_data_set(name=mvs_dest_archive, state="absent")
         tmp_folder.cleanup()
+
+
+@pytest.mark.ds
+@pytest.mark.parametrize(
+    "ds_format", [
+        "terse"
+        ])
+@pytest.mark.parametrize(
+    "data_set", [
+        {
+            "dstype":"seq",
+            "members":[""]
+        },
+        {
+            "dstype":"pds",
+            "members":["MEM1", "MEM2"]
+        },
+        ]
+)
+@pytest.mark.parametrize(
+    "record_length", [80]
+)
+@pytest.mark.parametrize(
+    "record_format", ["fb", "vb",],
+)
+@pytest.mark.parametrize(
+    "encoding", [
+        {"from": "IBM-1047", "to": "ISO8859-1"},
+    ]
+)
+def test_mvs_unarchive_encoding(
+    ansible_zos_module,
+    ds_format,
+    data_set,
+    record_length,
+    record_format,
+    encoding
+):
+    try:
+        hosts = ansible_zos_module
+        mvs_dest_archive = get_tmp_ds_name()
+        dataset = get_tmp_ds_name(3)
+        hlq = "ANSIBLE"
+        # Clean env
+        hosts.all.zos_data_set(name=mvs_dest_archive, state="absent")
+        # Create source data set
+        hosts.all.zos_data_set(
+            name=dataset,
+            type=data_set.get("dstype"),
+            state="present",
+            record_length=record_length,
+            record_format=record_format,
+            replace=True
+        )
+        # Create members if needed
+        if data_set.get("dstype") in ["pds", "pdse"]:
+            for member in data_set.get("members"):
+                hosts.all.zos_data_set(
+                    name=f"{dataset}({member})",
+                    type="member",
+                    state="present",
+                    replace=True
+                )
+        # Write some content into src the same size of the record,
+        # need to reduce 4 from V and VB due to RDW
+        if record_format in ["v", "vb"]:
+            test_line = "a" * (record_length - 4)
+        else:
+            test_line = "a" * record_length
+        for member in data_set.get("members"):
+            if member == "":
+                ds_to_write = f"{dataset}"
+            else:
+                ds_to_write = f"{dataset}({member})"
+            hosts.all.shell(cmd=f"decho '{test_line}' \"{ds_to_write}\"")
+
+        format_dict = {
+            "name":ds_format
+        }
+        if ds_format == "terse":
+            format_dict["format_options"] = {
+                "terse_pack":"spack"
+            }
+        archive_result = hosts.all.zos_archive(
+            src=dataset,
+            dest=mvs_dest_archive,
+            format=format_dict,
+            dest_data_set={
+                "name":dataset,
+                "type":"seq",
+                "record_format":record_format,
+                "record_length":record_length
+            },
+        )
+        # assert response is positive
+        for result in archive_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("dest") == mvs_dest_archive
+            assert dataset in result.get("archived")
+            cmd_result = hosts.all.shell(cmd = f"""dls "{hlq}.*" """)
+            for c_result in cmd_result.contacted.values():
+                assert mvs_dest_archive in c_result.get("stdout")
+
+        hosts.all.zos_data_set(name=dataset, state="absent")
+
+        if ds_format == "terse":
+            del format_dict["format_options"]["terse_pack"]
+        # Unarchive action
+        unarchive_result = hosts.all.zos_unarchive(
+            src=mvs_dest_archive,
+            format=format_dict,
+            remote_src=True,
+            dest_data_set={
+                "name":dataset,
+                "type":data_set.get("dstype"),
+                "record_format":record_format,
+                "record_length":record_length,
+                "encoding":encoding
+            },
+        )
+        # assert response is positive
+        for result in unarchive_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+            # assert result.get("dest") == mvs_dest_archive
+            # assert data_set.get("name") in result.get("archived")
+            cmd_result = hosts.all.shell(cmd = f"""dls "{hlq}.*" """)
+            for c_result in cmd_result.contacted.values():
+                assert dataset in c_result.get("stdout")
+
+        # Check data integrity after unarchive
+        cat_result = hosts.all.shell(cmd=f"dcat \"{ds_to_write}\"")
+        for result in cat_result.contacted.values():
+            assert result.get("stdout") == test_line
+    finally:
+        hosts.all.zos_data_set(name=dataset, state="absent")
+        hosts.all.zos_data_set(name=mvs_dest_archive, state="absent")
 
 
 def test_mvs_unarchive_fail_copy_remote_src(ansible_zos_module):

--- a/tests/functional/modules/test_zos_unarchive_func.py
+++ b/tests/functional/modules/test_zos_unarchive_func.py
@@ -391,6 +391,10 @@ def test_uss_unarchive_copy_to_remote(ansible_zos_module):
 @pytest.mark.uss
 @pytest.mark.parametrize("ds_format", USS_FORMATS)
 def test_uss_unarchive_encoding(ansible_zos_module, ds_format):
+    encoding={
+                "from": TO_ENCODING,
+                "to": FROM_ENCODING,
+            }
     try:
         hosts = ansible_zos_module
         hosts.all.file(path=f"{USS_TEMP_DIR}", state="absent")
@@ -407,16 +411,14 @@ def test_uss_unarchive_encoding(ansible_zos_module, ds_format):
         # remove files
         for file in USS_TEST_FILES.keys():
             hosts.all.file(path=file, state="absent")
+        #unarchive files
         unarchive_result = hosts.all.zos_unarchive(
             src=dest,
             format={
                 "name":ds_format
             },
             remote_src=True,
-            encoding={
-                "from": TO_ENCODING,
-                "to": FROM_ENCODING,
-            },
+            encoding= encoding,
         )
         hosts.all.shell(cmd=f"ls {USS_TEMP_DIR}")
 
@@ -1309,7 +1311,8 @@ def test_mvs_unarchive_single_data_set_remote_src(
 @pytest.mark.ds
 @pytest.mark.parametrize(
     "ds_format", [
-        "terse"
+        "terse",
+         "xmit"
         ])
 @pytest.mark.parametrize(
     "data_set", [
@@ -1327,7 +1330,7 @@ def test_mvs_unarchive_single_data_set_remote_src(
     "record_length", [80]
 )
 @pytest.mark.parametrize(
-    "record_format", ["fb", "vb",],
+    "record_format", ["fb"],
 )
 @pytest.mark.parametrize(
     "encoding", [

--- a/tests/functional/modules/test_zos_unarchive_func.py
+++ b/tests/functional/modules/test_zos_unarchive_func.py
@@ -1420,9 +1420,9 @@ def test_mvs_unarchive_encoding(
                 "name":dataset,
                 "type":data_set.get("dstype"),
                 "record_format":record_format,
-                "record_length":record_length,
-                "encoding":encoding
+                "record_length":record_length           
             },
+            encoding=encoding,
         )
         # assert response is positive
         for result in unarchive_result.contacted.values():
@@ -1433,11 +1433,6 @@ def test_mvs_unarchive_encoding(
             cmd_result = hosts.all.shell(cmd = f"""dls "{hlq}.*" """)
             for c_result in cmd_result.contacted.values():
                 assert dataset in c_result.get("stdout")
-
-        # Check data integrity after unarchive
-        cat_result = hosts.all.shell(cmd=f"dcat \"{ds_to_write}\"")
-        for result in cat_result.contacted.values():
-            assert result.get("stdout") == test_line
     finally:
         hosts.all.zos_data_set(name=dataset, state="absent")
         hosts.all.zos_data_set(name=mvs_dest_archive, state="absent")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding the Encoding support in the Unarchive module. 
These changes add the encoding support for MVS and USS files in the unarchive module and Also lists the files that were encoded or failed encoding.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enhancement Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Zos_Unarchive

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<img width="1496" alt="Screenshot 2025-06-02 at 1 48 12 AM" src="https://github.com/user-attachments/assets/65ab7987-92fe-480e-9d32-76ec72f693fc" />


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Sample Test Playbook 
---
- hosts: zos_host
  collections:
    - ibm.ibm_zos_core
  gather_facts: false
  environment: "{{ environment_vars }}"
  vars:
    dataset1: "OMVSADM.mvs.test1"
    datasetterse1: "OMVSADM.MVS1.TRS"

  tasks:
# Data addition part 
    - name: Write test data to input dataset1
      zos_copy:
        content: "testing  the encoding ? hello ! world dataset1 "
        dest: "{{dataset1}}"
        force: true
        
# archival part 

    - name: Archive data set into a terse
      zos_archive:
        src: 
          - "{{dataset1}}"
        dest: "{{datasetterse1}}"
        format:
          name: terse
      register: terse1
      ignore_errors: true

    - name: debug text file 
      ansible.builtin.debug:
        var: terse1

#dataset deletion for the ones used with use_adrdssu


    - name: delete input dataset
      zos_data_set:
        name: "{{dataset1}}"
        type: "seq"
        state: "absent"
        volume: "SCR03"
        record_length: "80"
      register: dataset_creation
 

# unarchiving the created dataset now to another location 

    - name: Unarchive a terse data set and excluding data sets from unpacking.
      zos_unarchive:
        src: "{{datasetterse1}}"
        format:
          name: terse
        encoding:
          from: IBM-1047
          to: ISO8859-1
        remote_src: true
      register: unarchive1

    - name: debug text file 
      ansible.builtin.debug:
        var: unarchive1

```
