### PR TITLE
[Enabler] Remove dependencies from tests when testing zos_data_set

### DIFF
--- a/changelogs/fragments/2259-reduce-test-dep-zos_data_set.yml
+++ b/changelogs/fragments/2259-reduce-test-dep-zos_data_set.yml
@@ -1,0 +1,13 @@
+trivial:
+  - test_zos_backup_restore.py - Removed calls to zos_data_set that would increase the test case dependency between the modules.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2259).
+  - test_zos_blockinfile_func.py - Removed calls to zos_data_set that would increase the test case dependency between the modules.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2259).
+  - test_zos_job_output_func.py - Removed calls to zos_data_set that would increase the test case dependency between the modules.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2259).
+  - test_zos_job_query_func.py - Removed calls to zos_data_set that would increase the test case dependency between the modules.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2259).
+  - test_zos_mount_func.py - Removed calls to zos_data_set that would increase the test case dependency between the modules.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2259).
+  - test_zos_volume_init_func.py - Removed calls to zos_data_set that would increase the test case dependency between the modules.
+     (https://github.com/ansible-collections/ibm_zos_core/pull/2259).

--- a/plugins/action/zos_script.py
+++ b/plugins/action/zos_script.py
@@ -92,7 +92,7 @@ class ActionModule(ActionBase):
             copy_module_args = dict(
                 src=script_path,
                 dest=tempfile_path,
-                force=True,
+                replace=True,
                 is_binary=False,
                 encoding=module_args.get('encoding'),
                 use_template=module_args.get('use_template', False),

--- a/plugins/action/zos_unarchive.py
+++ b/plugins/action/zos_unarchive.py
@@ -100,7 +100,7 @@ class ActionModule(ActionBase):
                     src=source,
                     dest=dest,
                     dest_data_set=dest_data_set,
-                    force=force,
+                    replace=force,
                     is_binary=True,
                 )
             )

--- a/tests/functional/modules/test_zos_backup_restore.py
+++ b/tests/functional/modules/test_zos_backup_restore.py
@@ -73,10 +73,8 @@ def create_sequential_data_set_with_contents(
 ):
     if volume is not None:
         results = hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{data_set_name}'")
-        # results = hosts.all.zos_data_set(name=data_set_name, type="seq", volumes=volume)
     else:
         results = hosts.all.shell(cmd=f"dtouch -tseq '{data_set_name}'")
-        # results = hosts.all.zos_data_set(name=data_set_name, type="seq")
     assert_module_did_not_fail(results)
     results = hosts.all.shell("decho '{0}' {1}".format(contents, data_set_name))
     assert_module_did_not_fail(results)
@@ -96,7 +94,6 @@ def delete_data_set_or_file(hosts, name):
 
 def delete_data_set(hosts, data_set_name):
     hosts.all.shell(cmd=f"drm '{data_set_name}'")
-    # hosts.all.zos_data_set(name=data_set_name, state="absent")
 
 
 def delete_file(hosts, path):
@@ -903,17 +900,14 @@ def test_backup_gds(ansible_zos_module, dstype):
         data_set_name = get_tmp_ds_name(symbols=True).replace("-", "")
         backup_dest = get_tmp_ds_name(symbols=True).replace("-", "")
         results = hosts.all.shell(cmd=f"dtouch -tGDG -L3 '{data_set_name}'")
-        # results = hosts.all.zos_data_set(name=data_set_name, state="present", type="gdg", limit=3)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
         results = hosts.all.shell(cmd=f"dtouch -t{dstype} '{data_set_name}(+1)'")
-        # results = hosts.all.zos_data_set(name=f"{data_set_name}(+1)", state="present", type=dstype)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
         results = hosts.all.shell(cmd=f"dtouch -t{dstype} '{data_set_name}(+1)'")
-        # results = hosts.all.zos_data_set(name=f"{data_set_name}(+1)", state="present", type=dstype)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
@@ -942,17 +936,14 @@ def test_backup_into_gds(ansible_zos_module, dstype):
         data_set_name = get_tmp_ds_name(symbols=True).replace("-", "")
         ds_name = get_tmp_ds_name(symbols=True).replace("-", "")
         results = hosts.all.shell(cmd=f"dtouch -tGDG -L3 '{data_set_name}'")
-        # results = hosts.all.zos_data_set(name=data_set_name, state="present", type="gdg", limit=3)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
         results = hosts.all.shell(cmd=f"dtouch -t{dstype} '{data_set_name}(+1)'")
-        # results = hosts.all.zos_data_set(name=f"{data_set_name}(+1)", state="present", type=dstype)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
         results = hosts.all.shell(cmd=f"dtouch -t{dstype} '{ds_name}'")
-        # results = hosts.all.zos_data_set(name=ds_name, state="present", type=dstype)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None

--- a/tests/functional/modules/test_zos_backup_restore.py
+++ b/tests/functional/modules/test_zos_backup_restore.py
@@ -72,9 +72,11 @@ def create_sequential_data_set_with_contents(
     hosts, data_set_name, contents, volume=None
 ):
     if volume is not None:
-        results = hosts.all.zos_data_set(name=data_set_name, type="seq", volumes=volume)
+        results = hosts.all.shell(cmd=f"dtouch -tseq -V{volume} '{data_set_name}'")
+        # results = hosts.all.zos_data_set(name=data_set_name, type="seq", volumes=volume)
     else:
