### PR TITLE
[Enabler] Stabilize zos_archive tests

### DIFF
--- a/changelogs/fragments/2265-stabilize-zos_archive-tests.yml
+++ b/changelogs/fragments/2265-stabilize-zos_archive-tests.yml
@@ -1,0 +1,6 @@
+trivial:
+  - test_zos_archive_func.py - Modify the way dls is executed in zos_archive tests
+    adding a single quote wrap around wildcard searches.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2265).
+  - test_zos_encode_func.py - Modified zos_encode test cases so that no temporary files are being left behind.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2265).

--- a/tests/functional/modules/test_zos_archive_func.py
+++ b/tests/functional/modules/test_zos_archive_func.py
@@ -536,7 +536,7 @@ def test_mvs_archive_single_dataset(
             assert result.get("changed") is True
             assert result.get("dest") == archive_data_set
             assert src_data_set in result.get("archived")
-            cmd_result = hosts.all.shell(cmd = f"dls {hlq}.*")
+            cmd_result = hosts.all.shell(cmd = f"dls '{hlq}.*'")
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
     finally:
@@ -635,7 +635,7 @@ def test_mvs_archive_single_dataset_use_adrdssu(
             assert result.get("changed") is True
             assert result.get("dest") == archive_data_set
             assert src_data_set in result.get("archived")
-            cmd_result = hosts.all.shell(cmd = f"dls {hlq}.*")
+            cmd_result = hosts.all.shell(cmd = f"dls '{hlq}.*'")
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
     finally:
@@ -717,7 +717,7 @@ def test_mvs_archive_single_data_set_remove_target(ansible_zos_module, ds_format
             assert result.get("changed") is True
             assert result.get("dest") == archive_data_set
             assert src_data_set in result.get("archived")
-            cmd_result = hosts.all.shell(cmd = f"dls {hlq}.*")
+            cmd_result = hosts.all.shell(cmd = f"dls '{hlq}.*'")
 
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
@@ -791,7 +791,7 @@ def test_mvs_archive_multiple_data_sets(ansible_zos_module, ds_format, data_set)
             assert result.get("dest") == archive_data_set
             for ds in target_ds_list:
                 assert ds.get("name") in result.get("archived")
-            cmd_result = hosts.all.shell(cmd = f"dls {hlq}.*")
+            cmd_result = hosts.all.shell(cmd = f"dls '{hlq}.*'")
 
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
@@ -869,7 +869,7 @@ def test_mvs_archive_multiple_data_sets_with_exclusion(ansible_zos_module, ds_fo
                     assert exclude not in result.get("archived")
                 else:
                     assert ds.get("name") in result.get("archived")
-            cmd_result = hosts.all.shell(cmd = f"dls {hlq}.*")
+            cmd_result = hosts.all.shell(cmd = f"dls '{hlq}.*'")
 
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
@@ -941,7 +941,7 @@ def test_mvs_archive_multiple_data_sets_and_remove(ansible_zos_module, ds_format
         for result in archive_result.contacted.values():
             assert result.get("changed") is True
             assert result.get("dest") == archive_data_set
-            cmd_result = hosts.all.shell(cmd = f"dls {hlq}.*")
+            cmd_result = hosts.all.shell(cmd = f"dls '{hlq}.*'")
 
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
@@ -1027,7 +1027,7 @@ def test_mvs_archive_multiple_data_sets_with_missing(ansible_zos_module, ds_form
                     assert ds.get("name") not in result.get("archived")
                 else:
                     assert ds.get("name") in result.get("archived")
-            cmd_result = hosts.all.shell(cmd = f"dls {hlq}.*")
+            cmd_result = hosts.all.shell(cmd = f"dls '{hlq}.*'")
 
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
@@ -1122,7 +1122,7 @@ def test_mvs_archive_single_dataset_force_lock(ansible_zos_module, ds_format, da
             assert result.get("changed") is True
             assert result.get("dest") == archive_data_set
             assert src_data_set in result.get("archived")
-            cmd_result = hosts.all.shell(cmd = f"dls {hlq}.*")
+            cmd_result = hosts.all.shell(cmd = f"dls '{hlq}.*'")
 
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
@@ -1306,7 +1306,7 @@ def test_mvs_archive_single_dataset_encoding(
             assert result.get("changed") is True
             assert result.get("dest") == archive_data_set
             assert src_data_set in result.get("archived")
-            cmd_result = hosts.all.shell(cmd = f"dls {hlq}.*")
+            cmd_result = hosts.all.shell(cmd = f"dls '{hlq}.*'")
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
     finally:
@@ -1380,7 +1380,7 @@ def test_mvs_archive_multiple_dataset_pattern_encoding(ansible_zos_module, ds_fo
                 assert result.get("changed") is True
                 assert result.get("dest") == archive_data_set
                 assert ds_name in result.get("archived")
-            cmd_result = hosts.all.shell(cmd=f"dls {archive_data_set}")
+            cmd_result = hosts.all.shell(cmd=f"dls '{archive_data_set}'")
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
 
@@ -1459,7 +1459,7 @@ def test_mvs_archive_multiple_dataset_pattern_encoding_skip_encoding(ansible_zos
                 assert result.get("changed") is True
                 assert result.get("dest") == archive_data_set
                 assert ds_name in result.get("archived")
-            cmd_result = hosts.all.shell(cmd=f"dls {archive_data_set}")
+            cmd_result = hosts.all.shell(cmd=f"dls '{archive_data_set}'")
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
 
@@ -1579,7 +1579,7 @@ def test_mvs_archive_multiple_dataset_pattern_encoding_revert_src_encoding(ansib
                 assert result.get("changed") is True
                 assert result.get("dest") == archive_data_set
                 assert ds_name in result.get("archived")
-            cmd_result = hosts.all.shell(cmd=f"dls {archive_data_set}")
+            cmd_result = hosts.all.shell(cmd=f"dls '{archive_data_set}'")
             for c_result in cmd_result.contacted.values():
                 assert archive_data_set in c_result.get("stdout")
 

--- a/tests/functional/modules/test_zos_encode_func.py
+++ b/tests/functional/modules/test_zos_encode_func.py
@@ -349,7 +349,7 @@ def test_uss_encoding_conversion_mvs_ps_to_uss_file(ansible_zos_module):
         hosts = ansible_zos_module
         mvs_ps = get_tmp_ds_name()
         hosts.all.zos_data_set(name=mvs_ps, state="present", type="seq")
-        hosts.all.copy(content=TEST_DATA, dest=mvs_ps)
+        hosts.all.zos_copy(content=TEST_DATA, dest=mvs_ps)
         hosts.all.copy(content="test", dest=uss_dest_file)
         results = hosts.all.zos_encode(
             src=mvs_ps,
@@ -455,7 +455,7 @@ def test_uss_encoding_conversion_mvs_pds_member_to_uss_file(ansible_zos_module):
         hosts.all.zos_data_set(
             name=mvs_pds_member, type="member", state="present"
         )
-        hosts.all.copy(content=TEST_DATA, dest=mvs_pds_member)
+        hosts.all.zos_copy(content=TEST_DATA, dest=mvs_pds_member)
         hosts.all.copy(content="test", dest=uss_dest_file)
         results = hosts.all.zos_encode(
             src=mvs_pds_member,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Addresses part of the issue of #2258, in that PR I removed a zos_lineinfile code that left some files behind, now after finding some other tests in zos_encode that left files behind I'm making the following changes:
1.- Modify the `zos_encode` test cases so that no temporary files are being left behind.
2.- Modify the way `dls` is executed in `zos_archive` tests, so that if in the future there is a temporary file like `ANSIBLE.TEST.ABC` as a uss file using `dls ANSIBLE.*` won;t get resolved to `dls ANSIBLE.TEST.ABC` but now we are using single quotes around the wildcard (`dls 'ANSIBLE.*'`) so shell doesn't resolve `ANSIBLE.*` making the tests fail.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Enabler Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_encode
zos_archive

