### PR TITLE
[Enhancement][data_set]Enhance error messages when not able to delete GDGs

### DIFF
--- a/changelogs/fragments/2255-data_set-Enhance-error-message.yml
+++ b/changelogs/fragments/2255-data_set-Enhance-error-message.yml
@@ -1,0 +1,3 @@
+minor_changes:
+   - zos_data_set - Enhances error messages when deleting a Generation Data Group fails.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2255)

--- a/plugins/module_utils/data_set.py
+++ b/plugins/module_utils/data_set.py
@@ -3073,7 +3073,7 @@ class GenerationDataGroup():
                         else:
                             raise GenerationDataGroupDeleteError(
                                 msg=f"GDG deletion failed. Raw error: {stderr}"
-                          )
+                            )
         else:
             return False
         return True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Override Zoau Error response with more descriptive error messages
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix #1985 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
data_set
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yml
 - name: Delete GDG base
     zos_data_set:
      name: "NAZARE.WDEPLOY.ANSIBLE.TEST"
      type: gdg
      state: absent
      force: true
     register: dataset_creation
  
   - name: Print dataset creation output
     debug:
      msg:
        - "Dataset creation output: {{dataset_creation }}"
```
```yml
The full traceback is:
  File "/tmp/ansible_zos_data_set_payload_ecjuam8_/ansible_zos_data_set_payload.zip/ansible_collections/ibm/ibm_zos_core/plugins/modules/zos_data_set.py", line 1965, in run_module
    current_changed = perform_data_set_operations(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ansible_zos_data_set_payload_ecjuam8_/ansible_zos_data_set_payload.zip/ansible_collections/ibm/ibm_zos_core/plugins/modules/zos_data_set.py", line 1463, in perform_data_set_operations
    changed = data_set.ensure_absent(force=force)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ansible_zos_data_set_payload_ecjuam8_/ansible_zos_data_set_payload.zip/ansible_collections/ibm/ibm_zos_core/plugins/module_utils/data_set.py", line 3065, in ensure_absent
    raise GenerationDataGroupDeleteError(
fatal: [zvm]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "batch": null,
            "block_size": null,
            "directory_blocks": null,
            "empty": false,
            "extended": false,
            "fifo": false,
            "force": true,
            "key_length": null,
            "key_offset": null,
            "limit": null,
            "name": "NAZARE.WDEPLOY.ANSIBLE.TEST",
            "noscratch": false,
            "purge": false,
            "record_format": "fb",
            "record_length": null,
            "replace": false,
            "scratch": false,
            "sms_data_class": null,
            "sms_management_class": null,
            "sms_storage_class": null,
            "space_primary": 5,
            "space_secondary": 3,
            "space_type": "m",
            "state": "absent",
            "tmp_hlq": null,
            "type": "gdg",
            "volumes": null
        }
    },
    "message": "",
    "msg": "GenerationDataGroupDeleteError('Data set deletion failed: the generation data set is currently in use by another job or session. Try deleting after ensuring no active usage.')",
    "names": [
        "NAZARE.WDEPLOY.ANSIBLE.TEST"
    ]
}

PLAY RECAP *******************************************************************************************************************************************************
zvm                        : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