-        results = hosts.all.zos_data_set(name=data_set_name, type="seq")
+        results = hosts.all.shell(cmd=f"dtouch -tseq '{data_set_name}'")
+        # results = hosts.all.zos_data_set(name=data_set_name, type="seq")
     assert_module_did_not_fail(results)
     results = hosts.all.shell("decho '{0}' {1}".format(contents, data_set_name))
     assert_module_did_not_fail(results)
@@ -93,7 +95,8 @@ def delete_data_set_or_file(hosts, name):
 
 
 def delete_data_set(hosts, data_set_name):
-    hosts.all.zos_data_set(name=data_set_name, state="absent")
+    hosts.all.shell(cmd=f"drm '{data_set_name}'")
+    # hosts.all.zos_data_set(name=data_set_name, state="absent")
 
 
 def delete_file(hosts, path):
@@ -899,15 +902,18 @@ def test_backup_gds(ansible_zos_module, dstype):
         # We need to replace hyphens because of NAZARE-10614: dzip fails archiving data set names with '-'
         data_set_name = get_tmp_ds_name(symbols=True).replace("-", "")
         backup_dest = get_tmp_ds_name(symbols=True).replace("-", "")
-        results = hosts.all.zos_data_set(name=data_set_name, state="present", type="gdg", limit=3)
+        results = hosts.all.shell(cmd=f"dtouch -tGDG -L3 '{data_set_name}'")
+        # results = hosts.all.zos_data_set(name=data_set_name, state="present", type="gdg", limit=3)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
-        results = hosts.all.zos_data_set(name=f"{data_set_name}(+1)", state="present", type=dstype)
+        results = hosts.all.shell(cmd=f"dtouch -t{dstype} '{data_set_name}(+1)'")
+        # results = hosts.all.zos_data_set(name=f"{data_set_name}(+1)", state="present", type=dstype)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
-        results = hosts.all.zos_data_set(name=f"{data_set_name}(+1)", state="present", type=dstype)
+        results = hosts.all.shell(cmd=f"dtouch -t{dstype} '{data_set_name}(+1)'")
+        # results = hosts.all.zos_data_set(name=f"{data_set_name}(+1)", state="present", type=dstype)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
@@ -935,15 +941,18 @@ def test_backup_into_gds(ansible_zos_module, dstype):
         # We need to replace hyphens because of NAZARE-10614: dzip fails archiving data set names with '-'
         data_set_name = get_tmp_ds_name(symbols=True).replace("-", "")
         ds_name = get_tmp_ds_name(symbols=True).replace("-", "")
-        results = hosts.all.zos_data_set(name=data_set_name, state="present", type="gdg", limit=3)
+        results = hosts.all.shell(cmd=f"dtouch -tGDG -L3 '{data_set_name}'")
+        # results = hosts.all.zos_data_set(name=data_set_name, state="present", type="gdg", limit=3)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
-        results = hosts.all.zos_data_set(name=f"{data_set_name}(+1)", state="present", type=dstype)
+        results = hosts.all.shell(cmd=f"dtouch -t{dstype} '{data_set_name}(+1)'")
+        # results = hosts.all.zos_data_set(name=f"{data_set_name}(+1)", state="present", type=dstype)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None
-        results = hosts.all.zos_data_set(name=ds_name, state="present", type=dstype)
+        results = hosts.all.shell(cmd=f"dtouch -t{dstype} '{ds_name}'")
+        # results = hosts.all.zos_data_set(name=ds_name, state="present", type=dstype)
         for result in results.contacted.values():
             assert result.get("changed") is True
             assert result.get("module_stderr") is None

--- a/tests/functional/modules/test_zos_blockinfile_func.py
+++ b/tests/functional/modules/test_zos_blockinfile_func.py
@@ -464,10 +464,12 @@ def remove_uss_environment(ansible_zos_module, file):
 def set_ds_environment(ansible_zos_module, temp_file, ds_name, ds_type, content):
     hosts = ansible_zos_module
     hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
-    hosts.all.zos_data_set(name=ds_name, type=ds_type)
+    hosts.all.shell(cmd=f"dtouch -t{ds_type} '{ds_name}'")
+    # hosts.all.zos_data_set(name=ds_name, type=ds_type)
     if ds_type in ["pds", "pdse"]:
         ds_full_name = ds_name + "(MEM)"
-        hosts.all.zos_data_set(name=ds_full_name, state="present", type="member")
+        hosts.all.shell(cmd=f"decho '' '{ds_full_name}'")
+        # hosts.all.zos_data_set(name=ds_full_name, state="present", type="member")
         cmd_str = f"cp -CM {quote(temp_file)} \"//'{ds_full_name}'\""
     else:
         ds_full_name = ds_name
@@ -478,7 +480,8 @@ def set_ds_environment(ansible_zos_module, temp_file, ds_name, ds_type, content)
 
 def remove_ds_environment(ansible_zos_module, ds_name):
     hosts = ansible_zos_module
-    hosts.all.zos_data_set(name=ds_name, state="absent")
+    hosts.all.shell(cmd=f"drm '{ds_name}'")
+    # hosts.all.zos_data_set(name=ds_name, state="absent")
 
 #########################
 # USS test cases
@@ -1322,7 +1325,8 @@ def test_ds_tmp_hlq_option(ansible_zos_module):
     try:
         ds_full_name = get_tmp_ds_name()
         temp_file = get_random_file_name(dir=TMP_DIRECTORY)
