### PR TITLE
[zos_replace][1.16.0] Write uss files using encoding provided and only write if an occurrence was found

### DIFF
--- a/changelogs/fragments/2383_zos_replace_utf8fix.yml
+++ b/changelogs/fragments/2383_zos_replace_utf8fix.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - zos_replace - Module would always write USS files in UTF-8 encoding regardless if an occurrence was found or not.
-    Fix now writes the file with the provided ``encoding`` value only if an occurrence if found.
+    Fix now writes the file with the provided ``encoding`` value only if an occurrence is found.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2383).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Used the encoding value to write into a USS file and changed the logic of both USS and data set to only write if any occurrences were found.

Port of #2372 

Fixes #2380 

I'm sorry this pull request is only the changelog but I accidentally used my super powers to merge straight into staging-v1.16.0-beta.1 :( 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
