### PR TITLE
[Bug][zos_started_task] Fetching System logs is getting failed due to variable name conflict

### DIFF
--- a/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
+++ b/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - zos_started_task - Added a get_system_logs variable to distinguish the boolean control flag from the system_logs output variable,
+  - zos_started_task - System logs could not be fetched due to an internal variable name conflict. Fix renames the internal variable to distinguish the boolean control flag from the system_logs output variable.
     resolving naming conflict that was preventing successful log retrieval.
-    (https://github.com/ansible-collections/ibm_zos_core/pull/2440)
+    (https://github.com/ansible-collections/ibm_zos_core/issues/2422)

--- a/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
+++ b/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
@@ -1,4 +1,4 @@
-trivial:
+bugfixes:
   - zos_started_task - Added a get_system_logs variable to distinguish the boolean control flag from the system_logs output variable,
     resolving naming conflicts that were preventing successful log retrieval.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2440)

--- a/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
+++ b/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
@@ -1,4 +1,4 @@
-minor_changes:
+trivial:
   - zos_started_task - Added a get_system_logs variable to distinguish the boolean control flag from the system_logs output variable,
     resolving naming conflicts that were preventing successful log retrieval.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2440)

--- a/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
+++ b/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
@@ -1,4 +1,3 @@
 bugfixes:
   - zos_started_task - System logs could not be fetched due to an internal variable name conflict. Fix renames the internal variable to distinguish the boolean control flag from the system_logs output variable.
-    resolving naming conflict that was preventing successful log retrieval.
     (https://github.com/ansible-collections/ibm_zos_core/issues/2422)

--- a/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
+++ b/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
@@ -1,0 +1,4 @@
+trivial:
+  - zos_started_task - Introduced get_system_logs variable to separate the boolean control flag from the system_logs output variable,
+    preventing naming conflicts that blocked log retrieval.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2440)

--- a/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
+++ b/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
@@ -1,4 +1,4 @@
-trivial:
-  - zos_started_task - Introduced get_system_logs variable to separate the boolean control flag from the system_logs output variable,
-    preventing naming conflicts that blocked log retrieval.
+minor_changes:
+  - zos_started_task - Added a get_system_logs variable to distinguish the boolean control flag from the system_logs output variable,
+    resolving naming conflicts that were preventing successful log retrieval.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2440)

--- a/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
+++ b/changelogs/fragments/2440_zos_started_task_fixing_system_logs_issue.yml
@@ -1,4 +1,4 @@
 bugfixes:
   - zos_started_task - Added a get_system_logs variable to distinguish the boolean control flag from the system_logs output variable,
-    resolving naming conflicts that were preventing successful log retrieval.
+    resolving naming conflict that was preventing successful log retrieval.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2440)

--- a/plugins/modules/zos_started_task.py
+++ b/plugins/modules/zos_started_task.py
@@ -230,7 +230,7 @@ attributes:
     support: full
     description: Supports being used with the ``async`` keyword.
   check_mode:
-    support: None
+    support: none
     description: Can run in check_mode and return changed status prediction without modifying target. If not supported, the action will be skipped.
 """
 EXAMPLES = r"""

--- a/plugins/modules/zos_started_task.py
+++ b/plugins/modules/zos_started_task.py
@@ -1487,7 +1487,7 @@ def run_module():
     asidx = module.params.get('asidx')
     duplicate_tasks = False
     started_task_name_from_id = ""
-    system_logs = module.params.get('system_logs')
+    get_system_logs = module.params.get('system_logs')
     task_params_before = []
     task_params_after = []
     if task_id and state != "displayed":
@@ -1572,7 +1572,7 @@ def run_module():
         err_msg = modify_errmsg
         started_task_name, cmd = prepare_modify_command(module, started_task_name_from_id)
     # Note the timestamp before operation execution to fetch system logs within that time frame.
-    if system_logs:
+    if get_system_logs:
         before_time = fetch_current_time()
     changed = False
     stdout = ""
@@ -1621,9 +1621,9 @@ def run_module():
                 is_failed = True
             elif verbose:
                 task_output_logs = get_task_logs(task_params_after[0].get('task_id'))
-        # Fetch system logs as per the recorded timestamp before operation execution
-        if system_logs:
-            system_logs = fetch_logs(cmd.upper(), before_time)
+    # Fetch system logs as per the recorded timestamp after operation execution
+    if get_system_logs:
+        system_logs = fetch_logs(cmd.upper(), before_time)
     # Create response to return
     current_state = ""
     if is_failed:

--- a/plugins/modules/zos_started_task.py
+++ b/plugins/modules/zos_started_task.py
@@ -230,7 +230,7 @@ attributes:
     support: full
     description: Supports being used with the ``async`` keyword.
   check_mode:
