### PR TITLE
[Enabler][zos_zfs_resize] Updated zos_zfs_resize test that failed on ansible 2.18

### DIFF
--- a/changelogs/fragments/2240-fix2.18-zos_zfs_resize.yml
+++ b/changelogs/fragments/2240-fix2.18-zos_zfs_resize.yml
@@ -1,4 +1,4 @@
 trivial:
-   - test_zos_zfs_resize_func.py - modified test case `test_ztest_grow_n_shrink_operations_trace_ds_not_created` and `test_ztest_grow_n_shrink_operations_trace_ds`
+   - test_zos_zfs_resize_func.py - modified test case `test_grow_n_shrink_operations_trace_ds_not_created` and `test_grow_n_shrink_operations_trace_ds`
      to resolve issues when testing ansible 2.18.
      (https://github.com/ansible-collections/ibm_zos_core/pull/2240).

--- a/changelogs/fragments/2240-fix2.18-zos_zfs_resize.yml
+++ b/changelogs/fragments/2240-fix2.18-zos_zfs_resize.yml
@@ -1,0 +1,4 @@
+trivial:
+   - test_zos_zfs_resize_func.py - modified test case `test_ztest_grow_n_shrink_operations_trace_ds_not_created` and `test_ztest_grow_n_shrink_operations_trace_ds`
+     to resolve issues when testing ansible 2.18.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2240).

--- a/tests/functional/modules/test_zos_zfs_resize_func.py
+++ b/tests/functional/modules/test_zos_zfs_resize_func.py
@@ -655,10 +655,10 @@ def test_grow_n_shrink_operations_trace_ds(ansible_zos_module, trace_destination
             assert result.get('new_free_space') >= result.get('old_free_space')
             assert result.get('space_type') == "k"
             assert "Printing contents of table at address" in result.get("stdout")
-            cmd = "dcat \"{0}\" ".format(trace_destination_ds)
+            cmd = "dcat \"{0}\" | wc -l".format(trace_destination_ds)
             output_of_trace_file = hosts.all.shell(cmd=cmd)
             for out in output_of_trace_file.contacted.values():
-                assert out.get("stdout") is not None
+                assert int(out.get("stdout")) != 0
             assert result.get('stderr') == ""
             assert result.get('stderr_lines') == []
 
@@ -687,10 +687,10 @@ def test_grow_n_shrink_operations_trace_ds(ansible_zos_module, trace_destination
             assert result.get('new_free_space') <= result.get('old_free_space')
             assert result.get('space_type') == "k"
             assert "print of in-memory trace table has completed" in result.get('stdout')
-            cmd = "dcat \"{0}\" ".format(trace_destination_ds_s)
+            cmd = "dcat \"{0}\" | wc -l".format(trace_destination_ds_s)
             output_of_trace_file = hosts.all.shell(cmd=cmd)
             for out in output_of_trace_file.contacted.values():
-                assert out.get("stdout") is not None
+                assert int(out.get("stdout")) != 0
             assert result.get('stderr') == ""
             assert result.get('stderr_lines') == []
 
@@ -736,10 +736,10 @@ def test_grow_n_shrink_operations_trace_ds_not_created(ansible_zos_module, trace
             assert result.get('new_free_space') >= result.get('old_free_space')
             assert result.get('space_type') == "k"
             assert "Printing contents of table at address" in result.get("stdout")
-            cmd = "dcat \"{0}\" ".format(trace_destination_ds)
+            cmd = "dcat \"{0}\" | wc -l".format(trace_destination_ds)
             output_of_trace_file = hosts.all.shell(cmd=cmd)
             for out in output_of_trace_file.contacted.values():
-                assert out.get("stdout") is not None
+                assert int(out.get("stdout")) != 0
             assert result.get('stderr') == ""
             assert result.get('stderr_lines') == []
 
@@ -762,10 +762,10 @@ def test_grow_n_shrink_operations_trace_ds_not_created(ansible_zos_module, trace
             assert result.get('new_free_space') <= result.get('old_free_space')
             assert result.get('space_type') == "k"
             assert "print of in-memory trace table has completed" in result.get('stdout')
-            cmd = "dcat \"{0}\" ".format(trace_destination_ds_s)
+            cmd = "dcat \"{0}\" | wc -l".format(trace_destination_ds_s)
             output_of_trace_file = hosts.all.shell(cmd=cmd)
             for out in output_of_trace_file.contacted.values():
-                assert out.get("stdout") is not None
+                assert int(out.get("stdout")) != 0
             assert result.get('stderr') == ""
             assert result.get('stderr_lines') == []
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changed the logic of instead of getting the full dump from dcat command we instead get it piped through `wc` so that we know if the data set is empty or not.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix #2227

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_zfs_resize