-        hosts.all.zos_data_set(name=ds_full_name, type=ds_type, replace=True)
+        hosts.all.shell(cmd=f"dtouch -t{ds_type} '{ds_full_name}'")
+        # hosts.all.zos_data_set(name=ds_full_name, type=ds_type, replace=True)
         hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
         cmd_str = f"cp {quote(temp_file)} \"//'{ds_full_name}'\" "
         hosts.all.shell(cmd=cmd_str)
@@ -1336,7 +1340,8 @@ def test_ds_tmp_hlq_option(ansible_zos_module):
             for key in kwargs:
                 assert kwargs.get(key) in result.get(key)
     finally:
-        hosts.all.zos_data_set(name=ds_full_name, state="absent")
+        hosts.all.shell(cmd=f"drm '{ds_full_name}'")
+        # hosts.all.zos_data_set(name=ds_full_name, state="absent")
         hosts.all.file(name=temp_file, state="absent")
 
 
@@ -1410,7 +1415,8 @@ def test_ds_block_insertafter_eof_with_backup(ansible_zos_module, dstype, backup
     finally:
         remove_ds_environment(ansible_zos_module, ds_name)
         if backup_ds_name != "":
-            ansible_zos_module.all.zos_data_set(name=backup_ds_name, state="absent")
+            hosts.all.shell(cmd=f"drm '{backup_ds_name}'")
+            # ansible_zos_module.all.zos_data_set(name=backup_ds_name, state="absent")
 
 
 
@@ -1435,24 +1441,28 @@ def test_ds_block_insertafter_regex_force(ansible_zos_module, dstype):
     else:
         params["path"] = f"{default_data_set_name}({member_2})"
     try:
+        hosts.all.shell(cmd=f"dtouch -t{ds_type} '{default_data_set_name}'")
         # set up:
-        hosts.all.zos_data_set(
-            name=default_data_set_name,
-            state="present",
-            type=ds_type,
-            replace=True
-        )
+        # hosts.all.zos_data_set(
+        #     name=default_data_set_name,
+        #     state="present",
+        #     type=ds_type,
+        #     replace=True
+        # )
         hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
-        hosts.all.zos_data_set(
-            batch=[
-                {
-                    "name": f"{default_data_set_name}({member_1})",
-                    "type": "member",
-                    "state": "present", "replace": True, },
-                {   "name": params["path"], "type": "member",
-                    "state": "present", "replace": True, },
-            ]
-        )
+        # Create two empty members
+        hosts.all.shell(cmd=f"decho '' '{default_data_set_name}({member_1})'")
+        hosts.all.shell(cmd=f"decho '' '{params['path']}'")
+        # hosts.all.zos_data_set(
+        #     batch=[
+        #         {
+        #             "name": f"{default_data_set_name}({member_1})",
+        #             "type": "member",
+        #             "state": "present", "replace": True, },
+        #         {   "name": params["path"], "type": "member",
+        #             "state": "present", "replace": True, },
+        #     ]
+        # )
         # write memeber to verify cases
         if ds_type in ["pds", "pdse"]:
             cmd_str = "cp -CM {0} \"//'{1}'\"".format(quote(temp_file), params["path"])
@@ -1486,7 +1496,8 @@ def test_ds_block_insertafter_regex_force(ansible_zos_module, dstype):
         pid = list(ps_list_res.contacted.values())[0].get('stdout').strip().split(' ')[0]
         hosts.all.shell(cmd=f"kill 9 {pid.strip()}")
         hosts.all.shell(cmd='rm -r {0}'.format(path))
-        hosts.all.zos_data_set(name=default_data_set_name, state="absent")
+        hosts.all.shell(cmd=f"drm '{default_data_set_name}'")
+        # hosts.all.zos_data_set(name=default_data_set_name, state="absent")
 
 
 @pytest.mark.ds
@@ -1545,7 +1556,8 @@ def test_special_characters_ds_insert_block(ansible_zos_module):
     ds_name = get_tmp_ds_name(5, 5, symbols=True)
     backup = get_tmp_ds_name(6, 6, symbols=True)
     try:
-        result = hosts.all.zos_data_set(name=ds_name, type="seq", state="present")
+        hosts.all.shell(cmd=f"dtouch -tseq '{ds_name}'")
+        # result = hosts.all.zos_data_set(name=ds_name, type="seq", state="present")
 
         params["src"] = ds_name
         results = hosts.all.zos_blockinfile(**params)
@@ -1613,7 +1625,8 @@ def test_special_characters_ds_insert_block(ansible_zos_module):
     ds_name = get_tmp_ds_name(5, 5, symbols=True)
     backup = get_tmp_ds_name(6, 6, symbols=True)
     try:
-        result = hosts.all.zos_data_set(name=ds_name, type="seq", state="present")
+        hosts.all.shell(cmd=f"dtouch -tseq '{ds_name}'")
+        # result = hosts.all.zos_data_set(name=ds_name, type="seq", state="present")
 
         params["src"] = ds_name
         results = hosts.all.zos_blockinfile(**params)
@@ -1715,7 +1728,8 @@ def test_ds_not_supported(ansible_zos_module, dstype):
     ds_name = get_tmp_ds_name()
     try:
         ds_name = ds_name.upper() + "." + ds_type
-        results = hosts.all.zos_data_set(name=ds_name, type=ds_type, replace='yes')
+        hosts.all.shell(cmd=f"dtouch -t{ds_type} '{ds_name}'")
+        # results = hosts.all.zos_data_set(name=ds_name, type=ds_type, replace='yes')
         for result in results.contacted.values():
             assert result.get("changed") is True
         params["path"] = ds_name
@@ -1724,7 +1738,8 @@ def test_ds_not_supported(ansible_zos_module, dstype):
             assert result.get("changed") is False
             assert result.get("msg") == "VSAM data set type is NOT supported"
     finally:
-        hosts.all.zos_data_set(name=ds_name, state="absent")
+        hosts.all.shell(cmd=f"drm '{ds_name}'")
+        # hosts.all.zos_data_set(name=ds_name, state="absent")
 
 
 # Enhancemed #1339
@@ -1746,30 +1761,34 @@ def test_ds_block_insertafter_regex_fail(ansible_zos_module, dstype):
     params["path"] = f"{default_data_set_name}({member_2})"
     content = TEST_CONTENT
     try:
+        hosts.all.shell(cmd=f"dtouch -t{ds_type} '{default_data_set_name}'")
         # set up:
-        hosts.all.zos_data_set(
-            name=default_data_set_name,
-            state="present",
-            type=ds_type,
-            replace=True
-        )
+        # hosts.all.zos_data_set(
+        #     name=default_data_set_name,
+        #     state="present",
+        #     type=ds_type,
+        #     replace=True
+        # )
         hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
-        hosts.all.zos_data_set(
-            batch=[
-                {
-                    "name": f"{default_data_set_name}({member_1})",
-                    "type": "member",
-                    "state": "present",
-                    "replace": True,
-                },
-                {
-                    "name": params["path"],
-                    "type": "member",
-                    "state": "present",
-                    "replace": True,
-                },
-            ]
-        )
+        # Create two empty members
+        hosts.all.shell(cmd=f"decho '' '{default_data_set_name}({member_1})'")
+        hosts.all.shell(cmd=f"decho '' '{params['path']}'")
+        # hosts.all.zos_data_set(
+        #     batch=[
+        #         {
+        #             "name": f"{default_data_set_name}({member_1})",
+        #             "type": "member",
+        #             "state": "present",
+        #             "replace": True,
+        #         },
+        #         {
+        #             "name": params["path"],
+        #             "type": "member",
+        #             "state": "present",
+        #             "replace": True,
+        #         },
+        #     ]
+        # )
         cmd_str = "cp -CM {0} \"//'{1}'\"".format(quote(temp_file) ,params["path"])
         hosts.all.shell(cmd=cmd_str)
         results = hosts.all.shell(cmd="cat \"//'{0}'\" | wc -l ".format(params["path"]))
@@ -1796,4 +1815,5 @@ def test_ds_block_insertafter_regex_fail(ansible_zos_module, dstype):
         pid = list(ps_list_res.contacted.values())[0].get('stdout').strip().split(' ')[0]
         hosts.all.shell(cmd=f"kill 9 {pid.strip()}")
         hosts.all.shell(cmd='rm -r {0}'.format(path))
-        hosts.all.zos_data_set(name=default_data_set_name, state="absent")
+        hosts.all.shell(cmd=f"drm '{default_data_set_name}'")
+        # hosts.all.zos_data_set(name=default_data_set_name, state="absent")

--- a/tests/functional/modules/test_zos_blockinfile_func.py
+++ b/tests/functional/modules/test_zos_blockinfile_func.py
@@ -1728,7 +1728,7 @@ def test_ds_not_supported(ansible_zos_module, dstype):
     ds_name = get_tmp_ds_name()
     try:
         ds_name = ds_name.upper() + "." + ds_type
-        hosts.all.shell(cmd=f"dtouch -t{ds_type} '{ds_name}'")
+        results = hosts.all.shell(cmd=f"dtouch -t{ds_type} '{ds_name}'")
         # results = hosts.all.zos_data_set(name=ds_name, type=ds_type, replace='yes')
         for result in results.contacted.values():
             assert result.get("changed") is True

--- a/tests/functional/modules/test_zos_job_query_func.py
+++ b/tests/functional/modules/test_zos_job_query_func.py
@@ -98,20 +98,18 @@ TEMP_PATH = "/tmp/"
 def test_zos_job_id_query_multi_wildcards_func(ansible_zos_module):
     try:
         hosts = ansible_zos_module
-        jdata_set_name = get_tmp_ds_name()
+        data_set_name = get_tmp_ds_name()
         temp_path = get_random_file_name(dir=TEMP_PATH)
         hosts.all.file(path=temp_path, state="directory")
         hosts.all.shell(
             cmd=f"echo {quote(JCLQ_FILE_CONTENTS)} > {temp_path}/SAMPLE"
         )
-        hosts.all.zos_data_set(
-            name=jdata_set_name, state="present", type="pds", replace=True
-        )
+        hosts.all.shell(cmd=f"dtouch -tpds '{data_set_name}'")
         hosts.all.shell(
-            cmd=f"cp {temp_path}/SAMPLE \"//'{jdata_set_name}(SAMPLE)'\""
+            cmd=f"cp {temp_path}/SAMPLE \"//'{data_set_name}(SAMPLE)'\""
         )
         results = hosts.all.zos_job_submit(
-            src=f"{jdata_set_name}(SAMPLE)", remote_src=True, wait_time=10
+            src=f"{data_set_name}(SAMPLE)", remote_src=True, wait_time=10
         )
         for result in results.contacted.values():
             assert result.get("changed") is True
@@ -188,27 +186,25 @@ def test_zos_job_id_query_multi_wildcards_func(ansible_zos_module):
 
     finally:
         hosts.all.file(path=temp_path, state="absent")
-        hosts.all.zos_data_set(name=jdata_set_name, state="absent")
+        hosts.all.shell(cmd=f"drm '{data_set_name}'")
 
 
 # test to show multi wildcard in Job_name query won't crash the search
 def test_zos_job_name_query_multi_wildcards_func(ansible_zos_module):
     try:
         hosts = ansible_zos_module
-        ndata_set_name = get_tmp_ds_name()
+        data_set_name = get_tmp_ds_name()
         temp_path = get_random_file_name(dir=TEMP_PATH)
         hosts.all.file(path=temp_path, state="directory")
         hosts.all.shell(
             cmd=f"echo {quote(JCLQ_FILE_CONTENTS)} > {temp_path}/SAMPLE"
         )
-        hosts.all.zos_data_set(
-            name=ndata_set_name, state="present", type="pds", replace=True
-        )
+        hosts.all.shell(cmd=f"dtouch -tpds '{data_set_name}'")
         hosts.all.shell(
-            cmd=f"cp {temp_path}/SAMPLE \"//'{ndata_set_name}(SAMPLE)'\""
+            cmd=f"cp {temp_path}/SAMPLE \"//'{data_set_name}(SAMPLE)'\""
         )
         results = hosts.all.zos_job_submit(
-            src=f"{ndata_set_name}(SAMPLE)", remote_src=True, wait_time=10
+            src=f"{data_set_name}(SAMPLE)", remote_src=True, wait_time=10
         )
         for result in results.contacted.values():
             assert result.get("changed") is True
@@ -283,7 +279,7 @@ def test_zos_job_name_query_multi_wildcards_func(ansible_zos_module):
                 assert rc.get("msg_txt") == "CC"
     finally:
         hosts.all.file(path=temp_path, state="absent")
-        hosts.all.zos_data_set(name=ndata_set_name, state="absent")
+        hosts.all.shell(cmd=f"drm '{data_set_name}'")
 
 
 def test_zos_job_id_query_short_ids_func(ansible_zos_module):

--- a/tests/functional/modules/test_zos_lineinfile_func.py
+++ b/tests/functional/modules/test_zos_lineinfile_func.py
@@ -1209,7 +1209,7 @@ def test_ds_line_force(ansible_zos_module, dstype):
         hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
         # Create two empty members
         hosts.all.shell(cmd=f"decho '' '{default_data_set_name}({member_1})'")
-        hosts.all.shell(cmd=f"decho '' '{params["path"]}'")
+        hosts.all.shell(cmd=f"decho '' '{params['path']}'")
         # write member to verify cases
         if ds_type in ["pds", "pdse"]:
             cmd_str = "cp -CM {0} \"//'{1}'\"".format(quote(temp_file), params["path"])
@@ -1269,7 +1269,7 @@ def test_ds_line_force_fail(ansible_zos_module, dstype):
         hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
         # Create two empty members
         hosts.all.shell(cmd=f"decho '' '{default_data_set_name}({member_1})'")
-        hosts.all.shell(cmd=f"decho '' '{params["path"]}'")
+        hosts.all.shell(cmd=f"decho '' '{params['path']}'")
         cmd_str = "cp -CM {0} \"//'{1}'\"".format(quote(temp_file), params["path"])
         hosts.all.shell(cmd=cmd_str)
         results = hosts.all.shell(cmd="cat \"//'{0}'\" | wc -l ".format(params["path"]))

--- a/tests/functional/modules/test_zos_lineinfile_func.py
+++ b/tests/functional/modules/test_zos_lineinfile_func.py
@@ -275,10 +275,10 @@ def remove_uss_environment(ansible_zos_module, file):
 def set_ds_environment(ansible_zos_module, temp_file, ds_name, ds_type, content):
     hosts = ansible_zos_module
     hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
-    hosts.all.zos_data_set(name=ds_name, type=ds_type)
+    hosts.all.shell(cmd=f"dtouch -t{ds_type} '{ds_name}'")
     if ds_type in ["pds", "pdse"]:
         ds_full_name = ds_name + "(MEM)"
-        hosts.all.zos_data_set(name=ds_full_name, state="present", type="member")
+        hosts.all.shell(cmd=f"decho '' '{ds_full_name}'")
         cmd_str = f"cp -CM {quote(temp_file)} \"//'{ds_full_name}'\""
     else:
         ds_full_name = ds_name
@@ -289,7 +289,7 @@ def set_ds_environment(ansible_zos_module, temp_file, ds_name, ds_type, content)
 
 def remove_ds_environment(ansible_zos_module, ds_name):
     hosts = ansible_zos_module
-    hosts.all.zos_data_set(name=ds_name, state="absent")
+    hosts.all.shell(cmd=f"drm '{ds_name}'")
 
 # supported data set types
 ds_type = ['seq', 'pds', 'pdse']
@@ -966,7 +966,7 @@ def test_special_characters_ds_insert_line(ansible_zos_module):
     backup = get_tmp_ds_name(6, 6, symbols=True)
     try:
         # Set environment
-        result = hosts.all.zos_data_set(name=ds_name, type="seq", state="present")
+        hosts.all.shell(cmd=f"dtouch -tseq '{ds_name}'")
 
         params["src"] = ds_name
         results = hosts.all.zos_lineinfile(**params)
@@ -1139,7 +1139,7 @@ def test_ds_tmp_hlq_option(ansible_zos_module):
     try:
         ds_full_name = get_tmp_ds_name()
         temp_file = get_random_file_name(dir=TMP_DIRECTORY)
-        hosts.all.zos_data_set(name=ds_full_name, type=ds_type, replace=True)
+        hosts.all.shell(cmd=f"dtouch -t{ds_type} '{ds_full_name}'")
         hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
         cmd_str = f"cp {quote(temp_file)} \"//'{ds_full_name}'\" "
         hosts.all.shell(cmd=cmd_str)
@@ -1154,7 +1154,7 @@ def test_ds_tmp_hlq_option(ansible_zos_module):
             for key in kwargs:
                 assert kwargs.get(key) in result.get(key)
     finally:
-        hosts.all.zos_data_set(name=ds_full_name, state="absent")
+        hosts.all.shell(cmd=f"drm '{ds_full_name}'")
 
 
 ## Non supported test cases
@@ -1171,7 +1171,7 @@ def test_ds_not_supported(ansible_zos_module, dstype):
     }
     try:
         ds_name = get_tmp_ds_name() + "." + ds_type
