### PR TITLE
[Bug][zos_backup_restore] Enable testcase test_backup_and_restore_of_data_set_from_volume_to_new_volume

### DIFF
--- a/changelogs/fragments/2348-zos_backup_restore_uncomment_testcase.yml
+++ b/changelogs/fragments/2348-zos_backup_restore_uncomment_testcase.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_backup_restore - Enabled test case test_backup_and_restore_of_data_set_from_volume_to_new_volume
+    with `temp_volume` parameter. Updated documentation to clarify `temp_volume` usage and document
+    known issue where operations fail if `temp_volume` matches source volume or is unspecified.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2437)

--- a/changelogs/fragments/2348-zos_backup_restore_uncomment_testcase.yml
+++ b/changelogs/fragments/2348-zos_backup_restore_uncomment_testcase.yml
@@ -1,5 +1,0 @@
-bugfixes:
-  - zos_backup_restore - Enabled test case test_backup_and_restore_of_data_set_from_volume_to_new_volume
-    with `temp_volume` parameter. Updated documentation to clarify `temp_volume` usage and document
-    known issue where operations fail if `temp_volume` matches source volume or is unspecified.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/2437)

--- a/changelogs/fragments/2437-zos_backup_restore_uncomment_testcase.yml
+++ b/changelogs/fragments/2437-zos_backup_restore_uncomment_testcase.yml
@@ -1,0 +1,9 @@
+bugfixes:
+  - zos_backup_restore - Updated documentation to clarify `temp_volume` usage and document
+    known issue where operations fail if `temp_volume` matches source volume or is unspecified.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2437)
+
+trivial:
+  - zos_backup_restore - Enabled test case test_backup_and_restore_of_data_set_from_volume_to_new_volume
+    with `temp_volume` parameter.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2437)

--- a/plugins/modules/zos_backup_restore.py
+++ b/plugins/modules/zos_backup_restore.py
@@ -156,6 +156,12 @@ options:
         created during the backup and restore process.
       - When I(operation=backup) and I(backup_name) is a data set, specifies the
         volume the backup should be placed in.
+      - When backing up a data set from one volume to another, the operation
+        will fail if I(temp_volume) is set to the same volume as the source volume. Additionally,
+        if I(temp_volume) is not specified, the underlying ZOAU mechanism may allocate temporary
+        data sets on the same volume as the source volume, which can also cause the operation to
+        fail. As a workaround, always use the I(temp_volume) option to specify a different volume
+        than the source volume for temporary data sets.
     type: str
     required: False
     aliases:
@@ -354,6 +360,12 @@ notes:
       the module option without access to the class.
     - If your system uses a different security product, consult that product's
       documentation to configure the required security classes.
+    - B(Known Issue:) When backing up a data set from one volume to another, the operation
+      will fail if I(temp_volume) is set to the same volume as the source volume. Additionally,
+      if I(temp_volume) is not specified, the underlying ZOAU mechanism may allocate temporary
+      data sets on the same volume as the source volume, which can also cause the operation to
+      fail. As a workaround, always use the I(temp_volume) option to specify a different volume
+      than the source volume for temporary data sets.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/zos_backup_restore.py
+++ b/plugins/modules/zos_backup_restore.py
@@ -157,11 +157,9 @@ options:
       - When I(operation=backup) and I(backup_name) is a data set, specifies the
         volume the backup should be placed in.
       - When backing up a data set from one volume to another, the operation
-        will fail if I(temp_volume) is set to the same volume as the source volume. Additionally,
-        if I(temp_volume) is not specified, the underlying ZOAU mechanism may allocate temporary
-        data sets on the same volume as the source volume, which can also cause the operation to
-        fail. As a workaround, always use the I(temp_volume) option to specify a different volume
-        than the source volume for temporary data sets.
+        will fail if temporary data sets are created on the same volume as the volume containing
+        the source data set(s). To avoid this, set I(temp_volume) to a different volume
+        than the source volume.
     type: str
     required: False
     aliases:
@@ -360,12 +358,11 @@ notes:
       the module option without access to the class.
     - If your system uses a different security product, consult that product's
       documentation to configure the required security classes.
-    - B(Known Issue:) When backing up a data set from one volume to another, the operation
-      will fail if I(temp_volume) is set to the same volume as the source volume. Additionally,
-      if I(temp_volume) is not specified, the underlying ZOAU mechanism may allocate temporary
-      data sets on the same volume as the source volume, which can also cause the operation to
-      fail. As a workaround, always use the I(temp_volume) option to specify a different volume
-      than the source volume for temporary data sets.
+    - When backing up a data set from one volume to another, the operation will
+      fail if temporary data sets are created on the same volume as the volume
+      containing the source data set(s). To avoid this, use the I(temp_volume)
+      option to specify a different volume than the source volume for temporary
+      data sets.
 """
 
 EXAMPLES = r"""

