### PR TITLE
[1.14.1][zos_copy] Fix permission denied when transferring file to managed node with non-root user

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_issue.yml
+++ b/.github/ISSUE_TEMPLATE/bug_issue.yml
@@ -33,6 +33,9 @@ body:
       description: Which version of z/OS Ansible core collection are you using. If you are unsure, review the [documentation](https://ibm.github.io/z_ansible_collections_doc/faqs/faqs.html#how-do-i-update-a-collection-to-the-latest-version).
       multiple: false
       options:
+        - v1.14.1
+        - v1.14.0
+        - v1.14.0-beta.1
         - v1.13.0
         - v1.13.0-beta.1
         - v1.12.0

--- a/.github/ISSUE_TEMPLATE/collaboration_issue.yml
+++ b/.github/ISSUE_TEMPLATE/collaboration_issue.yml
@@ -42,6 +42,9 @@ body:
       description: Which version of z/OS Ansible core collection are you using. If you are unsure, review the [documentation](https://ibm.github.io/z_ansible_collections_doc/faqs/faqs.html#how-do-i-update-a-collection-to-the-latest-version).
       multiple: false
       options:
+        - v1.14.1
+        - v1.14.0
+        - v1.14.0-beta.1
         - v1.13.0
         - v1.13.0-beta.1
         - v1.12.0

--- a/.github/ISSUE_TEMPLATE/doc_issue.yml
+++ b/.github/ISSUE_TEMPLATE/doc_issue.yml
@@ -34,6 +34,9 @@ body:
       description: Which version of z/OS Ansible core collection are you using. If you are unsure, review the [documentation](https://ibm.github.io/z_ansible_collections_doc/faqs/faqs.html#how-do-i-update-a-collection-to-the-latest-version).
       multiple: false
       options:
+        - v1.14.1
+        - v1.14.0
+        - v1.14.0-beta.1
         - v1.13.0
         - v1.13.0-beta.1
         - v1.12.0

--- a/changelogs/fragments/2196-fix-copy-permission-issues.yml
+++ b/changelogs/fragments/2196-fix-copy-permission-issues.yml
@@ -1,0 +1,13 @@
+bugfixes:
+  - zos_job_submit - Previously, if the ansible user was not a superuser copying a file into the managed node resulted
+    in permission denied error. Fix now sets the correct permissions for the ansible user for copying to the remote.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2196)
+  - zos_copy - Previously, if the ansible user was not a superuser copying a file into the managed node resulted
+    in permission denied error. Fix now sets the correct permissions for the ansible user for copying to the remote.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2196)
+  - zos_script - Previously, if the ansible user was not a superuser copying a file into the managed node resulted
+    in permission denied error. Fix now sets the correct permissions for the ansible user for copying to the remote.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2196)
+  - zos_unarchive - Previously, if the ansible user was not a superuser copying a file into the managed node resulted
+    in permission denied error. Fix now sets the correct permissions for the ansible user for copying to the remote.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2196)

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -293,24 +293,9 @@ class ActionModule(ActionBase):
             path = os.path.normpath(f"{self.tmp_dir}/ansible-zos-copy")
             # If another user created the temporary files, we'll need to run rm
             # with it too, lest we get a permissions issue.
-            if self._connection.become:
-                # We get the dirname from temp_path and not path = os.path.normpath(f"{self.tmp_dir}/ansible-zos-copy")
-                # because if default is ~/.ansible/tmp/ when using become it would be similar to /root/.ansible/tmp
-                # but the original tmp directory was resolved when user is non escalated yet. Meaning, the original
-                # tmp directory is similar to /u/usrt001/.ansible/tmp.
-                path = os.path.dirname(temp_path)
-                self._connection.set_option('remote_user', self._play_context._become_user)
-                display.vvv(
-                    u"ibm_zos_copy SSH cleanup user updated to {0}".format(self._play_context._become_user),
-                    host=self._play_context.remote_addr
-                )
+
             rm_res = self._connection.exec_command(f"rm -rf {path}*")
-            if self._connection.become:
-                self._connection.set_option('remote_user', self._play_context._remote_user)
-                display.vvv(
-                    u"ibm_zos_copy SSH cleanup user restored to {0}".format(self._play_context._remote_user),
-                    host=self._play_context.remote_addr
-                )
+
 
         if copy_res.get("note") and not force:
             result["note"] = copy_res.get("note")
@@ -342,16 +327,24 @@ class ActionModule(ActionBase):
         """Copy a file or directory to the remote z/OS system """
         self.tmp_dir = self._connection._shell._options.get("remote_tmp")
         temp_path = os.path.join(self.tmp_dir, _create_temp_path_name())
-        tempfile_args = {"path": temp_path, "state": "directory", "mode": "666"}
-        # Reverted this back to using file ansible module so ansible would handle all temporary dirs
-        # creation with correct permissions.
-        tempfile = self._execute_module(
-            module_name="file", module_args=tempfile_args, task_vars=task_vars, wrap_async=self._task.async_val
-        )
-        _sftp_action = 'put'
-        was_user_updated = False
 