-        results = hosts.all.zos_data_set(name=ds_name, type=ds_type, replace='yes')
+        results = hosts.all.shell(cmd=f"dtouch -t{ds_type} '{ds_name}'")
         for result in results.contacted.values():
             assert result.get("changed") is True
         params["path"] = ds_name
@@ -1180,7 +1180,7 @@ def test_ds_not_supported(ansible_zos_module, dstype):
             assert result.get("changed") is False
             assert result.get("msg") == "VSAM data set type is NOT supported"
     finally:
-        hosts.all.zos_data_set(name=ds_name, state="absent")
+        hosts.all.shell(cmd=f"drm '{ds_name}'")
 
 
 @pytest.mark.ds
@@ -1205,22 +1205,12 @@ def test_ds_line_force(ansible_zos_module, dstype):
         params["path"] = f"{default_data_set_name}({member_2})"
     try:
         # set up:
-        hosts.all.zos_data_set(
-            name=default_data_set_name,
-            state="present",
-            type=ds_type,
-            replace=True
-        )
+        hosts.all.shell(cmd=f"dtouch -t{ds_type} '{default_data_set_name}'")
         hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
-        hosts.all.zos_data_set(
-            batch=[
-                {   "name": f"{default_data_set_name}({member_1})",
-                    "type": "member", "state": "present", "replace": True, },
-                {   "name": params["path"], "type": "member",
-                    "state": "present", "replace": True, },
-            ]
-        )
-        # write memeber to verify cases
+        # Create two empty members
+        hosts.all.shell(cmd=f"decho '' '{default_data_set_name}({member_1})'")
+        hosts.all.shell(cmd=f"decho '' '{params["path"]}'")
+        # write member to verify cases
         if ds_type in ["pds", "pdse"]:
             cmd_str = "cp -CM {0} \"//'{1}'\"".format(quote(temp_file), params["path"])
         else:
