### PR TITLE
adding ansible.cfg back to resolve action plugin issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,7 +258,6 @@ shell_exploits.txt
 importer_result.json
 ac
 scripts/
-ansible.cfg
 
 ################################################################################
 # Debugging .ignore, if you want to know why a particular file is being ignored

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,47 @@
+################################################################################
+# Copyright (c) IBM Corporation 2020, 2021
+################################################################################
+
+################################################################################
+# For for on ansible.cfg options see:
+#   https://docs.ansible.com/ansible/latest/reference_appendices/config.html
+#
+# For a full sample see:
+#   https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg
+#
+# Note:
+#   Examples of some options often used:
+#   remote_temp - The temporary directory Ansible uses to transfer files onto
+#                  the controller. Default is `/.ansible/tmp`
+#   ansible_port - The connection port number Ansible uses to connect to the
+#                  target; configure the target if is not using default SSH
+#                  port 22
+#   debug - Toggles debug output in Ansible. This is very verbose and can
+#           hinder multiprocessing. Debug output can also include secret
+#           information despite no_log settings being enabled, which means debug
+#           mode should not be used in production. Optionally, ad-hoc you can
+#           use ANSIBLE_DEBUG=1
+#  verbosity - Sets the default verbosity, equivalent to the number of -v's
+#              passed in the command line.
+#              i.e. 0|1|2|3|4 == None|-v|-vv|-vvv|-vvvv
+################################################################################
+
+[defaults]
+forks = 25
+action_plugins=~/.ansible/collections/ansible_collections/ibm/ibm_zos_core/plugins/action
+# remote_tmp = /u/ansible/tmp
+# remote_port = 22
+# debug = True
+# verbosity = 1
+
+[ssh_connection]
+pipelining = True
+
+[connection]
+pipelining = True
+
+[colors]
+verbose = green
+
+[persistent_connection]
+command_timeout = 60


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ansible.cfg was added to the ac tool repo when it was separated. we need to have ansible.cfg in ibm_zos_core dir.
when a new version of the repository is pulled it will not have the ansible.cfg.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