-        temp_path = os.path.join(tempfile.get("path"), os.path.basename(src))
+        rc, stdout, stderr = self._connection.exec_command("mkdir -p {0}".format(temp_path))
+        display.vvv(f"ibm_zos_copy: remote mkdir result {rc}, {stdout}, {stderr} path {temp_path}")
+        if rc > 0:
+            msg = f"Failed to create remote temporary directory in {self.tmp_dir}. Ensure that user has proper access."
+            return self._exit_action({}, msg, failed=True)
+
+        # The temporary dir was created successfully using ssh connection user.
+        rc, stdout, stderr = self._connection.exec_command(F"cd {temp_path} && pwd")
+        display.vvv(f"ibm_zos_copy: remote pwd result {rc}, {stdout}, {stderr} path {temp_path}")
+        if rc > 0:
+            msg = f"Failed to resolve remote temporary directory {temp_path}. Ensure that user has proper access."
+            return self._exit_action({}, msg, failed=True)
+        temp_path = stdout.decode("utf-8").replace("\r", "").replace("\n", "")
+
+        _sftp_action = 'put'
+
+        temp_path = os.path.join(temp_path, os.path.basename(src))
         _src = src.replace("#", "\\#")
         full_temp_path = temp_path
 
@@ -392,13 +385,7 @@ class ActionModule(ActionBase):
                             sftp_transfer_method), host=self._play_context.remote_addr)
 
             display.vvv(u"ibm_zos_copy: {0} {1} TO {2}".format(_sftp_action, _src, temp_path), host=self._play_context.remote_addr)
-            if self._connection.become:
-                was_user_updated = True
-                self._connection.set_option('remote_user', self._play_context._become_user)
-                display.vvv(
-                    u"ibm_zos_copy SSH transfer user updated to {0}".format(self._play_context._become_user),
-                    host=self._play_context.remote_addr
-                )
+
             (returncode, stdout, stderr) = self._connection._file_transport_command(_src, temp_path, _sftp_action)
 
             display.vvv(u"ibm_zos_copy return code: {0}".format(returncode), host=self._play_context.remote_addr)
@@ -438,13 +425,6 @@ class ActionModule(ActionBase):
 
         finally:
             # Restore the users defined option `ssh_transfer_method` if it was overridden
-            if was_user_updated:
-                self._connection.set_option('remote_user', self._play_context._remote_user)
-                display.vvv(
-                    u"ibm_zos_copy SSH transfer user restored to {0}".format(self._play_context._remote_user),
-                    host=self._play_context.remote_addr
-                )
-
             if is_ssh_transfer_method_updated:
                 if version_major == 2 and version_minor >= 11:
                     self._connection.set_option('ssh_transfer_method', user_ssh_transfer_method)

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -293,7 +293,6 @@ class ActionModule(ActionBase):
             path = os.path.normpath(f"{self.tmp_dir}/ansible-zos-copy")
             rm_res = self._connection.exec_command(f"rm -rf {path}*")
 
-
         if copy_res.get("note") and not force:
             result["note"] = copy_res.get("note")
             return result

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -291,9 +291,6 @@ class ActionModule(ActionBase):
         # Remove temporary directory from remote
         if self.tmp_dir is not None:
             path = os.path.normpath(f"{self.tmp_dir}/ansible-zos-copy")
-            # If another user created the temporary files, we'll need to run rm
-            # with it too, lest we get a permissions issue.
-
             rm_res = self._connection.exec_command(f"rm -rf {path}*")
 
 

--- a/plugins/action/zos_job_submit.py
+++ b/plugins/action/zos_job_submit.py
@@ -79,13 +79,22 @@ class ActionModule(ActionBase):
             tmp_dir = self._connection._shell._options.get("remote_tmp")
             temp_file_dir = f'zos_job_submit_{datetime.now().strftime("%Y%m%d%S%f")}'
             dest_path = path.join(tmp_dir, temp_file_dir)
-            tempfile_args = {"path": dest_path, "state": "directory"}
-            # Reverted this back to using file ansible module so ansible would handle all temporary dirs
-            # creation with correct permissions.
-            tempfile = self._execute_module(
-                module_name="file", module_args=tempfile_args, task_vars=task_vars,
-            )
-            dest_path = tempfile.get("path")
+
+            rc, stdout, stderr = self._connection.exec_command("mkdir -p {0}".format(dest_path))
+            display.vvv(f"zos_job_submit: mkdir result {rc}, {stdout}, {stderr} dest path {dest_path}")
+            if rc > 0:
+                result["failed"] = True
+                result["msg"] = f"Failed to create remote temporary directory in {tmp_dir}. Ensure that user has proper access."
+                return result
+
+            # The temporary dir was created successfully using ssh connection user.
+            rc, stdout, stderr = self._connection.exec_command(F"cd {dest_path} && pwd")
+            display.vvv(f"zos_job_submit: remote pwd result {rc}, {stdout}, {stderr} path {dest_path}")
+            if rc > 0:
+                result["failed"] = True
+                result["msg"] = f"Failed to resolve remote temporary directory {dest_path}. Ensure that user has proper access."
+                return result
+            dest_path = stdout.decode("utf-8").replace("\r", "").replace("\n", "")
             dest_file = path.join(dest_path, path.basename(source))
 
             source_full = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR practically reverts the change done in #2109 [v1.14.0] Avoid failures when default dir ~/.ansible/tmp/ is not previously created and fix failures when using become in zos_job_submit, but keeps the functionality of working correctly when the `become` keyword is used in `zos_job_submit` and will not fail if ~/.ansible/tmp/ is not created. But reverts the use of `file` ansible module, which created problems when using the `become` keyword since files were created by BPXROOT in the non-root user folder.

Also, corrects the incorrect use of mode = `666` which left the files unusable, fixes #2196.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy
zos_job_submit