@@ -1253,7 +1243,7 @@ def test_ds_line_force(ansible_zos_module, dstype):
         pid = list(ps_list_res.contacted.values())[0].get('stdout').strip().split(' ')[0]
         hosts.all.shell(cmd=f"kill 9 {pid.strip()}")
         hosts.all.shell(cmd='rm -r {0}'.format(path))
-        hosts.all.zos_data_set(name=default_data_set_name, state="absent")
+        hosts.all.shell(cmd=f"drm '{default_data_set_name}*'")
 
 
 @pytest.mark.ds
@@ -1275,21 +1265,11 @@ def test_ds_line_force_fail(ansible_zos_module, dstype):
     content = TEST_CONTENT
     try:
         # set up:
-        hosts.all.zos_data_set(
-            name=default_data_set_name,
-            state="present",
-            type=ds_type,
-            replace=True
-        )
+        hosts.all.shell(cmd=f"dtouch -t{ds_type} '{default_data_set_name}'")
         hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
-        hosts.all.zos_data_set(
-            batch=[
-                {   "name": f"{default_data_set_name}({member_1})",
-                    "type": "member", "state": "present", "replace": True, },
-                {   "name": params["path"], "type": "member",
-                    "state": "present", "replace": True, },
-            ]
-        )
+        # Create two empty members
+        hosts.all.shell(cmd=f"decho '' '{default_data_set_name}({member_1})'")
+        hosts.all.shell(cmd=f"decho '' '{params["path"]}'")
         cmd_str = "cp -CM {0} \"//'{1}'\"".format(quote(temp_file), params["path"])
         hosts.all.shell(cmd=cmd_str)
         results = hosts.all.shell(cmd="cat \"//'{0}'\" | wc -l ".format(params["path"]))
