### PR TITLE
Enhancement/761/zos job output

### DIFF
--- a/changelogs/fragments/2207-SYSIN-support-zos_job_output.yml
+++ b/changelogs/fragments/2207-SYSIN-support-zos_job_output.yml
@@ -1,0 +1,3 @@
+minor_changes:
+   - zos_job_output - Adds support for SYSIN using input parameter.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2207)

--- a/changelogs/fragments/2207-SYSIN-support-zos_job_output.yml
+++ b/changelogs/fragments/2207-SYSIN-support-zos_job_output.yml
@@ -1,3 +1,3 @@
 minor_changes:
-   - zos_job_output - Adds support for SYSIN using input parameter.
+   - zos_job_output - Adds support to query SYSIN DDs from a job with new option input.
      (https://github.com/ansible-collections/ibm_zos_core/pull/2207)

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -411,7 +411,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, sysin=Fal
                 list_of_dds = []
 
                 try:
-                    list_of_dds = jobs.list_dds(entry.job_id,sysin=sysin)
+                    list_of_dds = jobs.list_dds(entry.job_id, sysin=sysin)
                 except exceptions.DDQueryException:
                     is_dd_query_exception = True
 
@@ -430,7 +430,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, sysin=Fal
                     try:
                         # Note, in the event of an exception, eg job has TYPRUN=HOLD
                         # list_of_dds will still be populated with valuable content
-                        list_of_dds = jobs.list_dds(entry.job_id,sysin=sysin)
+                        list_of_dds = jobs.list_dds(entry.job_id, sysin=sysin)
                         is_jesjcl = True if search_dictionaries("dd_name", "JESJCL", list_of_dds) else False
                         is_job_error_status = True if entry.status in JOB_ERROR_STATUSES else False
                     except exceptions.DDQueryException:

--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -58,7 +58,7 @@ JOB_ERROR_STATUSES = frozenset(["ABEND",      # ZOAU job ended abnormally
                                 ])
 
 
-def job_output(job_id=None, owner=None, job_name=None, dd_name=None, dd_scan=True, duration=0, timeout=0, start_time=timer()):
+def job_output(job_id=None, owner=None, job_name=None, dd_name=None, sysin=False, dd_scan=True, duration=0, timeout=0, start_time=timer()):
     """Get the output from a z/OS job based on various search criteria.
 
     Keyword Parameters
@@ -71,6 +71,8 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None, dd_scan=Tru
         The job name search for (default: {None}).
     dd_name : str
         The data definition to retrieve (default: {None}).
+    sysin : bool
+        The input DD to retrieve SYSIN value (default: {False}).
     dd_scan : bool
         Whether or not to pull information from the dd's for this job {default: {True}}.
     duration : int
@@ -112,6 +114,7 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None, dd_scan=Tru
         job_name=job_name,
         dd_name=dd_name,
         duration=duration,
+        sysin=sysin,
         dd_scan=dd_scan,
         timeout=timeout,
         start_time=start_time
@@ -128,6 +131,7 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None, dd_scan=Tru
             owner=owner,
             job_name=job_name,
             dd_name=dd_name,
+            sysin=sysin,
             dd_scan=dd_scan,
             duration=duration,
             timeout=timeout,
@@ -287,7 +291,7 @@ def _parse_steps(job_str):
     return stp
 
 
-def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=True, duration=0, timeout=0, start_time=timer()):
+def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, sysin=False, dd_scan=True, duration=0, timeout=0, start_time=timer()):
     """Get job status.
 
     Parameters
@@ -300,6 +304,8 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
         The job name search for (default: {None}).
     dd_name : str
         The data definition to retrieve (default: {None}).
+    sysin : bool
+        The input DD SYSIN (default: {False}).
     dd_scan : bool
         Whether or not to pull information from the dd's for this job {default: {True}}.
     duration : int
@@ -405,7 +411,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
                 list_of_dds = []
 
                 try:
-                    list_of_dds = jobs.list_dds(entry.job_id)
+                    list_of_dds = jobs.list_dds(entry.job_id,sysin=sysin)
                 except exceptions.DDQueryException:
                     is_dd_query_exception = True
 
@@ -424,7 +430,7 @@ def _get_job_status(job_id="*", owner="*", job_name="*", dd_name=None, dd_scan=T
                     try:
                         # Note, in the event of an exception, eg job has TYPRUN=HOLD
                         # list_of_dds will still be populated with valuable content
-                        list_of_dds = jobs.list_dds(entry.job_id)
+                        list_of_dds = jobs.list_dds(entry.job_id,sysin=sysin)
                         is_jesjcl = True if search_dictionaries("dd_name", "JESJCL", list_of_dds) else False
                         is_job_error_status = True if entry.status in JOB_ERROR_STATUSES else False
                     except exceptions.DDQueryException:

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -33,7 +33,7 @@ description:
     like "*".
   - If there is no ddname, or if ddname="?", output of all the ddnames under
     the given job will be displayed.
-  - If user needs input like SYSIN, input parameter should be set true.
+  - If SYSIN DDs are needed, C(input) should be set to C(true).
 version_added: "1.0.0"
 author:
   - "Jack Ho (@jacklotusho)"
@@ -64,7 +64,7 @@ options:
     required: false
   input:
     description:
-      - Input DD SYSIN (show only this DD on a found job).
+      - Whether to include SYSIN DDs as part of the output.
     type: bool
     default: false
     required: false
@@ -98,10 +98,10 @@ EXAMPLES = r"""
     owner: "IBMUSER"
     ddname: "?"
 
-- name: JES Job output with SYSIN
+- name: Query a job's output including SYSIN DDs
   zos_job_output:
     job_id: "JOB00548"
-    input: True
+    input: true
 """
 
 RETURN = r"""

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -66,6 +66,7 @@ options:
     description:
       - Input DD SYSIN (show only this DD on a found job).
     type: bool
+    default: false
     required: false
 
 attributes:
@@ -96,6 +97,11 @@ EXAMPLES = r"""
     job_name: "*"
     owner: "IBMUSER"
     ddname: "?"
+
+- name: JES Job output with SYSIN
+  zos_job_output:
+    job_id: "JOB00548"
+    input: True
 """
 
 RETURN = r"""

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -33,6 +33,7 @@ description:
     like "*".
   - If there is no ddname, or if ddname="?", output of all the ddnames under
     the given job will be displayed.
+  - If user needs input like SYSIN, input parameter should be set true.
 version_added: "1.0.0"
 author:
   - "Jack Ho (@jacklotusho)"
@@ -60,6 +61,11 @@ options:
       - Data definition name (show only this DD on a found job).
         (e.g "JESJCL", "?")
     type: str
+    required: false
+  input:
+    description:
+      - Input DD SYSIN (show only this DD on a found job).
+    type: bool
     required: false
 
 attributes:
@@ -496,6 +502,7 @@ def run_module():
         job_name=dict(type="str", required=False),
         owner=dict(type="str", required=False),
         ddname=dict(type="str", required=False),
+        input=dict(type="bool", required=False, default=False),
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
@@ -505,6 +512,7 @@ def run_module():
         job_name=dict(type="job_identifier", required=False),
         owner=dict(type="str", required=False),
         ddname=dict(type="str", required=False),
+        input=dict(type="bool", required=False, default=False),
     )
 
     try:
@@ -521,13 +529,14 @@ def run_module():
     job_name = module.params.get("job_name")
     owner = module.params.get("owner")
     ddname = module.params.get("ddname")
+    sysin = module.params.get("input")
 
     if not job_id and not job_name and not owner:
         module.fail_json(msg="Please provide a job_id or job_name or owner")
 
     try:
         results = {}
-        results["jobs"] = job_output(job_id=job_id, owner=owner, job_name=job_name, dd_name=ddname)
+        results["jobs"] = job_output(job_id=job_id, owner=owner, job_name=job_name, dd_name=ddname, sysin=sysin)
         results["changed"] = False
     except zoau_exceptions.JobFetchException as fetch_exception:
         module.fail_json(

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -191,8 +191,8 @@ def test_zos_job_output_job_exists_with_sysin(ansible_zos_module):
                         sysin_found = True
                         break
                 assert sysin_found
-        hosts.all.zos_data_set(name="TEST.DATASET.JCL", state="absent")
     finally:
+        hosts.all.zos_data_set(name="TEST.DATASET.JCL", state="absent")
         hosts.all.file(path=TEMP_PATH, state="absent")
 
 

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -191,6 +191,7 @@ def test_zos_job_output_job_exists_with_sysin(ansible_zos_module):
                         sysin_found = True
                         break
                 assert sysin_found
+        hosts.all.zos_data_set(name="TEST.DATASET.JCL", state="absent")
     finally:
         hosts.all.file(path=TEMP_PATH, state="absent")
 

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -30,6 +30,19 @@ HELLO, WORLD
 //
 """
 
+JCL_FILE_CONTENTS_SYSIN = """//SYSINS  JOB (T043JM,JM00,1,0,0,0),'SYSINS - JRM',CLASS=R,   
+//      MSGCLASS=X,MSGLEVEL=1,NOTIFY=OMVSADM               
+//STEP1   EXEC PGM=BPXBATCH,PARM='SH sleep 1'              
+//STDOUT   DD SYSOUT=*                                     
+//STDERR   DD SYSOUT=*                                     
+//LISTCAT EXEC PGM=IDCAMS,REGION=4M                        
+//SYSPRINT DD   SYSOUT=*                                   
+//SYSIN DD   *                                             
+     LISTCAT ENTRIES('TEST.DATASET.JCL') ALL           
+/*                                                         
+//
+"""
+
 TEMP_PATH = "/tmp/jcl"
 
 def test_zos_job_output_no_job_id(ansible_zos_module):
@@ -145,6 +158,39 @@ def test_zos_job_output_job_exists_with_filtered_ddname(ansible_zos_module):
             for job in result.get("jobs"):
                 assert len(job.get("ddnames")) == 1
                 assert job.get("ddnames")[0].get("ddname") == dd_name
+    finally:
+        hosts.all.file(path=TEMP_PATH, state="absent")
+
+
+def test_zos_job_output_job_exists_with_sysin(ansible_zos_module):
+    try:
+        hosts = ansible_zos_module
+        hosts.all.file(path=TEMP_PATH, state="directory")
+        hosts.all.zos_data_set(
+                    name="TEST.DATASET.JCL",
+                    type="PS",
+                    state="present"
+                )
+        hosts.all.shell(
+            cmd=f"echo {quote(JCL_FILE_CONTENTS_SYSIN)} > {TEMP_PATH}/SYSIN"
+        )
+        result = hosts.all.zos_job_submit(
+            src=f"{TEMP_PATH}/SYSIN", location="uss", volume=None
+        )
+        hosts.all.file(path=TEMP_PATH, state="absent")
+        sysin = "True"
+        results = hosts.all.zos_job_output(job_name="SYSINS", input=sysin)
+        for result in results.contacted.values():
+            print(result)
+            assert result.get("changed") is False
+            for job in result.get("jobs"):
+                assert len(job.get("ddnames")) >= 1
+                sysin_found = False
+                for ddname_entry in job.get("ddnames"):
+                    if ddname_entry.get("ddname") == "SYSIN":
+                        sysin_found = True
+                        break
+                assert sysin_found
     finally:
         hosts.all.file(path=TEMP_PATH, state="absent")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding the boolean support  "Input" parameter that specifically  returns the SYSIN.
Fixes #761.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enhancement Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_output

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Sample playbook to test the changes:

    - name: Submit JCL in a PS member.
      zos_job_submit:
        src: /sample.jcl
        location: local
      register: response
    - name: Display job submission results
      debug:
        msg: "Job Submission Result: {{ response }}"
    - name: JES Job output without ddname
      zos_job_output:
        job_id: "{{ response.job_id }}"
        input: True
      register: result

