### PR TITLE
Add_branch_protection_rules

### DIFF
--- a/branch_protection_rules.json
+++ b/branch_protection_rules.json
@@ -1,0 +1,12 @@
+[{
+    "type": "branch-protection",
+    "name": "code-review",
+    "params": {
+      "checks": [
+        "tekton/code-branch-protection",
+        "tekton/code-unit-tests",
+        "tekton/code-vulnerability-scan",
+        "tekton/code-detect-secrets"
+      ]
+    }
+}]


### PR DESCRIPTION
Add branch protection rules to ensure the proper run of statements and for SPS to know which scans to execute.

Is part to be compliance.