@@ -1316,7 +1296,7 @@ def test_ds_line_force_fail(ansible_zos_module, dstype):
         pid = list(ps_list_res.contacted.values())[0].get('stdout').strip().split(' ')[0]
         hosts.all.shell(cmd=f"kill 9 {pid.strip()}")
         hosts.all.shell(cmd='rm -r {0}'.format(path))
-        hosts.all.zos_data_set(name=default_data_set_name, state="absent")
+        hosts.all.shell(cmd=f"drm '{default_data_set_name}*'")
 
 
 @pytest.mark.ds
@@ -1411,10 +1391,10 @@ def test_ds_encoding(ansible_zos_module, encoding, dstype):
     try:
         hosts.all.shell(cmd=f"echo \"{content}\" > {temp_file}")
         hosts.all.shell(cmd=f"iconv -f IBM-1047 -t {params['encoding']} temp_file > temp_file ")
-        hosts.all.zos_data_set(name=ds_name, type=ds_type)
+        hosts.all.shell(cmd=f"dtouch -t{ds_type} '{ds_name}'")
         if ds_type in ["pds", "pdse"]:
             ds_full_name = ds_name + "(MEM)"
-            hosts.all.zos_data_set(name=ds_full_name, state="present", type="member")
+            hosts.all.shell(cmd=f"decho '' '{ds_full_name}'")
             cmd_str = f"cp -CM {quote(temp_file)} \"//'{ds_full_name}'\""
         else:
             ds_full_name = ds_name