-    support: full
+    support: None
     description: Can run in check_mode and return changed status prediction without modifying target. If not supported, the action will be skipped.
 """
 EXAMPLES = r"""
@@ -1356,7 +1356,7 @@ def run_module():
             ['identifier_name', 'task_id']
         ],
         # required_by={'retry_force': ['tcb_address']},
-        supports_check_mode=True
+        supports_check_mode=False
     )
 
     args_def = {
@@ -1649,8 +1649,6 @@ def run_module():
     result = dict()
     if state == "displayed":
         changed = False
-    if module.check_mode:
-        module.exit_json(**result)
 
     result = dict(
         changed=changed,

--- a/plugins/modules/zos_started_task.py
+++ b/plugins/modules/zos_started_task.py
@@ -230,7 +230,7 @@ attributes:
     support: full
     description: Supports being used with the ``async`` keyword.
   check_mode:
-    support: none
+    support: full
     description: Can run in check_mode and return changed status prediction without modifying target. If not supported, the action will be skipped.
 """
 EXAMPLES = r"""
@@ -1356,7 +1356,7 @@ def run_module():
             ['identifier_name', 'task_id']
         ],
         # required_by={'retry_force': ['tcb_address']},
-        supports_check_mode=False
+        supports_check_mode=True
     )
 
     args_def = {
@@ -1647,6 +1647,8 @@ def run_module():
         stderr = err
 
     result = dict()
+    if module.check_mode:
+        module.exit_json(**result)
     if state == "displayed":
         changed = False
 

--- a/tests/functional/modules/test_zos_started_task_func.py
+++ b/tests/functional/modules/test_zos_started_task_func.py
@@ -446,7 +446,8 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
         start_results = hosts.all.zos_started_task(
             state = "started",
             member_name = member_name,
-            verbose=True
+            verbose=True,
+            system_logs=True
         )
 
         for result in start_results.contacted.values():
@@ -454,6 +455,7 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
             assert result.get("rc") == 0
             assert result.get("stderr") == ""
             assert len(result.get("tasks")) > 0
+            assert result.get("system_logs") != ""
             assert result.get("verbose_output") != ""
 
         force_results = hosts.all.zos_started_task(
@@ -646,13 +648,15 @@ def test_stop_and_modify_with_vlf_task(ansible_zos_module):
     modify_results = hosts.all.zos_started_task(
         state = "modified",
         task = "VLF",
-        parameters = ["REPLACE" ,"NN=00"]
+        parameters = ["REPLACE" ,"NN=00"],
+        system_logs=True
     )
     for result in modify_results.contacted.values():
         assert result.get("changed") is True
         assert result.get("rc") == 0
         assert len(result.get("tasks")) > 0
         assert result.get("stderr") == ""
+        assert result.get("system_logs") != ""
         assert result.get("cmd") == "F VLF.VLF,REPLACE,NN=00"
 
     display_result = hosts.all.zos_started_task(
@@ -750,13 +754,15 @@ def test_starting_and_cancel_zos_started_task_with_params(ansible_zos_module):
             state = "started",
             member = "SAMPLE2",
             job_name = "SPROC",
-            verbose=True
+            verbose=True,
+            system_logs=True
         )
 
         for result in start_results.contacted.values():
             assert result.get("changed") is True
             assert result.get("rc") == 0
             assert result.get("stderr") == ""
+            assert result.get("system_logs") != ""
             assert len(result.get("tasks")) > 0
             assert result.get("verbose_output") != ""
 

--- a/tests/functional/modules/test_zos_started_task_func.py
+++ b/tests/functional/modules/test_zos_started_task_func.py
@@ -42,8 +42,8 @@ def test_start_task_with_invalid_member(ansible_zos_module):
     hosts = ansible_zos_module
     # Check with non-existing member
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "SAMTASK"
+        state="started",
+        member_name="SAMTASK"
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is False
@@ -51,8 +51,8 @@ def test_start_task_with_invalid_member(ansible_zos_module):
         assert result.get("msg") is not None
     # Validating with member name more than 8 chars
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "SAMPLETASK"
+        state="started",
+        member_name="SAMPLETASK"
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is False
@@ -63,10 +63,10 @@ def test_start_task_with_jobname_identifier(ansible_zos_module):
     hosts = ansible_zos_module
     # validate jobname and identifier with non-existing member
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "SAMPLE",
-        job_name = "SAMTASK",
-        identifier = "TESTER"
+        state="started",
+        member_name="SAMPLE",
+        job_name="SAMTASK",
+        identifier="TESTER"
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is False
@@ -77,9 +77,9 @@ def test_start_task_with_invalid_identifier(ansible_zos_module):
     hosts = ansible_zos_module
     # validate using invalid identifier
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "SAMPTASK",
-        identifier = "$HELLO"
+        state="started",
+        member_name="SAMPTASK",
+        identifier="$HELLO"
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is False
@@ -88,9 +88,9 @@ def test_start_task_with_invalid_identifier(ansible_zos_module):
 
     # validate using proper identifier and non-existing member
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "SAMPLE",
-        identifier = "HELLO"
+        state="started",
+        member_name="SAMPLE",
+        identifier="HELLO"
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is False
@@ -102,9 +102,9 @@ def test_start_task_with_invalid_jobaccount(ansible_zos_module):
     job_account = "(T043JM,JM00,1,0,0,This is the invalid job account information to test negative scenario)"
     # validate invalid job_account with non-existing member
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "SAMPLE",
-        job_account = job_account
+        state="started",
+        member_name="SAMPLE",
+        job_account=job_account
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is False
@@ -140,9 +140,9 @@ def test_start_task_with_invalid_jobaccount(ansible_zos_module):
 def test_start_task_with_invalid_parameters(ansible_zos_module):
     hosts = ansible_zos_module
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "SAMPLE",
-        parameters = ["KEY1"]
+        state="started",
+        member_name="SAMPLE",
+        parameters=["KEY1"]
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is False
@@ -151,9 +151,9 @@ def test_start_task_with_invalid_parameters(ansible_zos_module):
         assert result.get("msg") is not None
 
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "SAMPLE",
-        parameters = ["KEY1", "KEY2", "KEY3"]
+        state="started",
+        member_name="SAMPLE",
+        parameters=["KEY1", "KEY2", "KEY3"]
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is False
@@ -178,9 +178,9 @@ def test_start_task_with_invalid_parameters(ansible_zos_module):
 def test_start_task_with_invalid_subsystem_negative(ansible_zos_module):
     hosts = ansible_zos_module
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "VLF",
-        subsystem = "MSTRS"
+        state="started",
+        member_name="VLF",
+        subsystem="MSTRS"
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is False
@@ -191,9 +191,9 @@ def test_start_task_with_invalid_subsystem_negative(ansible_zos_module):
 def test_start_task_with_invalid_keywordparams_negative(ansible_zos_module):
     hosts = ansible_zos_module
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "VLF",
-        keyword_parameters = {
+        state="started",
+        member_name="VLF",
+        keyword_parameters={
             "key1key1key1key1key1key1key1key1": "value1value1value1value1value1value1"
         }
     )
@@ -203,9 +203,9 @@ def test_start_task_with_invalid_keywordparams_negative(ansible_zos_module):
         assert result.get("msg") is not None
 
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "VLF",
-        keyword_parameters = {
+        state="started",
+        member_name="VLF",
+        keyword_parameters={
             "key1key1key1key1key1key1key1key1key1key1key1key1": "value1"
         }
     )
@@ -215,9 +215,9 @@ def test_start_task_with_invalid_keywordparams_negative(ansible_zos_module):
         assert result.get("msg") is not None
 
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member_name = "VLF",
-        keyword_parameters = {
+        state="started",
+        member_name="VLF",
+        keyword_parameters={
             "KEY1": "VALUE1",
             "KEY2": "VALUE2"
         }
@@ -247,8 +247,8 @@ def test_start_task_with_invalid_keywordparams_negative(ansible_zos_module):
 def test_display_task_negative(ansible_zos_module):
     hosts = ansible_zos_module
     display_results = hosts.all.zos_started_task(
-        state = "displayed",
-        identifier = "SAMPLE"
+        state="displayed",
+        identifier="SAMPLE"
     )
     for result in display_results.contacted.values():
         assert result.get("changed") is False
@@ -259,8 +259,8 @@ def test_display_task_negative(ansible_zos_module):
 def test_stop_task_negative(ansible_zos_module):
     hosts = ansible_zos_module
     stop_results = hosts.all.zos_started_task(
-        state = "stopped",
-        job_name = "SAMPLE"
+        state="stopped",
+        job_name="SAMPLE"
     )
     for result in stop_results.contacted.values():
         assert result.get("changed") is False
@@ -268,9 +268,9 @@ def test_stop_task_negative(ansible_zos_module):
         assert result.get("msg") is not None
 
     stop_results = hosts.all.zos_started_task(
-        state = "stopped",
-        job_name = "TESTER",
-        identifier = "SAMPLE"
+        state="stopped",
+        job_name="TESTER",
+        identifier="SAMPLE"
     )
     for result in stop_results.contacted.values():
         assert result.get("changed") is False
@@ -280,8 +280,8 @@ def test_stop_task_negative(ansible_zos_module):
 def test_modify_task_negative(ansible_zos_module):
     hosts = ansible_zos_module
     modify_results = hosts.all.zos_started_task(
-        state = "modified",
-        identifier = "SAMPLE"
+        state="modified",
+        identifier="SAMPLE"
     )
     for result in modify_results.contacted.values():
         assert result.get("changed") is False
@@ -289,8 +289,8 @@ def test_modify_task_negative(ansible_zos_module):
         assert result.get("msg") is not None
     
     modify_results = hosts.all.zos_started_task(
-        state = "modified",
-        job_name = "TESTER"
+        state="modified",
+        job_name="TESTER"
     )
     for result in modify_results.contacted.values():
         assert result.get("changed") is False
@@ -298,10 +298,10 @@ def test_modify_task_negative(ansible_zos_module):
         assert result.get("msg") is not None
 
     modify_results = hosts.all.zos_started_task(
-        state = "modified",
-        job_name = "TESTER",
-        identifier = "SAMPLE",
-        parameters = ["REPLACE", "VX=10"]
+        state="modified",
+        job_name="TESTER",
+        identifier="SAMPLE",
+        parameters=["REPLACE", "VX=10"]
     )
     for result in modify_results.contacted.values():
         assert result.get("changed") is False
@@ -311,8 +311,8 @@ def test_modify_task_negative(ansible_zos_module):
 def test_cancel_task_negative(ansible_zos_module):
     hosts = ansible_zos_module
     cancel_results = hosts.all.zos_started_task(
-        state = "cancelled",
-        identifier = "SAMPLE"
+        state="cancelled",
+        identifier="SAMPLE"
     )
     for result in cancel_results.contacted.values():
         assert result.get("changed") is False
@@ -320,9 +320,9 @@ def test_cancel_task_negative(ansible_zos_module):
         assert result.get("msg") is not None
 
     cancel_results = hosts.all.zos_started_task(
-        state = "cancelled",
-        job_name = "TESTER",
-        identifier = "SAMPLE"
+        state="cancelled",
+        job_name="TESTER",
+        identifier="SAMPLE"
     )
     for result in cancel_results.contacted.values():
         assert result.get("changed") is False
@@ -330,10 +330,10 @@ def test_cancel_task_negative(ansible_zos_module):
         assert result.get("msg") is not None
 
     cancel_results = hosts.all.zos_started_task(
-        state = "cancelled",
-        asidx = "0012",
-        user_id = "OMVSTEST",
-        dump = True,
+        state="cancelled",
+        asidx="0012",
+        user_id="OMVSTEST",
+        dump=True,
         verbose=True
     )
     for result in cancel_results.contacted.values():
@@ -341,9 +341,9 @@ def test_cancel_task_negative(ansible_zos_module):
         assert result.get("failed") is True
         assert result.get("msg") is not None
     cancel_results = hosts.all.zos_started_task(
-        state = "cancelled",
-        user_id = "OMVSADM",
-        armrestart = True
+        state="cancelled",
+        user_id="OMVSADM",
+        armrestart=True
     )
     for result in cancel_results.contacted.values():
         assert result.get("changed") is False
@@ -353,8 +353,8 @@ def test_cancel_task_negative(ansible_zos_module):
 def test_force_task_negative(ansible_zos_module):
     hosts = ansible_zos_module
     force_results = hosts.all.zos_started_task(
-        state = "forced",
-        identifier = "SAMPLE"
+        state="forced",
+        identifier="SAMPLE"
     )
     for result in force_results.contacted.values():
         assert result.get("changed") is False
@@ -362,18 +362,18 @@ def test_force_task_negative(ansible_zos_module):
         assert result.get("msg") is not None
 
     force_results = hosts.all.zos_started_task(
-        state = "forced",
-        job_name = "TESTER",
-        identifier = "SAMPLE"
+        state="forced",
+        job_name="TESTER",
+        identifier="SAMPLE"
     )
     for result in force_results.contacted.values():
         assert result.get("changed") is False
         assert result.get("failed") is True
         assert result.get("msg") is not None
     force_results = hosts.all.zos_started_task(
-        state = "forced",
-        user_id = "OMVSADM",
-        armrestart = True
+        state="forced",
+        user_id="OMVSADM",
+        armrestart=True
     )
     for result in force_results.contacted.values():
         assert result.get("changed") is False
@@ -444,8 +444,8 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
         )
 
         start_results = hosts.all.zos_started_task(
-            state = "started",
-            member_name = member_name,
+            state="started",
+            member_name=member_name,
             verbose=True,
             system_logs=True
         )
@@ -459,8 +459,8 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
             assert result.get("verbose_output") != ""
 
         force_results = hosts.all.zos_started_task(
-            state = "forced",
-            task_name = member_name
+            state="forced",
+            task_name=member_name
         )
         for result in force_results.contacted.values():
             assert result.get("changed") is False
@@ -471,8 +471,8 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
             assert "CANCELABLE - ISSUE CANCEL BEFORE FORCE" in result.get("stderr")
 
         stop_results = hosts.all.zos_started_task(
-            state = "cancelled",
-            task_name = member_name
+            state="cancelled",
+            task_name=member_name
         )
 
         for result in stop_results.contacted.values():
@@ -484,10 +484,10 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
 
         # validate identifier
         start_results = hosts.all.zos_started_task(
-            state = "started",
-            member = member_name,
-            identifier = "TESTER",
-            reusable_asid = True
+            state="started",
+            member=member_name,
+            identifier="TESTER",
+            reusable_asid=True
         )
         for result in start_results.contacted.values():
             assert result.get("changed") is True
@@ -498,17 +498,17 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
             assert result.get("cmd") == f"S {member_name}.TESTER,REUSASID=YES"
 
         stop_results = hosts.all.zos_started_task(
-            state = "cancelled",
-            task_name = member_name
+            state="cancelled",
+            task_name=member_name
         )
         for result in stop_results.contacted.values():
             assert result.get("changed") is False
             assert result.get("msg") is not None
 
         stop_results = hosts.all.zos_started_task(
-            state = "cancelled",
-            task_name = member_name,
-            identifier = "TESTER"
+            state="cancelled",
+            task_name=member_name,
+            identifier="TESTER"
         )
         for result in stop_results.contacted.values():
             assert result.get("changed") is True
@@ -519,9 +519,9 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
 
         job_account = "(T043JM,JM00,1,0,0,)"
         start_results = hosts.all.zos_started_task(
-            state = "started",
-            member = member_name,
-            job_account = job_account
+            state="started",
+            member=member_name,
+            job_account=job_account
         )
 
         for result in start_results.contacted.values():
@@ -531,9 +531,9 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
             assert len(result.get("tasks")) > 0
             assert result.get("verbose_output") == ""
         start_results = hosts.all.zos_started_task(
-            state = "started",
-            member = member_name,
-            job_account = job_account
+            state="started",
+            member=member_name,
+            job_account=job_account
         )
 
         for result in start_results.contacted.values():
@@ -544,8 +544,8 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
             assert result.get("verbose_output") == ""
 
         display_result = hosts.all.zos_started_task(
-            state = "displayed",
-            task = member_name
+            state="displayed",
+            task=member_name
         )
         for result in display_result.contacted.values():
             assert result.get("changed") is False
@@ -558,9 +558,9 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
         asid_val =  re.search(r"\bA=([^ \n\r\t]+)", display_output).group(1)
         
         stop_results = hosts.all.zos_started_task(
-            state = "cancelled",
-            task_name = member_name,
-            asidx = asid_val,
+            state="cancelled",
+            task_name=member_name,
+            asidx=asid_val,
             verbose=True
         )
 
@@ -571,8 +571,8 @@ def test_start_and_cancel_zos_started_task(ansible_zos_module):
             assert len(result.get("tasks")) > 0
             assert result.get("verbose_output") == ""
         stop_results = hosts.all.zos_started_task(
-            state = "cancelled",
-            task_name = member_name,
+            state="cancelled",
+            task_name=member_name,
             verbose=True
         )
 
@@ -612,9 +612,9 @@ def test_start_with_jobname_and_cancel_zos_started_task(ansible_zos_module):
         )
 
         start_results = hosts.all.zos_started_task(
-            state = "started",
-            member = "SAMPLE",
-            job_name = "TESTTSK"
+            state="started",
+            member="SAMPLE",
+            job_name="TESTTSK"
         )
 
         for result in start_results.contacted.values():
@@ -624,8 +624,8 @@ def test_start_with_jobname_and_cancel_zos_started_task(ansible_zos_module):
             assert result.get("stderr") == ""
 
         stop_results = hosts.all.zos_started_task(
-            state = "cancelled",
-            task = "TESTTSK"
+            state="cancelled",
+            task="TESTTSK"
         )
 
         for result in stop_results.contacted.values():
@@ -646,9 +646,9 @@ def test_start_with_jobname_and_cancel_zos_started_task(ansible_zos_module):
 def test_stop_and_modify_with_vlf_task(ansible_zos_module):
     hosts = ansible_zos_module
     modify_results = hosts.all.zos_started_task(
-        state = "modified",
-        task = "VLF",
-        parameters = ["REPLACE" ,"NN=00"],
+        state="modified",
+        task="VLF",
+        parameters=["REPLACE" ,"NN=00"],
         system_logs=True
     )
     for result in modify_results.contacted.values():
@@ -660,8 +660,8 @@ def test_stop_and_modify_with_vlf_task(ansible_zos_module):
         assert result.get("cmd") == "F VLF.VLF,REPLACE,NN=00"
 
     display_result = hosts.all.zos_started_task(
-        state = "displayed",
-        task = "VLF"
+        state="displayed",
+        task="VLF"
     )
     for result in display_result.contacted.values():
         asid_val = result.get("tasks")[0]["asidx"]
@@ -672,9 +672,9 @@ def test_stop_and_modify_with_vlf_task(ansible_zos_module):
         assert result.get("verbose_output") == ""
 
     stop_results = hosts.all.zos_started_task(
-        state = "stopped",
-        task = "VLF",
-        asidx = asid_val
+        state="stopped",
+        task="VLF",
+        asidx=asid_val
     )
     for result in stop_results.contacted.values():
         assert result.get("changed") is True
@@ -684,10 +684,10 @@ def test_stop_and_modify_with_vlf_task(ansible_zos_module):
         assert result.get("cmd") == f"P VLF.VLF,A={asid_val}"
 
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member = "VLF",
-        identifier = "TESTER",
-        subsystem = "MSTR"
+        state="started",
+        member="VLF",
+        identifier="TESTER",
+        subsystem="MSTR"
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is True
@@ -696,10 +696,10 @@ def test_stop_and_modify_with_vlf_task(ansible_zos_module):
         assert result.get("stderr") == ""
 
     modify_results = hosts.all.zos_started_task(
-        state = "modified",
-        task = "VLF",
-        identifier = "TESTER",
-        parameters = ["REPLACE" ,"NN=00"]
+        state="modified",
+        task="VLF",
+        identifier="TESTER",
+        parameters=["REPLACE" ,"NN=00"]
     )
     for result in modify_results.contacted.values():
         assert result.get("changed") is True
@@ -709,9 +709,9 @@ def test_stop_and_modify_with_vlf_task(ansible_zos_module):
         assert result.get("cmd") == "F VLF.TESTER,REPLACE,NN=00"
     
     stop_results = hosts.all.zos_started_task(
-        state = "stopped",
-        task = "VLF",
-        identifier = "TESTER"
+        state="stopped",
+        task="VLF",
+        identifier="TESTER"
     )
     for result in stop_results.contacted.values():
         assert result.get("changed") is True
@@ -720,9 +720,9 @@ def test_stop_and_modify_with_vlf_task(ansible_zos_module):
         assert len(result.get("tasks")) > 0
 
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member = "VLF",
-        subsystem = "MSTR"
+        state="started",
+        member="VLF",
+        subsystem="MSTR"
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is True
@@ -751,9 +751,9 @@ def test_starting_and_cancel_zos_started_task_with_params(ansible_zos_module):
         )
 
         start_results = hosts.all.zos_started_task(
-            state = "started",
-            member = "SAMPLE2",
-            job_name = "SPROC",
+            state="started",
+            member="SAMPLE2",
+            job_name="SPROC",
             verbose=True,
             system_logs=True
         )
