### PR TITLE
Avoid failures when default dir ~/.ansible/tmp/ is not previously created and fix failures when using become in zos_job_submit

### DIFF
--- a/changelogs/fragments/2109-copy-fix-tmp-dir.yml
+++ b/changelogs/fragments/2109-copy-fix-tmp-dir.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - zos_job_submit - Previously, the use of `become` would result in a permissions error
+    while trying to execute a job from a local file. Fix now allows a user to escalate
+    privileges when executing a job transferred from the controller node.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2109)
+  - zos_copy - Previously, when trying to copy into remote and ansible's default temporary directory
+    was not created before execution the copy task would fail. Fix now creates the temporary directory if possible.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2109)

--- a/changelogs/fragments/2115-copy-fix-tmp-dir.yml
+++ b/changelogs/fragments/2115-copy-fix-tmp-dir.yml
@@ -2,7 +2,7 @@ bugfixes:
   - zos_job_submit - Previously, the use of `become` would result in a permissions error
     while trying to execute a job from a local file. Fix now allows a user to escalate
     privileges when executing a job transferred from the controller node.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/2109)
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2115)
   - zos_copy - Previously, when trying to copy into remote and ansible's default temporary directory
     was not created before execution the copy task would fail. Fix now creates the temporary directory if possible.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/2109)
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2115)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes two issues that were closely related, first, the issue of failing when the remote tmp dir is not present was because it is created once an ansiball is executed on the remote node, so, in our action plugins we were doing calls to that remote folder before giving it the chance to get created. That was fixed by returning to use file module in order to create the remote temporary file, not the remote tmp dir folder, but rather the file that is used by both modules: zos_job_submit and zos_copy. This automatically creates the remote temporary dir structure needed for the modules.

it is a port of https://github.com/ansible-collections/ibm_zos_core/pull/2101

Fix #2107

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy
zos_job_submit