--- a/tests/functional/modules/test_zos_mount_func.py
+++ b/tests/functional/modules/test_zos_mount_func.py
@@ -209,14 +209,7 @@ def test_basic_mount_with_bpx_nomarker_nobackup(ansible_zos_module, volumes_on_s
     dest = get_tmp_ds_name()
     dest_path = dest + "(AUTO1)"
 
-    hosts.all.zos_data_set(
-        name=dest,
-        type="pdse",
-        space_primary=5,
-        space_type="m",
-        record_format="fba",
-        record_length=80,
-    )
+    hosts.all.shell(cmd=f"dtouch -tpdse -s5M -IFBA -l80 {dest}")
     print("\nbnn-Copying {0} to {1}\n".format(tmp_file_filename, dest_path))
     hosts.all.zos_copy(
         src=tmp_file_filename,
@@ -252,15 +245,7 @@ def test_basic_mount_with_bpx_nomarker_nobackup(ansible_zos_module, volumes_on_s
         )
         hosts.all.file(path=tmp_file_filename, state="absent")
         hosts.all.file(path="/pythonx/", state="absent")
-        hosts.all.zos_data_set(
-            name=dest,
-            state="absent",
-            type="pdse",
-            space_primary=5,
-            space_type="m",
-            record_format="fba",
-            record_length=80,
-        )
+        hosts.all.shell(cmd=f"drm {dest}")
 
 def test_basic_mount_with_bpx_no_utf_8_characters(ansible_zos_module, volumes_on_systems):
     hosts = ansible_zos_module
@@ -365,14 +350,7 @@ def test_basic_mount_with_bpx_marker_backup(ansible_zos_module, volumes_on_syste
     dest_path = dest + "(AUTO2)"
     back_dest_path = dest + "(AUTO2BAK)"
 
-    hosts.all.zos_data_set(
-        name=dest,
-        type="pdse",
-        space_primary=5,
-        space_type="m",
-        record_format="fba",
-        record_length=80,
-    )
+    hosts.all.shell(cmd=f"dtouch -tpdse -s5M -IFBA -l80 {dest}")
 
     print("\nbcb-Copying {0} to {1}\n".format(tmp_file_filename, dest_path))
     hosts.all.zos_copy(
@@ -438,15 +416,7 @@ def test_basic_mount_with_bpx_marker_backup(ansible_zos_module, volumes_on_syste
         hosts.all.file(path=tmp_file_filename, state="absent")
         hosts.all.file(path=test_tmp_file_filename, state="absent")
         hosts.all.file(path="/pythonx/", state="absent")
-        hosts.all.zos_data_set(
-            name=dest,
-            state="absent",
-            type="pdse",
-            space_primary=5,
-            space_type="m",
-            record_format="fba",
-            record_length=80,
-        )
+        hosts.all.shell(cmd=f"drm {dest}")
 
 def test_basic_mount_with_tmp_hlq_option(ansible_zos_module, volumes_on_systems):
     hosts = ansible_zos_module
@@ -464,7 +434,7 @@ def test_basic_mount_with_tmp_hlq_option(ansible_zos_module, volumes_on_systems)
     finally:
         tmphlq = "TMPHLQ"
         persist_data_set = get_tmp_ds_name()
-        hosts.all.zos_data_set(name=persist_data_set, state="present", type="seq")
+        hosts.all.shell(cmd=f"dtouch -tseq {persist_data_set}")
         unmount_result = hosts.all.zos_mount(
             src=srcfn,
             path="/pythonx",
@@ -479,7 +449,7 @@ def test_basic_mount_with_tmp_hlq_option(ansible_zos_module, volumes_on_systems)
             stdin="",
         )
 
-        hosts.all.zos_data_set(name=persist_data_set, state="absent")
+        hosts.all.shell(cmd=f"drm {persist_data_set}")
         for result in unmount_result.values():
             assert result.get("rc") == 0
             assert result.get("stdout") != ""

--- a/tests/functional/modules/test_zos_volume_init_func.py
+++ b/tests/functional/modules/test_zos_volume_init_func.py
@@ -530,7 +530,8 @@ def test_no_existing_data_sets_check(ansible_zos_module, volumes_unit_on_systems
         hosts.all.zos_operator(cmd=f"vary {address},online")
 
         # allocate data set to volume
-        hosts.all.zos_data_set(name=dataset, type='pds', volumes=volume)
+        hosts.all.shell(cmd=f"dtouch -tpds -V{volume} '{name}'")
+        # hosts.all.zos_data_set(name=dataset, type='pds', volumes=volume)
 
         # take volume back offline
         hosts.all.zos_operator(cmd=f"vary {address},offline")
@@ -550,7 +551,8 @@ def test_no_existing_data_sets_check(ansible_zos_module, volumes_unit_on_systems
         hosts.all.zos_operator(cmd=f"vary {address},online")
 
         # remove data set
-        hosts.all.zos_data_set(name=dataset, state='absent')
+        hosts.all.shell(cmd=f"drm '{name}'")
+        # hosts.all.zos_data_set(name=dataset, state='absent')
 
 
 # Note - technically verify_offline is not REQUIRED but it defaults to True

--- a/tests/functional/modules/test_zos_volume_init_func.py
+++ b/tests/functional/modules/test_zos_volume_init_func.py
@@ -551,7 +551,6 @@ def test_no_existing_data_sets_check(ansible_zos_module, volumes_unit_on_systems
 
         # remove data set
         hosts.all.shell(cmd=f"drm '{dataset}'")
-        # hosts.all.zos_data_set(name=dataset, state='absent')
 
 
 # Note - technically verify_offline is not REQUIRED but it defaults to True

--- a/tests/functional/modules/test_zos_volume_init_func.py
+++ b/tests/functional/modules/test_zos_volume_init_func.py
@@ -530,7 +530,7 @@ def test_no_existing_data_sets_check(ansible_zos_module, volumes_unit_on_systems
         hosts.all.zos_operator(cmd=f"vary {address},online")
 
         # allocate data set to volume
-        hosts.all.shell(cmd=f"dtouch -tpds -V{volume} '{name}'")
+        hosts.all.shell(cmd=f"dtouch -tpds -V{volume} '{dataset}'")
         # hosts.all.zos_data_set(name=dataset, type='pds', volumes=volume)
 
         # take volume back offline
@@ -551,7 +551,7 @@ def test_no_existing_data_sets_check(ansible_zos_module, volumes_unit_on_systems
         hosts.all.zos_operator(cmd=f"vary {address},online")
 
         # remove data set
-        hosts.all.shell(cmd=f"drm '{name}'")
+        hosts.all.shell(cmd=f"drm '{dataset}'")
         # hosts.all.zos_data_set(name=dataset, state='absent')
 
 

--- a/tests/functional/modules/test_zos_volume_init_func.py
+++ b/tests/functional/modules/test_zos_volume_init_func.py
@@ -490,7 +490,7 @@ def test_bad_param_volid_value_too_long(ansible_zos_module, volumes_unit_on_syst
     hosts.all.zos_operator(cmd=f"vary {address},online")
 
 
-# Note - volume needs to be sms managed for zos_data_set to work. Possible
+# Note - volume needs to be sms managed for data set creation to work. Possible
 #        points of failure are:
 #        unable to init volume first time around
 #        unable to allocate data set
@@ -531,7 +531,6 @@ def test_no_existing_data_sets_check(ansible_zos_module, volumes_unit_on_systems
 
         # allocate data set to volume
         hosts.all.shell(cmd=f"dtouch -tpds -V{volume} '{dataset}'")
-        # hosts.all.zos_data_set(name=dataset, type='pds', volumes=volume)
 
         # take volume back offline
         hosts.all.zos_operator(cmd=f"vary {address},offline")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removes calls to zos_data_set in various test suite files, that results in fewer test files being tested when making changes to zos_data_set code coming from :
```
(AC2.18PY3.13) fernandoflores@192 tests % ./dependencyfinder.py -p .. -b dev -s functional/modules/test_module_security.py  -m
../tests/functional/modules/test_zos_apf_func.py ../tests/functional/modules/test_zos_volume_init_func.py ../tests/functional/modules/test_zos_mount_func.py ../tests/functional/modules/test_zos_find_func.py ../tests/functional/modules/test_zos_blockinfile_func.py ../tests/functional/modules/test_zos_backup_restore.py ../tests/functional/modules/test_zos_job_submit_func.py ../tests/functional/modules/test_zos_job_query_func.py ../tests/functional/modules/test_zos_zfs_resize_func.py ../tests/functional/modules/test_zos_encode_func.py ../tests/functional/modules/test_zos_stat_func.py ../tests/functional/modules/test_zos_archive_func.py ../tests/functional/modules/test_zos_fetch_func.py ../tests/functional/modules/test_zos_copy_func.py ../tests/functional/modules/test_zos_mvs_raw_func.py ../tests/functional/modules/test_zos_lineinfile_func.py ../tests/functional/modules/test_zos_data_set_func.py ../tests/functional/modules/test_zos_unarchive_func.py ../tests/functional/modules/test_zos_job_output_func.py

```
to

```

(AC2.18PY3.13) fernandoflores@192 tests % ./dependencyfinder.py -p .. -b remove-test-dep-zos_data_set  -s functional/modules/test_module_security.py  -m
../tests/functional/modules/test_zos_encode_func.py ../tests/functional/modules/test_zos_volume_init_func.py ../tests/functional/modules/test_zos_archive_func.py ../tests/functional/modules/test_zos_job_submit_func.py ../tests/functional/modules/test_zos_mount_func.py ../tests/functional/modules/test_zos_fetch_func.py ../tests/functional/modules/test_zos_zfs_resize_func.py ../tests/functional/modules/test_zos_find_func.py ../tests/functional/modules/test_zos_data_set_func.py ../tests/functional/modules/test_zos_stat_func.py ../tests/functional/modules/test_zos_unarchive_func.py ../tests/functional/modules/test_zos_mvs_raw_func.py ../tests/functional/modules/test_zos_apf_func.py ../tests/functional/modules/test_zos_copy_func.py
```

which results in less test files being tested from 19 files to 14 and about 1 hour and a half savings when testing changes in zos_data_set.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