@@ -767,8 +767,8 @@ def test_starting_and_cancel_zos_started_task_with_params(ansible_zos_module):
             assert result.get("verbose_output") != ""
 
         stop_results = hosts.all.zos_started_task(
-            state = "cancelled",
-            task = "SPROC"
+            state="cancelled",
+            task="SPROC"
         )
 
         for result in stop_results.contacted.values():
@@ -789,8 +789,8 @@ def test_starting_and_cancel_zos_started_task_with_params(ansible_zos_module):
 def test_force_and_start_with_icsf_task(ansible_zos_module):
     hosts = ansible_zos_module
     display_results = hosts.all.zos_started_task(
-        state = "displayed",
-        task = "ICSF"
+        state="displayed",
+        task="ICSF"
     )
     for result in display_results.contacted.values():
         assert result.get("changed") is False
@@ -801,8 +801,8 @@ def test_force_and_start_with_icsf_task(ansible_zos_module):
         asidx = result.get("tasks")[0]["asidx"]
     
     cancel_results = hosts.all.zos_started_task(
-        state = "cancelled",
-        task = "ICSF"
+        state="cancelled",
+        task="ICSF"
     )
     for result in cancel_results.contacted.values():
         assert result.get("changed") is False
@@ -810,11 +810,11 @@ def test_force_and_start_with_icsf_task(ansible_zos_module):
         assert result.get("stderr") != ""
         assert len(result.get("tasks")) == 0
     force_results = hosts.all.zos_started_task(
-        state = "forced",
-        task = "ICSF",
-        identifier = "ICSF",
-        asidx = asidx,
-        arm = True
+        state="forced",
+        task="ICSF",
+        identifier="ICSF",
+        asidx=asidx,
+        arm=True
     )
     for result in force_results.contacted.values():
         assert result.get("changed") is True
