### PR TITLE
[Enhancement][zos_mvs_raw] Add support for volume definition in zos_mvs_raw module…

### DIFF
--- a/changelogs/fragments/2194-zos_mvs_raw-Supporting-for-volume-definition-in-zos_mvs_raw.yml
+++ b/changelogs/fragments/2194-zos_mvs_raw-Supporting-for-volume-definition-in-zos_mvs_raw.yml
@@ -1,5 +1,5 @@
 minor_changes:
-   - zos_mvs_raw - Added support for volume definition in zos_mvs_raw module to allow specifying unit and disposition parameters.
+   - zos_mvs_raw - Adds support for volume data definition.
      (https://github.com/ansible-collections/ibm_zos_core/pull/2194)
 
 trivial:

--- a/changelogs/fragments/2194-zos_mvs_raw-Supporting-for-volume-definition-in-zos_mvs_raw.yml
+++ b/changelogs/fragments/2194-zos_mvs_raw-Supporting-for-volume-definition-in-zos_mvs_raw.yml
@@ -1,0 +1,7 @@
+trivial:
+   - zos_mvs_raw - Added support for volume definition in zos_mvs_raw module to allow specifying unit and disposition parameters.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2194)
+
+trivial:
+  - test_zos_mvs_raw_func - added test cases to verify volume definition functionality in zos_mvs_raw module.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2194).

