### PR TITLE
[Bugfix][2285]zos_mount_persistant_delete_all_content

### DIFF
--- a/changelogs/fragments/2347-zos_mount_persistant_delete_all_content.yaml
+++ b/changelogs/fragments/2347-zos_mount_persistant_delete_all_content.yaml
@@ -1,4 +1,5 @@
 bugfixes:
-  - zos_mount - Module previously deleted the persistent dataset and then rewrote the content regardless of whether a pattern match occurre
-    Fix now ensures to only delete content only is triggered when a pattern match is detected.
+  - zos_mount - Previously, using the persistent parameter caused the module to clear the entire member or data set
+    provided even without a pattern match, leaving it empty despite a successful mount.
+    The fix now ensures content is only deleted when a pattern match is detected, preserving existing configuration.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2347).

--- a/changelogs/fragments/2347-zos_mount_persistant_delete_all_content.yaml
+++ b/changelogs/fragments/2347-zos_mount_persistant_delete_all_content.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zos_mount - Module previously deleted the persistent dataset and then rewrote the content regardless of whether a pattern match occurre
+    Fix now ensures to only delete content only is triggered when a pattern match is detected.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2347).

--- a/plugins/modules/zos_mount.py
+++ b/plugins/modules/zos_mount.py
@@ -663,11 +663,14 @@ def get_str_to_keep(dataset, src):
 
     decode_list = [codecs.decode(record, "cp1047") for record in dataset_content]
 
-    for record in decode_list:
+    # Use enumerate to avoid cases when dataset have content before so required to return
+    # all the content.
+    for idx, record in enumerate(decode_list):
         if pattern.match(record) is not None:
-            line_counter += 1
+            line_counter = idx + 1
             break
-        line_counter += 1
+    else:
+        return decode_list
 
     begin_block_code = line_counter
     for line in reversed(decode_list[:line_counter]):
@@ -1048,30 +1051,24 @@ def run_module(module, arg_def):
                 stderr=str(res_args),
             )
 
-        bk_ds = datasets.tmp_name(high_level_qualifier=tmphlq)
-        datasets.create(name=bk_ds, dataset_type="SEQ")
-
         new_str = get_str_to_keep(dataset=name, src=src)
+        modified_str = [line for line in new_str if line.strip() or line.lstrip()]
 
         rc_write = 0
 
         try:
-            for line in new_str:
-                rc_write = datasets.write(dataset_name=bk_ds, content=line.rstrip(), append=True)
-                if rc_write != 0:
-                    raise Exception("Non zero return code from datasets.write.")
+            # zoau_io.zopen on mode w allow delete all the content inside the dataset allowing to write the new one
+            with zoau_io.zopen(f"//'{name}'", "w", recfm="*") as ds:
+                pass
+            full_text = "\n".join(modified_str)
+            rc_write = datasets.write(dataset_name=name, content=full_text, append=True, force=True)
+            if rc_write != 0:
+                raise Exception("Non zero return code from datasets.write.")
         except Exception as e:
-            datasets.delete(dataset=bk_ds)
             module.fail_json(
                 msg="Unable to write on persistent data set {0}. {1}".format(name, e),
                 stderr=str(res_args),
             )
-
-        try:
-            datasets.delete(dataset=name)
-            datasets.copy(source=bk_ds, target=name)
-        finally:
-            datasets.delete(dataset=bk_ds)
 
         if will_mount:
             d = datetime.today()

--- a/tests/functional/modules/test_zos_mount_func.py
+++ b/tests/functional/modules/test_zos_mount_func.py
@@ -38,10 +38,10 @@ SRC_INVALID_UTF8 = """MOUNT FILESYSTEM('TEST.ZFS.DATA.USER')
     SECURITY
 """
 
-TEXT_TO_KEEP = """USER NO 1
-    TICKET SERVICE 20
-    MOUNT FILESYSTEM('SYS1.TEST.ZFS')
-    YPE(ZFS) MODE(RDWR) AUTOMOVE
+TEXT_TO_KEEP = """/* Service path                                                    */
+MOUNT FILESYSTEM('{0}')
+    TYPE(ZFS) MODE(RDWR) AUTOMOVE
+    MOUNTPOINT('/Service')
 """
 
 SHELL_EXECUTABLE = "/bin/sh"
@@ -333,10 +333,10 @@ def test_basic_mount_with_persistent_keep_dataset(ansible_zos_module, volumes_on
         cmd="touch {0}".format(tmp_file_filename)
     )
 
-    hosts.all.zos_blockinfile(path=tmp_file_filename, insertafter="EOF", block=TEXT_TO_KEEP)
-
     dest = get_tmp_ds_name()
     dest_path = dest + "(AUTO1)"
+
+    hosts.all.zos_blockinfile(path=tmp_file_filename, insertafter="EOF", block=TEXT_TO_KEEP.format(srcfn))
 
     hosts.all.shell(
         cmd="dtouch -tpdse {0}".format(dest)
@@ -369,7 +369,7 @@ def test_basic_mount_with_persistent_keep_dataset(ansible_zos_module, volumes_on
         for result in result_cat.contacted.values():
             print(result)
             assert srcfn in result.get("stdout")
-            assert "USER NO 1" in result.get("stdout")
+            assert "Service path" in result.get("stdout")
     finally:
         hosts.all.zos_mount(
             src=srcfn,


### PR DESCRIPTION
##### SUMMARY
Code before delete the dataset and write the content that do not match specifications expected by the module, now if there is no match the content will remain on the text and also avoid to delete the dataset, only delete content in case of a match.

Fixes #2285 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Use zos_replace logic to the deletion of content of the dataset


<img width="1107" height="415" alt="Screenshot 2025-10-01 at 12 46 32 p m" src="https://github.com/user-attachments/assets/c8850a06-f59b-49ef-85f5-8dbca7cf603f" />