@@ -823,8 +823,8 @@ def test_force_and_start_with_icsf_task(ansible_zos_module):
         assert result.get("cmd") == f"FORCE ICSF.ICSF,A={asidx},ARM"
 
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member = "ICSF"
+        state="started",
+        member="ICSF"
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is True
@@ -852,8 +852,8 @@ def test_start_with_keyword_param_and_cancel_zos_started_task(ansible_zos_module
             cmd="dcp {0} \"//'{1}(MSLEEP)'\"".format(data_set_name, PROC_PDS)
         )
         display_results = hosts.all.zos_started_task(
-            state = "displayed",
-            task = "MSLEEP"
+            state="displayed",
+            task="MSLEEP"
         )
         for result in display_results.contacted.values():
             assert result.get("changed") is False
@@ -862,10 +862,10 @@ def test_start_with_keyword_param_and_cancel_zos_started_task(ansible_zos_module
             assert result.get("msg") is not None
 
         start_results = hosts.all.zos_started_task(
-            state = "started",
-            member = "MSLEEP",
-            keyword_parameters = {"SECS": "60"},
-            verbose = True
+            state="started",
+            member="MSLEEP",
+            keyword_parameters={"SECS": "60"},
+            verbose=True
         )
 
         for result in start_results.contacted.values():
@@ -875,10 +875,10 @@ def test_start_with_keyword_param_and_cancel_zos_started_task(ansible_zos_module
             assert result.get("stderr") == ""
         
         start_results = hosts.all.zos_started_task(
-            state = "started",
-            member = "MSLEEP",
-            keyword_parameters = {"SECS": "80"},
-            verbose = True
+            state="started",
+            member="MSLEEP",
+            keyword_parameters={"SECS": "80"},
+            verbose=True
         )
 
         for result in start_results.contacted.values():
@@ -888,8 +888,8 @@ def test_start_with_keyword_param_and_cancel_zos_started_task(ansible_zos_module
             assert result.get("stderr") == ""
 
         display_results = hosts.all.zos_started_task(
-            state = "displayed",
-            task = "MSLEEP"
+            state="displayed",
+            task="MSLEEP"
         )
 
         for result in display_results.contacted.values():
@@ -900,9 +900,9 @@ def test_start_with_keyword_param_and_cancel_zos_started_task(ansible_zos_module
             asid_val = result.get("tasks")[0]["asidx"]
 
         stop_results = hosts.all.zos_started_task(
-            state = "cancelled",
-            task = "MSLEEP",
-            asidx = asid_val
+            state="cancelled",
+            task="MSLEEP",
+            asidx=asid_val
         )
 
         for result in stop_results.contacted.values():
@@ -912,8 +912,8 @@ def test_start_with_keyword_param_and_cancel_zos_started_task(ansible_zos_module
             assert result.get("stderr") == ""
         
         display_results = hosts.all.zos_started_task(
-            state = "displayed",
-            task = "MSLEEP"
+            state="displayed",
+            task="MSLEEP"
         )
 
         for result in display_results.contacted.values():
@@ -948,8 +948,8 @@ def test_start_and_cancel_zos_started_task_using_task_id(ansible_zos_module):
             cmd="dcp {0} \"//'{1}(TSLEEP)'\"".format(data_set_name, PROC_PDS)
         )
         display_results = hosts.all.zos_started_task(
-            state = "displayed",
-            task_id = "STCABCDEF"
+            state="displayed",
+            task_id="STCABCDEF"
         )
         for result in display_results.contacted.values():
             assert result.get("changed") is False
@@ -957,10 +957,10 @@ def test_start_and_cancel_zos_started_task_using_task_id(ansible_zos_module):
             assert result.get("msg") != ""
 
         start_results = hosts.all.zos_started_task(
-            state = "started",
-            member = "TSLEEP",
-            keyword_parameters = {"SECS": "100"},
-            verbose = True
+            state="started",
+            member="TSLEEP",
+            keyword_parameters={"SECS": "100"},
+            verbose=True
         )
 
         for result in start_results.contacted.values():
@@ -970,10 +970,10 @@ def test_start_and_cancel_zos_started_task_using_task_id(ansible_zos_module):
             assert result.get("stderr") == ""
         
         start_results = hosts.all.zos_started_task(
-            state = "started",
-            member = "TSLEEP",
-            keyword_parameters = {"SECS": "100"},
-            verbose = True
+            state="started",
+            member="TSLEEP",
+            keyword_parameters={"SECS": "100"},
+            verbose=True
         )
 
         for result in start_results.contacted.values():
@@ -983,8 +983,8 @@ def test_start_and_cancel_zos_started_task_using_task_id(ansible_zos_module):
             assert result.get("stderr") == ""
 
         display_results = hosts.all.zos_started_task(
-            state = "displayed",
-            task = "TSLEEP"
+            state="displayed",
+            task="TSLEEP"
         )
 
         for result in display_results.contacted.values():
@@ -995,8 +995,8 @@ def test_start_and_cancel_zos_started_task_using_task_id(ansible_zos_module):
             assert result.get("stderr") == ""
 
         stop_results = hosts.all.zos_started_task(
-            state = "cancelled",
-            task_id = task_id
+            state="cancelled",
+            task_id=task_id
         )
         for result in stop_results.contacted.values():
             assert result.get("changed") is True
@@ -1004,8 +1004,8 @@ def test_start_and_cancel_zos_started_task_using_task_id(ansible_zos_module):
             assert len(result.get("tasks")) == 1
             assert result.get("stderr") == ""
         display_results = hosts.all.zos_started_task(
-            state = "displayed",
-            task = "TSLEEP"
+            state="displayed",
+            task="TSLEEP"
         )
 
         for result in display_results.contacted.values():
@@ -1025,8 +1025,8 @@ def test_start_and_cancel_zos_started_task_using_task_id(ansible_zos_module):
 def test_stop_and_force_with_ICSF_task_using_task_id(ansible_zos_module):
     hosts = ansible_zos_module
     display_result = hosts.all.zos_started_task(
-        state = "displayed",
-        task = "ICSF"
+        state="displayed",
+        task="ICSF"
     )
     for result in display_result.contacted.values():
         task_id = result.get('tasks')[0]['task_id']
@@ -1037,8 +1037,8 @@ def test_stop_and_force_with_ICSF_task_using_task_id(ansible_zos_module):
         assert len(result.get("tasks")) > 0
         assert result.get("verbose_output") == ""
     stop_results = hosts.all.zos_started_task(
-        state = "stopped",
-        task_id = task_id
+        state="stopped",
+        task_id=task_id
     )
     for result in stop_results.contacted.values():
         assert result.get("changed") is True
@@ -1048,8 +1048,8 @@ def test_stop_and_force_with_ICSF_task_using_task_id(ansible_zos_module):
         assert result.get("cmd") == f"P ICSF.ICSF,A={asid_val}"
 
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member = "ICSF"
+        state="started",
+        member="ICSF"
     )
     for result in start_results.contacted.values():
         task_id = result.get('tasks')[0]['task_id']
@@ -1059,9 +1059,9 @@ def test_stop_and_force_with_ICSF_task_using_task_id(ansible_zos_module):
         assert len(result.get("tasks")) > 0
         assert result.get("stderr") == ""
     modify_results = hosts.all.zos_started_task(
-        state = "modified",
-        task_id = task_id,
-        parameters = ["REFRESH"]
+        state="modified",
+        task_id=task_id,
+        parameters=["REFRESH"]
     )
     for result in modify_results.contacted.values():
         task_id = result.get('tasks')[0]['task_id']
@@ -1071,9 +1071,9 @@ def test_stop_and_force_with_ICSF_task_using_task_id(ansible_zos_module):
         assert len(result.get("tasks")) > 0
         assert result.get("stderr") == ""
     force_results = hosts.all.zos_started_task(
-        state = "forced",
-        task_id = task_id,
-        arm = True
+        state="forced",
+        task_id=task_id,
+        arm=True
     )
     for result in force_results.contacted.values():
         assert result.get("changed") is True
@@ -1083,8 +1083,8 @@ def test_stop_and_force_with_ICSF_task_using_task_id(ansible_zos_module):
         assert result.get("cmd") == f"FORCE ICSF.ICSF,A={asid_val},ARM"
 
     start_results = hosts.all.zos_started_task(
-        state = "started",
-        member = "ICSF"
+        state="started",
+        member="ICSF"
     )
     for result in start_results.contacted.values():
         assert result.get("changed") is True


### PR DESCRIPTION
##### SUMMARY
Fixes #2422

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zos_started_task

##### ADDITIONAL INFORMATION
- Removed system_logs variable conflict by adding new variable get_system_logs