--- a/tests/functional/modules/test_zos_backup_restore_func.py
+++ b/tests/functional/modules/test_zos_backup_restore_func.py
@@ -931,43 +931,43 @@ def test_backup_and_restore_a_data_set_with_same_hlq(ansible_zos_module):
         delete_remnants(hosts)
 
 
-# Commented this test because it was commented previously and keeps failing. Tracked on https://github.com/ansible-collections/ibm_zos_core/issues/2348
-# def test_backup_and_restore_of_data_set_from_volume_to_new_volume(ansible_zos_module, volumes_on_systems):
-#     hosts = ansible_zos_module
-#     data_set_name = get_tmp_ds_name()
-#     data_set_restore_location = get_tmp_ds_name()
-#     hlqs = "TMPHLQ"
-#     try:
-#         volumes = Volume_Handler(volumes_on_systems)
-#         volume_1 = volumes.get_available_vol()
-#         volume_2 = volumes.get_available_vol()
-#         delete_data_set_or_file(hosts, data_set_name)
-#         delete_data_set_or_file(hosts, data_set_restore_location)
-#         create_sequential_data_set_with_contents(
-#             hosts, data_set_name, DATA_SET_CONTENTS, volume_1
-#         )
-#         results = hosts.all.zos_backup_restore(
-#             operation="backup",
-#             data_sets=dict(include=data_set_name),
-#             volume=volume_1,
-#             backup_name=data_set_restore_location,
-#             overwrite=True,
-#         )
-#         assert_module_did_not_fail(results)
-#         assert_data_set_or_file_exists(hosts, data_set_restore_location)
-#         results = hosts.all.zos_backup_restore(
-#             operation="restore",
-#             backup_name=data_set_restore_location,
-#             overwrite=True,
-#             volume=volume_2,
-#             output={"hlq": hlqs},
-#         )
-#         assert_module_did_not_fail(results)
-#         assert_data_set_exists(hosts, data_set_restore_location)
-#     finally:
-#         delete_data_set_or_file(hosts, data_set_name)
-#         delete_data_set_or_file(hosts, data_set_restore_location)
-#         delete_remnants(hosts, hlqs)
+def test_backup_and_restore_of_data_set_from_volume_to_new_volume(ansible_zos_module, volumes_on_systems):
+    hosts = ansible_zos_module
+    data_set_name = get_tmp_ds_name()
+    data_set_restore_location = get_tmp_ds_name()
+    hlqs = "TMPHLQ"
+    try:
+        volumes = Volume_Handler(volumes_on_systems)
+        volume_1 = volumes.get_available_vol()
+        volume_2 = volumes.get_available_vol()
+        delete_data_set_or_file(hosts, data_set_name)
+        delete_data_set_or_file(hosts, data_set_restore_location)
+        create_sequential_data_set_with_contents(
+            hosts, data_set_name, DATA_SET_CONTENTS, volume_1
+        )
+        results = hosts.all.zos_backup_restore(
+            operation="backup",
+            data_sets=dict(include=data_set_name),
+            volume=volume_1,
+            temp_volume=volume_2,
+            backup_name=data_set_restore_location,
+            overwrite=True,
+        )
+        assert_module_did_not_fail(results)
+        assert_data_set_or_file_exists(hosts, data_set_restore_location)
+        results = hosts.all.zos_backup_restore(
+            operation="restore",
+            backup_name=data_set_restore_location,
+            overwrite=True,
+            volume=volume_2,
+            output={"hlq": hlqs},
+        )
+        assert_module_did_not_fail(results)
+        assert_data_set_exists(hosts, data_set_restore_location)
+    finally:
+        delete_data_set_or_file(hosts, data_set_name)
+        delete_data_set_or_file(hosts, data_set_restore_location)
+        delete_remnants(hosts, hlqs)
 
 
 def test_backup_and_restore_of_sms_group(ansible_zos_module, volumes_sms_systems):


### PR DESCRIPTION
##### SUMMARY
Fixes #2348 and fixes #2436

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request


##### COMPONENT NAME
zos_backup_restore

##### ADDITIONAL INFORMATION

- Enabled test case test_backup_and_restore_of_data_set_from_volume_to_new_volume with `temp_volume` parameter. 
- Updated documentation to clarify `temp_volume` usage and document known issue where operations fail if `temp_volume` matches source volume or is unspecified.