--- a/changelogs/fragments/2194-zos_mvs_raw-Supporting-for-volume-definition-in-zos_mvs_raw.yml
+++ b/changelogs/fragments/2194-zos_mvs_raw-Supporting-for-volume-definition-in-zos_mvs_raw.yml
@@ -1,4 +1,4 @@
-trivial:
+minor_chnages:
    - zos_mvs_raw - Added support for volume definition in zos_mvs_raw module to allow specifying unit and disposition parameters.
      (https://github.com/ansible-collections/ibm_zos_core/pull/2194)
 

--- a/changelogs/fragments/2194-zos_mvs_raw-Supporting-for-volume-definition-in-zos_mvs_raw.yml
+++ b/changelogs/fragments/2194-zos_mvs_raw-Supporting-for-volume-definition-in-zos_mvs_raw.yml
@@ -1,4 +1,4 @@
-minor_chnages:
+minor_changes:
    - zos_mvs_raw - Added support for volume definition in zos_mvs_raw module to allow specifying unit and disposition parameters.
      (https://github.com/ansible-collections/ibm_zos_core/pull/2194)
 

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -656,18 +656,19 @@ class DatasetDefinition(DataDefinition):
 
 
 class VolumeDefinition(DataDefinition):
-    def __init__(self, volume_name, unit =None, disposition=None):
-        """Volume DD data type to be used in a DDStatement.
-
+    def __init__(self, volume=None, volume_name=None, unit=None, disposition=None):
+        """
         Parameters
         ----------
-        volume_name : str
-            The volume name to associate with the DD statement.
+        volume or volume_name : str
+            Volume serial (volser) to use. Either parameter can be provided.
         """
-        
-        if isinstance(volume_name, list) and len(volume_name) > 0:
-            volume_name = volume_name[0]
-        super().__init__(volume_name)
+        # Allow both volume or volume_name, but require at least one
+        volser = volume_name or volume
+        if not volser:
+            raise ValueError("You must provide either 'volume' or 'volume_name'.")
+
+        super().__init__(volser)
         self.unit = unit
         self.disposition = disposition
 

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -664,6 +664,7 @@ class VolumeDefinition(DataDefinition):
         volume_name : str
             The volume name to associate with the DD statement.
         """
+        
         if isinstance(volume_name, list) and len(volume_name) > 0:
             volume_name = volume_name[0]
         super().__init__(volume_name)

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -656,19 +656,19 @@ class DatasetDefinition(DataDefinition):
 
 
 class VolumeDefinition(DataDefinition):
-    def __init__(self, volume=None, volume_name=None, unit=None, disposition=None):
+    def __init__(self, volume_name, unit, disposition):
         """
         Parameters
         ----------
-        volume or volume_name : str
-            Volume serial (volser) to use. Either parameter can be provided.
+        volume_name : str
+            The volume name to associate with the DD statement.
+        unit : str
+            The unit of measurement to use when defining the volume.
+        disposition : str
+            The disposition of the volume.
+        
         """
-        # Allow both volume or volume_name, but require at least one
-        volser = volume_name or volume
-        if not volser:
-            raise ValueError("You must provide either 'volume' or 'volume_name'.")
-
-        super().__init__(volser)
+        super().__init__(volume_name)
         self.unit = unit
         self.disposition = disposition
 

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -656,7 +656,7 @@ class DatasetDefinition(DataDefinition):
 
 
 class VolumeDefinition(DataDefinition):
-    def __init__(self, volume_name):
+    def __init__(self, volume_name, unit =None, disposition=None):
         """Volume DD data type to be used in a DDStatement.
 
         Parameters
@@ -664,7 +664,11 @@ class VolumeDefinition(DataDefinition):
         volume_name : str
             The volume name to associate with the DD statement.
         """
+        if isinstance(volume_name, list) and len(volume_name) > 0:
+            volume_name = volume_name[0]
         super().__init__(volume_name)
+        self.unit = unit
+        self.disposition = disposition
 
     def _build_arg_string(self):
         """Build a string representing the arguments of this particular data type
@@ -675,7 +679,12 @@ class VolumeDefinition(DataDefinition):
         str
             ',vol'
         """
-        return ",vol"
+        #return ",vol"
+        mvscmd_string = ",vol"
+        mvscmd_string = self._append_mvscmd_string(mvscmd_string, "unit", self.unit)
+        if self.disposition:
+            mvscmd_string += f",{self.disposition}"
+        return mvscmd_string
 
 
 class StdoutDefinition(DataDefinition):

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -666,7 +666,6 @@ class VolumeDefinition(DataDefinition):
             The unit of measurement to use when defining the volume.
         disposition : str
             The disposition of the volume.
-        
         """
         super().__init__(volume_name)
         self.unit = unit

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -658,6 +658,7 @@ class DatasetDefinition(DataDefinition):
 class VolumeDefinition(DataDefinition):
     def __init__(self, volume_name, unit, disposition):
         """
+        Volume DD data type to be used in a DDStatement.
         Parameters
         ----------
         volume_name : str

--- a/plugins/module_utils/dd_statement.py
+++ b/plugins/module_utils/dd_statement.py
@@ -681,7 +681,6 @@ class VolumeDefinition(DataDefinition):
         str
             ',vol'
         """
-        #return ",vol"
         mvscmd_string = ",vol"
         mvscmd_string = self._append_mvscmd_string(mvscmd_string, "unit", self.unit)
         if self.disposition:

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -700,7 +700,7 @@ options:
             description: The DD name for the volume.
             type: str
             required: true
-          volume:
+          volume_name:
             description:
               - Volume serial number or serial numbers on which a data set resides or will reside.
             type: str
@@ -1406,7 +1406,7 @@ EXAMPLES = r"""
           type: seq
       - dd_volume:
           dd_name: voldd
-          volume: "000000"
+          volume_name: "000000"
           unit: "3390"
           disposition: old
       - dd_input:
@@ -1973,7 +1973,7 @@ def run_module():
         )
     )
     dd_volume_base = dict(
-        volume=dict(type="str", required=True),
+        volume_name=dict(type="str", required=True),
         unit=dict(type="str", choices=["SYSD", "TAPE", "DISK", "3390"], required=True),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
     )
@@ -2220,7 +2220,7 @@ def parse_and_validate_args(params):
         )
     )
     dd_volume_base = dict(
-        volume=dict(type="str", required=True),
+        volume_name=dict(type="str", required=True),
         unit=dict(type="str", choices=["SYSD", "TAPE", "DISK", "3390"], required=True),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
     )
@@ -2880,7 +2880,7 @@ def build_data_definition(dd):
     elif dd.get("dd_volume"):
         volume_args = dd["dd_volume"]
         data_definition = VolumeDefinition(
-            volume=volume_args.get("volume"),
+            volume_name=volume_args.get("volume_name"),
             unit=volume_args.get("unit"),
             disposition=volume_args.get("disposition"),
         )

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -692,7 +692,7 @@ options:
             type: str
       dd_volume:
         description:
