### PR TITLE
Adding test case  to test working of tmp_hlq  in  zos_backup_restore

### DIFF
--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -176,7 +176,7 @@ def test_dispositions_for_existing_data_set(ansible_zos_module, disposition):
         )
         idcams_dataset, idcams_listcat_dataset_cmd = get_temp_idcams_dataset(hosts)
 
-        results = hosts.all.zos_mvs_raw(
+        results = hosts.all.zos_mvus_raw(
             program_name="idcams",
             auth=True,
             dds=[


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A trivial change  to create a test case to check the tmp_hlq  being used in the zos_backup_restore module. It was not supported in zoau version 1.3.1 and is added support in zoau 1.3.4 But the test case to check if its working or broken was missing. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test_zos_backup_restore.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
As this  test  case was tested it was not working with ansible version 2.18. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
