### PR TITLE
Adding error suggestion to generic error while copying GDG if its in edit mode.

### DIFF
--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3963,8 +3963,12 @@ def run_module(module, arg_def):
         # Copy to a GDG
         # ---------------------------------------------------------------------
         elif dest_ds_type == "GDG":
-            copy_handler.copy_to_gdg(src, dest)
-            res_args["changed"] = True
+            try:
+                copy_handler.copy_to_gdg(src, dest)
+                res_args["changed"] = True
+            except Exception as e:
+                res_args["msg"] = f"Failure to copy might be because of source GDG in open state {e}"
+
 
         # ------------------------------- o -----------------------------------
         # Copy to VSAM data set


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The error from the ZOAU is very generic and does not suggest that the possible failure reason can be the src GDG in edit mode or being used by another task. This change improves the error handling and gives user a suggestion to resolve the issue. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below


```