-          - Defines a DD that specifies a volume or volumes on which a data set resides or will reside.
+          - Use I(dd_volume) to specify the volume to use in the DD statement.
         required: false
         type: dict
         suboptions:

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1909,7 +1909,7 @@ def run_module():
         )
     )
     dd_volume_base = dict(
-        volser=dict(type="list", elements="str", required=True),
+        volume=dict(type="str", required=True),
         unit= dict(type="str", required=False, default=None),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=False),
         return_content=dict(
@@ -2166,7 +2166,7 @@ def parse_and_validate_args(params):
         )
     )
     dd_volume_base = dict(
-        volser=dict(type="list", elements="str", required=True),
+        volume=dict(type="str", required=True),
         unit=dict(type="str"),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=False),
         return_content=dict(
@@ -2835,7 +2835,7 @@ def build_data_definition(dd):
     elif dd.get("dd_volume"):
         volume_args = dd["dd_volume"]
         data_definition = VolumeDefinition(
-            volser=volume_args.get("volser"),
+            volume=volume_args.get("volume"),
             unit=volume_args.get("unit"),
             disposition=volume_args.get("disposition"),
         )

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -2001,8 +2001,8 @@ def run_module():
     )
     dd_volume_base = dict(
         volume=dict(type="str", required=True),
-        unit= dict(type="str", required=False, default=None),
-        disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=False),
+        unit= dict(type="str", default=None, required=True),
+        disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
         return_content=dict(
             type="dict",
             options=dict(
@@ -2258,8 +2258,8 @@ def parse_and_validate_args(params):
     )
     dd_volume_base = dict(
         volume=dict(type="str", required=True),
-        unit=dict(type="str"),
-        disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=False),
+        unit=dict(type="str", required=True ),
+        disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
         return_content=dict(
             type="dict",
             options=dict(

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1408,8 +1408,11 @@ EXAMPLES = r"""
       - dd_input:
           dd_name: sysin
           content: " VOLDUMP VOL(voldd) DSNAME(dumpdd) FULL"
-      - dd_dummy:
+      - dd_output:
           dd_name: sysprint
+          return_content:
+            type: text
+          
 
 - name: List data sets matching patterns in catalog,
     save output to a new sequential data set and return output as text.

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -693,8 +693,8 @@ options:
       dd_volume:
         description:
           - Defines a DD that specifies a volume or volumes on which a data set resides or will reside.
-        required: true
-        type: string
+        required: false
+        type: dict
         suboptions:
           dd_name:
             description: The DD name for the volume.

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -725,34 +725,6 @@ options:
               - shr
               - mod
               - old
-          return_content:
-            description:
-              - Determines how content should be returned to the user.
-              - If not provided, no content from the DD is returned.
-            type: dict
-            required: false
-            suboptions:
-              type:
-                description:
-                  - The type of the content to be returned.
-                  - C(text) means return content in encoding specified by I(response_encoding).
-                  - I(src_encoding) and I(response_encoding) are only used when I(type=text).
-                  - C(base64) means return content as base64 encoded in binary.
-                type: str
-                choices:
-                  - text
-                  - base64
-                required: true
-              src_encoding:
-                description:
-                  - The encoding of the data set on the z/OS system.
-                type: str
-                default: ibm-1047
-              response_encoding:
-                description:
-                  - The encoding to use when returning the contents of the data set.
-                type: str
-                default: iso8859-1
       dd_concat:
         description:
           - I(dd_concat) is used to specify a data set concatenation.
@@ -1437,8 +1409,6 @@ EXAMPLES = r"""
           volume: "000000"
           unit: "3390"
           disposition: old
-          return_content:
-            type: text
       - dd_input:
           dd_name: sysin
           content: " VOLDUMP VOL(voldd) DSNAME(dumpdd) FULL"
@@ -2006,14 +1976,6 @@ def run_module():
         volume=dict(type="str", required=True),
         unit=dict(type="str", choices=["SYSD", "TAPE", "DISK", "3390"], required=True),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
-        return_content=dict(
-            type="dict",
-            options=dict(
-                type=dict(type="str", choices=["text", "base64"], required=True),
-                src_encoding=dict(type="str", default="ibm-1047"),
-                response_encoding=dict(type="str", default="iso8859-1"),
-            ),
-        ),
     )
     dd_data_set = dict(type="dict", options=combine_dicts(dd_name_base, dd_data_set_base))
     dd_unix = dict(type="dict", options=combine_dicts(dd_name_base, dd_unix_base))
@@ -2261,14 +2223,6 @@ def parse_and_validate_args(params):
         volume=dict(type="str", required=True),
         unit=dict(type="str", choices=["SYSD", "TAPE", "DISK", "3390"], required=True),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
-        return_content=dict(
-            type="dict",
-            options=dict(
-                type=dict(type="str", choices=["text", "base64"], required=True),
-                src_encoding=dict(type="str", default="ibm-1047"),
-                response_encoding=dict(type="str", default="iso8859-1"),
-            ),
-        ),
     )
     dd_data_set = dict(type="dict", options=combine_dicts(dd_name_base, dd_data_set_base))
     dd_unix = dict(type="dict", options=combine_dicts(dd_name_base, dd_unix_base))

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1412,7 +1412,6 @@ EXAMPLES = r"""
           dd_name: sysprint
           return_content:
             type: text
-          
 
 - name: List data sets matching patterns in catalog,
     save output to a new sequential data set and return output as text.

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -747,8 +747,7 @@ options:
                 description:
                   - The encoding to use when returning the contents of the data set.
                 type: str
-                default: iso8859-1  
-
+                default: iso8859-1
       dd_concat:
         description:
           - I(dd_concat) is used to specify a data set concatenation.
@@ -1441,7 +1440,6 @@ EXAMPLES = r"""
       - dd_dummy:
           dd_name: sysprint
 
-      
 - name: List data sets matching patterns in catalog,
     save output to a new sequential data set and return output as text.
   zos_mvs_raw:
@@ -2012,8 +2010,6 @@ def run_module():
             ),
         ),
     )
