### PR TITLE
Rename option name input to sysin_dd for job_output

### DIFF
--- a/changelogs/fragments/2251-zos_job_output-input-sysin_dd-rename.yml
+++ b/changelogs/fragments/2251-zos_job_output-input-sysin_dd-rename.yml
@@ -1,0 +1,7 @@
+trivial:
+   - zos_job_output - renamed the input parameter to be called as sysin_dd.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2251).
+
+   - test_zos_job_output_func - modified the test case 'test_zos_job_output_job_exists_with_sysin'
+     to use sysin_dd instead of input.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2251).

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -33,7 +33,7 @@ description:
     like "*".
   - If there is no ddname, or if ddname="?", output of all the ddnames under
     the given job will be displayed.
-  - If SYSIN DDs are needed, C(input) should be set to C(true).
+  - If SYSIN DDs are needed, C(sysin_dd) should be set to C(true).
 version_added: "1.0.0"
 author:
   - "Jack Ho (@jacklotusho)"
@@ -62,7 +62,7 @@ options:
         (e.g "JESJCL", "?")
     type: str
     required: false
-  input:
+  sysin_dd:
     description:
       - Whether to include SYSIN DDs as part of the output.
     type: bool
@@ -101,7 +101,7 @@ EXAMPLES = r"""
 - name: Query a job's output including SYSIN DDs
   zos_job_output:
     job_id: "JOB00548"
-    input: true
+    sysin_dd: true
 """
 
 RETURN = r"""
@@ -508,7 +508,7 @@ def run_module():
         job_name=dict(type="str", required=False),
         owner=dict(type="str", required=False),
         ddname=dict(type="str", required=False),
-        input=dict(type="bool", required=False, default=False),
+        sysin_dd=dict(type="bool", required=False, default=False),
     )
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
@@ -518,7 +518,7 @@ def run_module():
         job_name=dict(type="job_identifier", required=False),
         owner=dict(type="str", required=False),
         ddname=dict(type="str", required=False),
-        input=dict(type="bool", required=False, default=False),
+        sysin_dd=dict(type="bool", required=False, default=False),
     )
 
     try:
@@ -535,7 +535,7 @@ def run_module():
     job_name = module.params.get("job_name")
     owner = module.params.get("owner")
     ddname = module.params.get("ddname")
-    sysin = module.params.get("input")
+    sysin = module.params.get("sysin_dd")
 
     if not job_id and not job_name and not owner:
         module.fail_json(msg="Please provide a job_id or job_name or owner")

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -33,7 +33,7 @@ description:
     like "*".
   - If there is no ddname, or if ddname="?", output of all the ddnames under
     the given job will be displayed.
-  - If SYSIN DDs are needed, C(sysin_dd) should be set to C(true).
+  - If SYSIN DDs are needed, O(sysin_dd) should be set to C(true).
 version_added: "1.0.0"
 author:
   - "Jack Ho (@jacklotusho)"

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -33,7 +33,7 @@ description:
     like "*".
   - If there is no ddname, or if ddname="?", output of all the ddnames under
     the given job will be displayed.
-  - If SYSIN DDs are needed, O(sysin_dd) should be set to C(true).
+  - If SYSIN DDs are needed, I(sysin_dd) should be set to C(true).
 version_added: "1.0.0"
 author:
   - "Jack Ho (@jacklotusho)"

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -179,7 +179,7 @@ def test_zos_job_output_job_exists_with_sysin(ansible_zos_module):
         )
         hosts.all.file(path=TEMP_PATH, state="absent")
         sysin = "True"
-        results = hosts.all.zos_job_output(job_name="SYSINS", input=sysin)
+        results = hosts.all.zos_job_output(job_name="SYSINS", sysin_dd=sysin)
         for result in results.contacted.values():
             print(result)
             assert result.get("changed") is False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Option input was added to retrieve the sysin dd content,  now its changed to sysin_dd as a boolean, behavior is same its just the option name that is refactored.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_job_output

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
