### PR TITLE
[Doc][zos_started_task] update examples in module docs to not use aliases

### DIFF
--- a/plugins/modules/zos_started_task.py
+++ b/plugins/modules/zos_started_task.py
@@ -237,31 +237,31 @@ EXAMPLES = r"""
 - name: Start a started task using a member in a partitioned data set.
   zos_started_task:
     state: "started"
-    member: "PROCAPP"
+    member_name: "PROCAPP"
 
 - name: Start a started task using a member name and giving it an identifier.
   zos_started_task:
     state: "started"
-    member: "PROCAPP"
-    identifier: "SAMPLE"
+    member_name: "PROCAPP"
+    identifier_name: "SAMPLE"
 
 - name: Start a started task using both a member and a job name.
   zos_started_task:
     state: "started"
-    member: "PROCAPP"
+    member_name: "PROCAPP"
     job_name: "SAMPLE"
 
 - name: Start a started task and enable verbose output.
   zos_started_task:
     state: "started"
-    member: "PROCAPP"
+    member_name: "PROCAPP"
     job_name: "SAMPLE"
     verbose: True
 
 - name: Start a started task and wait for 30 seconds before fetching task details.
   zos_started_task:
     state: "started"
-    member: "PROCAPP"
+    member_name: "PROCAPP"
     verbose: True
     wait_time: 30
     wait_full_time: True
@@ -269,14 +269,14 @@ EXAMPLES = r"""
 - name: Start a started task specifying the subsystem and enabling a reusable ASID.
   zos_started_task:
     state: "started"
-    member: "PROCAPP"
+    member_name: "PROCAPP"
     subsystem: "MSTR"
     reusable_asid: "YES"
 
 - name: Display a started task using a started task name.
   zos_started_task:
     state: "displayed"
-    task_name: "PROCAPP"
+    job_name: "PROCAPP"
 
 - name: Display a started task using a started task id.
   zos_started_task:
@@ -286,17 +286,17 @@ EXAMPLES = r"""
 - name: Display all started tasks that begin with an s using a wildcard.
   zos_started_task:
     state: "displayed"
-    task_name: "s*"
+    job_name: "s*"
 
 - name: Display all started tasks.
   zos_started_task:
     state: "displayed"
-    task_name: "all"
+    job_name: "all"
 
 - name: Cancel a started task using task name.
   zos_started_task:
     state: "cancelled"
-    task_name: "SAMPLE"
+    job_name: "SAMPLE"
 
 - name: Cancel a started task using a started task id.
   zos_started_task:
@@ -306,13 +306,13 @@ EXAMPLES = r"""
 - name: Cancel a started task using it's task name and ASID.
   zos_started_task:
     state: "cancelled"
-    task_name: "SAMPLE"
+    job_name: "SAMPLE"
     asidx: 0014
 
 - name: Modify a started task's parameters.
   zos_started_task:
     state: "modified"
-    task_name: "SAMPLE"
+    job_name: "SAMPLE"
     parameters: ["XX=12"]
 
 - name: Modify a started task's parameters using a started task id.
@@ -324,7 +324,7 @@ EXAMPLES = r"""
 - name: Stop a started task using it's task name.
   zos_started_task:
     state: "stopped"
-    task_name: "SAMPLE"
+    job_name: "SAMPLE"
 
 - name: Stop a started task using a started task id.
   zos_started_task:
@@ -334,14 +334,14 @@ EXAMPLES = r"""
 - name: Stop a started task using it's task name, identifier and ASID.
   zos_started_task:
     state: "stopped"
-    task_name: "SAMPLE"
-    identifier: "SAMPLE"
+    job_name: "SAMPLE"
+    identifier_name: "SAMPLE"
     asidx: 00A5
 
 - name: Force a started task using it's task name.
   zos_started_task:
     state: "forced"
-    task_name: "SAMPLE"
+    job_name: "SAMPLE"
 
 - name: Force a started task using it's task id.
   zos_started_task:

--- a/plugins/modules/zos_started_task.py
+++ b/plugins/modules/zos_started_task.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2025
+# Copyright (c) IBM Corporation 2026
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #2449

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_started_task

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Replaced the parameter aliases uses in the examples section of the zos_started_task module with the official module option names.

<!--- Paste verbatim command output below, e.g. before and after your change -->