-
-
     dd_data_set = dict(type="dict", options=combine_dicts(dd_name_base, dd_data_set_base))
     dd_unix = dict(type="dict", options=combine_dicts(dd_name_base, dd_unix_base))
     dd_input = dict(type="dict", options=combine_dicts(dd_name_base, dd_input_base))
@@ -2269,7 +2265,6 @@ def parse_and_validate_args(params):
             ),
         ),
     )
-
     dd_data_set = dict(type="dict", options=combine_dicts(dd_name_base, dd_data_set_base))
     dd_unix = dict(type="dict", options=combine_dicts(dd_name_base, dd_unix_base))
     dd_input = dict(type="dict", options=combine_dicts(dd_name_base, dd_input_base))

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -700,13 +700,13 @@ options:
             description: The DD name for the volume.
             type: str
             required: true
-          volume: 
+          volume:
             description:
               - Volume serial number or serial numbers on which a data set resides or will reside.
             type: str
             required: true
           unit:
-            description: 
+            description:
               - Device type for the volume.
             type: str
             required: true

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -714,7 +714,7 @@ options:
               - SYSD
               - TAPE
               - DISK
-              - 3390
+              - '3390'
           disposition:
             description:
               - I(disposition) indicates the status of a data set.

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -691,7 +691,7 @@ options:
             required: true
             type: str
       dd_volume:
-        description::
+        description:
           - Defines a DD that specifies a volume or volumes on which a data set resides or will reside.
         required: true
         type: string

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -726,28 +726,28 @@ options:
               - If not provided, no content from the DD is returned.
             type: dict
             required: false
