### PR TITLE
Allow run dependency finder with other command

### DIFF
--- a/tests/dependencyfinder.py
+++ b/tests/dependencyfinder.py
@@ -545,8 +545,9 @@ def get_changed_plugins(path, branch="origin/dev"):
     current_branch_name = current_branch_name.rstrip()
 
     branch = branch.rstrip()
+    diff_branches = f"{branch}..{current_branch_name}"
     get_diff_pr = subprocess.Popen(
-        ["git", "request-pull", branch, "git@github.com:ansible-collections/ibm_zos_core.git", current_branch_name],
+        ["git", "diff", "--name-status", diff_branches],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         cwd=path,


### PR DESCRIPTION
##### SUMMARY
Working on SPS and to allow the use of dependency finder right now` request-pull` is not able to be run on every system.
After some investigation the command is the mesh of some output of variety of commands, been the most important `diff --name-status`.
This will enable the dependency finder in more systems 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
Only get the files we are modifying no the full log on request-pull, here a list of commands to get the same output as request-pull. Being the most important the git diff command


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
BASE_COMMIT=$(git merge-base "<branch_to_compare>" "<base_branch>")
echo "$BASE_COMMIT"  
git log --oneline "<base_branch>".."<branch_to_compare>" 
git diff --name-status "<base_branch>".."<branch_to_compare>" 
git format-patch "<base_branch>".."<branch_to_compare>" 
```
