### PR TITLE
[v1.14.0] Avoid failures when default dir ~/.ansible/tmp/ is not previously created and fix failures when using become in zos_job_submit

### DIFF
--- a/changelogs/fragments/2109-copy-fix-tmp-dir.yml
+++ b/changelogs/fragments/2109-copy-fix-tmp-dir.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - zos_job_submit - Previously, the use of `become` would result in a permissions error
+    while trying to execute a job from a local file. Fix now allows a user to escalate
+    privileges when executing a job transferred from the controller node.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2109)
+  - zos_copy - Previously, when trying to copy into remote and ansible's default temporary directory
+    was not created before execution the copy task would fail. Fix now creates the temporary directory if possible.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2109)

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -323,7 +323,7 @@ class ActionModule(ActionBase):
         """Copy a file or directory to the remote z/OS system """
         self.tmp_dir = self._connection._shell._options.get("remote_tmp")
         temp_path = os.path.join(self.tmp_dir, _create_temp_path_name())
-        tempfile_args = {"path": temp_path, "state": "directory"}
+        tempfile_args = {"path": temp_path, "state": "directory", "mode":"666"}
         # Reverted this back to using file ansible module so ansible would handle all temporary dirs
         # creation with correct permissions.
         tempfile = self._execute_module(

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -155,7 +155,7 @@ class ActionModule(ActionBase):
                 try:
                     local_content = _write_content_to_temp_file(content)
                     transfer_res = self._copy_to_remote(
-                        local_content, ignore_stderr=ignore_sftp_stderr
+                        local_content, ignore_stderr=ignore_sftp_stderr, task_vars=task_vars
                     )
                 finally:
                     os.remove(local_content)
@@ -243,7 +243,7 @@ class ActionModule(ActionBase):
 
                 display.vvv(u"ibm_zos_copy calculated size: {0}".format(os.stat(src).st_size), host=self._play_context.remote_addr)
                 transfer_res = self._copy_to_remote(
-                    src, is_dir=is_src_dir, ignore_stderr=ignore_sftp_stderr
+                    src, is_dir=is_src_dir, ignore_stderr=ignore_sftp_stderr, task_vars=task_vars
                 )
 
             temp_path = transfer_res.get("temp_path")
@@ -319,7 +319,7 @@ class ActionModule(ActionBase):
 
         return copy_res
 
-    def _copy_to_remote(self, src, is_dir=False, ignore_stderr=False):
+    def _copy_to_remote(self, src, is_dir=False, ignore_stderr=False, task_vars=None):
         """Copy a file or directory to the remote z/OS system """
         self.tmp_dir = self._connection._shell._options.get("remote_tmp")
         temp_path = os.path.join(self.tmp_dir, _create_temp_path_name())
@@ -327,7 +327,7 @@ class ActionModule(ActionBase):
         # Reverted this back to using file ansible module so ansible would handle all temporary dirs
         # creation with correct permissions.
         tempfile = self._execute_module(
-            module_name="file", module_args=tempfile_args, task_vars=task_vars,
+            module_name="file", module_args=tempfile_args, task_vars=task_vars, wrap_async=self._task.async_val
         )
         _sftp_action = 'put'
         was_user_updated = False

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -323,7 +323,7 @@ class ActionModule(ActionBase):
         """Copy a file or directory to the remote z/OS system """
         self.tmp_dir = self._connection._shell._options.get("remote_tmp")
         temp_path = os.path.join(self.tmp_dir, _create_temp_path_name())
-        tempfile_args = {"path": temp_path, "state": "directory", "mode":"666"}
+        tempfile_args = {"path": temp_path, "state": "directory", "mode": "666"}
         # Reverted this back to using file ansible module so ansible would handle all temporary dirs
         # creation with correct permissions.
         tempfile = self._execute_module(

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -77,6 +77,7 @@ class ActionModule(ActionBase):
                 return result
 
             tmp_dir = self._connection._shell._options.get("remote_tmp")
+            temp_file_dir = f'zos_job_submit_{datetime.now().strftime("%Y%m%d%S%f")}'
             dest_path = path.join(tmp_dir, temp_file_dir)
             tempfile_args = {"path": dest_path, "state": "directory"}
             # Reverted this back to using file ansible module so ansible would handle all temporary dirs
@@ -162,7 +163,7 @@ class ActionModule(ActionBase):
 
             result.update(copy_action.run(task_vars=task_vars))
             if result.get("msg") is None:
-                module_args["src"] = dest_path
+                module_args["src"] = dest_file
                 result.update(
                     self._execute_module(
                         module_name="ibm.ibm_zos_core.zos_job_submit",

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -77,16 +77,15 @@ class ActionModule(ActionBase):
                 return result
 
             tmp_dir = self._connection._shell._options.get("remote_tmp")
-            rc, stdout, stderr = self._connection.exec_command("cd {0} && pwd".format(tmp_dir))
-            if rc > 0:
-                msg = f"Failed to resolve remote temporary directory {tmp_dir}. Ensure that the directory exists and user has proper access."
-                return self._exit_action({}, msg, failed=True)
-
-            tmp_dir = stdout.decode("utf-8").replace("\r", "").replace("\n", "")
-            temp_file_dir = f'zos_job_submit_{datetime.now().strftime("%Y%m%d%S%f")}'
-            dest_path = path.join(tmp_dir, temp_file_dir, path.basename(source))
-            # Creating the name for the temp file needed.
-            self._connection.exec_command("mkdir -p {0}".format(path.dirname(dest_path)))
+            dest_path = path.join(tmp_dir, temp_file_dir)
+            tempfile_args = {"path": dest_path, "state": "directory"}
+            # Reverted this back to using file ansible module so ansible would handle all temporary dirs
+            # creation with correct permissions.
+            tempfile = self._execute_module(
+                module_name="file", module_args=tempfile_args, task_vars=task_vars,
+            )
+            dest_path = tempfile.get("path")
+            dest_file = path.join(dest_path, path.basename(source))
 
             source_full = None
             try:
@@ -139,8 +138,8 @@ class ActionModule(ActionBase):
             copy_module_args.update(
                 dict(
                     src=source_full,
-                    dest=dest_path,
-                    mode="0600",
+                    dest=dest_file,
+                    mode="0666",
                     force=True,
                     encoding=module_args.get('encoding'),
                     remote_src=False,

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -649,6 +649,29 @@ def test_copy_local_file_to_uss_file_convert_encoding(ansible_zos_module):
 
 
 @pytest.mark.uss
+def test_copy_local_file_to_uss_file_with_absent_remote_tmp_dir(ansible_zos_module):
+    hosts = ansible_zos_module
+    dest_path = get_random_file_name(dir=TMP_DIRECTORY) + "/profile"
+    try:
+        hosts.all.shell(cmd="rm -rf ~/.ansible/tmp")
+        copy_res = hosts.all.zos_copy(
+            src="/etc/profile",
+            dest=dest_path,
+            encoding={"from": "ISO8859-1", "to": "IBM-1047"},
+        )
+        stat_res = hosts.all.stat(path=dest_path)
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest_path
+            assert result.get("state") == "file"
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+    finally:
+        hosts.all.file(path=dest_path, state="absent")
+
+
+@pytest.mark.uss
 def test_copy_inline_content_to_uss_dir(ansible_zos_module):
     hosts = ansible_zos_module
     dest = get_random_file_name(dir=TMP_DIRECTORY, suffix='/')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes two issues that were closely related, first, the issue of failing when the remote tmp dir is not present was because it is created once an ansiball is executed on the remote node, so, in our action plugins we were doing calls to that remote folder before giving it the chance to get created. That was fixed by returning to use file module in order to create the remote temporary file, not the remote tmp dir folder, but rather the file that is used by both modules: zos_job_submit and zos_copy. This automatically creates the remote temporary dir structure needed for the modules.

it is a port of #2101 

Fix #2106 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy
zos_job_submit