-              suboptions:
-                type:
-                  description:
-                    - The type of the content to be returned.
-                    - C(text) means return content in encoding specified by I(response_encoding).
-                    - I(src_encoding) and I(response_encoding) are only used when I(type=text).
-                    - C(base64) means return content as base64 encoded in binary.
-                  type: str
-                  choices:
-                    - text
-                    - base64
-                  required: true
-                src_encoding:
-                  description:
-                    - The encoding of the data set on the z/OS system.
-                  type: str
-                  default: ibm-1047
-                response_encoding:
-                  description:
-                    - The encoding to use when returning the contents of the data set.
-                  type: str
-                  default: iso8859-1  
+            suboptions:
+              type:
+                description:
+                  - The type of the content to be returned.
+                  - C(text) means return content in encoding specified by I(response_encoding).
+                  - I(src_encoding) and I(response_encoding) are only used when I(type=text).
+                  - C(base64) means return content as base64 encoded in binary.
+                type: str
+                choices:
+                  - text
+                  - base64
+                required: true
+              src_encoding:
+                description:
+                  - The encoding of the data set on the z/OS system.
+                type: str
+                default: ibm-1047
+              response_encoding:
+                description:
+                  - The encoding to use when returning the contents of the data set.
+                type: str
+                default: iso8859-1  
 
       dd_concat:
         description:

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -697,24 +697,20 @@ options:
         type: dict
         suboptions:
           dd_name:
-            description: The DD name for the volume.
-            type: str
+            description: The DD name.
             required: true
+            type: str
           volume_name:
             description:
-              - Volume serial number or serial numbers on which a data set resides or will reside.
+              - The volume serial number.
             type: str
             required: true
           unit:
             description:
               - Device type for the volume.
+              - This option is case sensitive.
             type: str
             required: true
-            choices:
-              - SYSD
-              - TAPE
-              - DISK
-              - '3390'
           disposition:
             description:
               - I(disposition) indicates the status of a data set.
@@ -1386,7 +1382,7 @@ EXAMPLES = r"""
           dd_name: sysin
           content: " LISTCAT ENTRIES('SOME.DATASET.*')"
 
-- name: Full volumedump using ADDRDSU with volume DD
+- name: Full volume dump using ADDRDSU.
   zos_mvs_raw:
     program_name: adrdssu
     auth: true
@@ -1974,7 +1970,7 @@ def run_module():
     )
     dd_volume_base = dict(
         volume_name=dict(type="str", required=True),
-        unit=dict(type="str", choices=["SYSD", "TAPE", "DISK", "3390"], required=True),
+        unit=dict(type="str", required=True),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
     )
     dd_data_set = dict(type="dict", options=combine_dicts(dd_name_base, dd_data_set_base))
@@ -2221,7 +2217,7 @@ def parse_and_validate_args(params):
     )
     dd_volume_base = dict(
         volume_name=dict(type="str", required=True),
-        unit=dict(type="str", choices=["SYSD", "TAPE", "DISK", "3390"], required=True),
+        unit=dict(type="str", required=True),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
     )
     dd_data_set = dict(type="dict", options=combine_dicts(dd_name_base, dd_data_set_base))

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -1999,7 +1999,7 @@ def run_module():
     )
     dd_volume_base = dict(
         volume=dict(type="str", required=True),
-        unit= dict(type="str", default=None, required=True),
+        unit=dict(type="str", required=True),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
         return_content=dict(
             type="dict",
@@ -2254,7 +2254,7 @@ def parse_and_validate_args(params):
     )
     dd_volume_base = dict(
         volume=dict(type="str", required=True),
-        unit=dict(type="str", required=True ),
+        unit=dict(type="str", required=True),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
         return_content=dict(
             type="dict",

--- a/plugins/modules/zos_mvs_raw.py
+++ b/plugins/modules/zos_mvs_raw.py
@@ -710,6 +710,11 @@ options:
               - Device type for the volume.
             type: str
             required: true
+            choices:
+              - SYSD
+              - TAPE
+              - DISK
+              - 3390
           disposition:
             description:
               - I(disposition) indicates the status of a data set.
@@ -1999,7 +2004,7 @@ def run_module():
     )
     dd_volume_base = dict(
         volume=dict(type="str", required=True),
-        unit=dict(type="str", required=True),
+        unit=dict(type="str", choices=["SYSD", "TAPE", "DISK", "3390"], required=True),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
         return_content=dict(
             type="dict",
@@ -2254,7 +2259,7 @@ def parse_and_validate_args(params):
     )
     dd_volume_base = dict(
         volume=dict(type="str", required=True),
-        unit=dict(type="str", required=True),
+        unit=dict(type="str", choices=["SYSD", "TAPE", "DISK", "3390"], required=True),
         disposition=dict(type="str", choices=["new", "shr", "mod", "old"], required=True),
         return_content=dict(
             type="dict",

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -87,8 +87,11 @@ def test_full_volume_dump_with_custom_dd_volume(ansible_zos_module, volumes_on_s
                     }
                 },
                 {
-                    "dd_dummy": {
-                        "dd_name": "SYSPRINT"
+                    "dd_output":{
+                        "dd_name":"SYSPRINT",
+                        "return_content":{
+                            "type":"text"
+                        }
                     }
                 },
             ],

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -85,7 +85,7 @@ def test_full_volume_dump_with_custom_dd_volume(ansible_zos_module, volumes_on_s
                 {
                     "dd_volume": {
                         "dd_name": "VOLDD",
-                        "volser": test_volume,
+                        "volume": test_volume,
                         "unit": "3390",
                         "disposition": "old",
                     }
@@ -108,7 +108,7 @@ def test_full_volume_dump_with_custom_dd_volume(ansible_zos_module, volumes_on_s
             assert result.get("changed", False) is True
     finally:
         hosts.all.zos_data_set(name=dump_dataset, state="absent")
-        
+
 def test_failing_name_format(ansible_zos_module):
     hosts = ansible_zos_module
     results = hosts.all.zos_mvs_raw(

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -75,7 +75,7 @@ def test_full_volume_dump_with_custom_dd_volume(ansible_zos_module, volumes_on_s
                 {
                     "dd_volume": {
                         "dd_name": "VOLDD",
-                        "volume": test_volume,
+                        "volume_name": test_volume,
                         "unit": "3390",
                         "disposition": "old",
                     }

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -45,7 +45,70 @@ def get_temp_idcams_dataset(hosts):
 #                               Data set DD tests                              #
 # ---------------------------------------------------------------------------- #
 
-
+@pytest.mark.parametrize(
+    "block_size",
+    [32760],
+)
+@pytest.mark.parametrize(
+    "space_type,primary,secondary",
+    [
+        ("cyl", 3, 1),
+    ],
+)
+def test_full_volume_dump_with_custom_dd_volume(ansible_zos_module, volumes_on_systems, block_size ,space_type,primary,secondary):
+    hosts = ansible_zos_module
+    dump_dataset = get_tmp_ds_name()
+    volume_handler = Volume_Handler(volumes_on_systems)
+    test_volume = volume_handler.get_available_vol()
+    try:
+        results = hosts.all.zos_mvs_raw(
+            program_name="ADRDSSU",
+            auth=True,
+            verbose=True,
+            dds=[
+                {
+                    "dd_data_set": {
+                        "dd_name": "DUMPDD",
+                        "data_set_name": dump_dataset,
+                        "disposition": "new",
+                        "disposition_normal": "catalog",
+                        "disposition_abnormal": "delete",
+                        "space_type": space_type,
+                        "space_primary": primary,
+                        "space_secondary": secondary,
+                        "record_format": "u",
+                        "record_length": 0,
+                        "block_size": block_size,
+                        "type": "seq",
+                    }
+                },
+                {
+                    "dd_volume": {
+                        "dd_name": "VOLDD",
+                        "volser": test_volume,
+                        "unit": "3390",
+                        "disposition": "old",
+                    }
+                },
+                {
+                    "dd_input": {
+                        "dd_name": "SYSIN",
+                        "content": "  DUMP FULL INDDNAME(VOLDD) OUTDDNAME(DUMPDD)"
+                    }
+                },
+                {
+                    "dd_dummy": {
+                        "dd_name": "SYSPRINT"
+                    }
+                },
+            ],
+        )
+        for result in results.contacted.values():
+            assert result.get("ret_code", {}).get("code", -1) == 0
+            assert result.get("changed", False) is True
+    finally:
+        hosts.all.zos_data_set(name=dump_dataset, state="absent")
+        
 def test_failing_name_format(ansible_zos_module):
     hosts = ansible_zos_module
     results = hosts.all.zos_mvs_raw(

--- a/tests/functional/modules/test_zos_mvs_raw_func.py
+++ b/tests/functional/modules/test_zos_mvs_raw_func.py
@@ -45,17 +45,7 @@ def get_temp_idcams_dataset(hosts):
 #                               Data set DD tests                              #
 # ---------------------------------------------------------------------------- #
 
-@pytest.mark.parametrize(
-    "block_size",
-    [32760],
-)
-@pytest.mark.parametrize(
-    "space_type,primary,secondary",
-    [
-        ("cyl", 3, 1),
-    ],
-)
-def test_full_volume_dump_with_custom_dd_volume(ansible_zos_module, volumes_on_systems, block_size ,space_type,primary,secondary):
+def test_full_volume_dump_with_custom_dd_volume(ansible_zos_module, volumes_on_systems):
     hosts = ansible_zos_module
     dump_dataset = get_tmp_ds_name()
     volume_handler = Volume_Handler(volumes_on_systems)
@@ -73,12 +63,12 @@ def test_full_volume_dump_with_custom_dd_volume(ansible_zos_module, volumes_on_s
                         "disposition": "new",
                         "disposition_normal": "catalog",
                         "disposition_abnormal": "delete",
-                        "space_type": space_type,
-                        "space_primary": primary,
-                        "space_secondary": secondary,
+                        "space_type": "cyl",
+                        "space_primary": 10,
+                        "space_secondary": 2,
                         "record_format": "u",
                         "record_length": 0,
-                        "block_size": block_size,
+                        "block_size": 32760,
                         "type": "seq",
                     }
                 },


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added direct volume access support to enable storage management utilities  that requires raw volume operation.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#2077
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_mvs_raw
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yml 
- name: Custom ADRDSSU dump using enhanced zos_mvs_raw
  hosts: zvm
  gather_facts: false
  collections:
    - ibm.ibm_zos_core
  environment: "{{ environment_vars }}"

  tasks:
    - name: Run full volume dump with custom dd_volume
      zos_mvs_raw:
        program_name: ADRDSSU
        auth: true
        verbose: true
        dds:
          - dd_data_set:
              dd_name: DUMPDD
              data_set_name: OMVSADM.TEST.FULLDUMP
              disposition: new
              disposition_normal: catalog
              disposition_abnormal: delete
              space_type: cyl
              space_primary: 50
              space_secondary: 10
              record_format: u
              record_length: 0
              block_size: 32760
              type: seq

          - dd_volume:
              dd_name: VOLDD
              volume: "000000"
              unit: "3390"
              disposition: old
          
          - dd_input:
              dd_name: SYSIN
              content: "  DUMP FULL INDDNAME(VOLDD) OUTDDNAME(DUMPDD)"

          - dd_dummy:
              dd_name: SYSPRINT

```
``` yml 
changed: [zvm] => {
    "backups": [],
    "changed": true,
    "dd_names": [],
    "invocation": {
        "module_args": {
            "auth": true,
            "dds": [
                {
                    "dd_concat": null,
                    "dd_data_set": {
                        "backup": false,
                        "block_size": 32760,
                        "data_set_name": "OMVSADM.TEST.FULLDUMP",
                        "dd_name": "DUMPDD",
                        "directory_blocks": null,
                        "disposition": "new",
                        "disposition_abnormal": "delete",
                        "disposition_normal": "catalog",
                        "encryption_key_1": null,
                        "encryption_key_2": null,
                        "key_label": null,
                        "key_length": null,
                        "key_offset": null,
                        "record_format": "u",
                        "record_length": 0,
                        "replace": false,
                        "return_content": null,
                        "reuse": false,
                        "sms_data_class": null,
                        "sms_management_class": null,
                        "sms_storage_class": null,
                        "space_primary": 50,
                        "space_secondary": 10,
                        "space_type": "cyl",
                        "type": "seq",
                        "volumes": null
                    },
                    "dd_dummy": null,
                    "dd_input": null,
                    "dd_output": null,
                    "dd_unix": null,
                    "dd_vio": null,
                    "dd_volume": null
                },
                {
                    "dd_concat": null,
                    "dd_data_set": null,
                    "dd_dummy": null,
                    "dd_input": null,
                    "dd_output": null,
                    "dd_unix": null,
                    "dd_vio": null,
                    "dd_volume": {
                        "dd_name": "VOLDD",
                        "disposition": "old",
                        "return_content": {
                            "response_encoding": "iso8859-1",
                            "src_encoding": "ibm-1047",
                            "type": "text"
                        },
                        "unit": "3390",
                        "volume": "000000"
                    }
                },
                {
                    "dd_concat": null,
                    "dd_data_set": null,
                    "dd_dummy": null,
                    "dd_input": {
                        "content": "  DUMP FULL INDDNAME(VOLDD) OUTDDNAME(DUMPDD)",
                        "dd_name": "SYSIN",
                        "reserved_cols": 2,
                        "return_content": null
                    },
                    "dd_output": null,
                    "dd_unix": null,
                    "dd_vio": null,
                    "dd_volume": null
                },
                {
                    "dd_concat": null,
                    "dd_data_set": null,
                    "dd_dummy": {
                        "dd_name": "SYSPRINT"
                    },
                    "dd_input": null,
                    "dd_output": null,
                    "dd_unix": null,
                    "dd_vio": null,
                    "dd_volume": null
                }
            ],
            "max_rc": 0,
            "parm": null,
            "program_name": "ADRDSSU",
            "tmp_hlq": null,
            "verbose": true
        }
    },
    "ret_code": {
        "code": 0
    },
    "stderr": "BGYSC0307I Program: <ADRDSSU> Arguments: <>\nBGYSC0308I DDNames:\nBGYSC0311I   SYSPRINT=DUMMY\nBGYSC0312I   SYSIN=OMVSADM.P6777601.T0194008.C0000000\nBGYSC0312I   VOLDD=000000,volume\nBGYSC0312I   DUMPDD=OMVSADM.TEST.FULLDUMP\nBGYSC0306I DUMMY Dynalloc succeeded for SYSPRINT=DUMMY\nBGYSC0303I Dataset allocation succeeded for SYSIN=OMVSADM.P6777601.T0194008.C0000000\nBGYSC0303I Dataset allocation succeeded for VOLDD=000000\nBGYSC0303I Dataset allocation succeeded for DUMPDD=OMVSADM.TEST.FULLDUMP\nBGYSC0328I OS Load program ADRDSSU \nBGYSC0319I Program is APF authorized.\nBGYSC0320I Addressing mode: AMODE31\nBGYSC0327I Attach Exit code: 0 from ADRDSSU.\nBGYSC0354I Dummy free succeeded for SYSPRINT\nBGYSC0338I Dataset free succeeded for SYSIN=OMVSADM.P6777601.T0194008.C0000000\nBGYSC0358I Volume free succeeded for VOLDD\nBGYSC0338I Dataset free succeeded for DUMPDD=OMVSADM.TEST.FULLDUMP\n",
    "stderr_lines": [
        "BGYSC0307I Program: <ADRDSSU> Arguments: <>",
        "BGYSC0308I DDNames:",
        "BGYSC0311I   SYSPRINT=DUMMY",
        "BGYSC0312I   SYSIN=OMVSADM.P6777601.T0194008.C0000000",
        "BGYSC0312I   VOLDD=000000,volume",
        "BGYSC0312I   DUMPDD=OMVSADM.TEST.FULLDUMP",
        "BGYSC0306I DUMMY Dynalloc succeeded for SYSPRINT=DUMMY",
        "BGYSC0303I Dataset allocation succeeded for SYSIN=OMVSADM.P6777601.T0194008.C0000000",
        "BGYSC0303I Dataset allocation succeeded for VOLDD=000000",
        "BGYSC0303I Dataset allocation succeeded for DUMPDD=OMVSADM.TEST.FULLDUMP",
        "BGYSC0328I OS Load program ADRDSSU ",
        "BGYSC0319I Program is APF authorized.",
        "BGYSC0320I Addressing mode: AMODE31",
        "BGYSC0327I Attach Exit code: 0 from ADRDSSU.",
        "BGYSC0354I Dummy free succeeded for SYSPRINT",
        "BGYSC0338I Dataset free succeeded for SYSIN=OMVSADM.P6777601.T0194008.C0000000",
        "BGYSC0358I Volume free succeeded for VOLDD",
        "BGYSC0338I Dataset free succeeded for DUMPDD=OMVSADM.TEST.FULLDUMP"
    ],
    "stdout": "",
    "stdout_lines": []
}

PLAY RECAP *********************************************************************************
zvm                        : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```

