### PR TITLE
[Enhancement][zos_operator] - replace content with stdout and stderr in response

### DIFF
--- a/changelogs/fragments/2492_zos_operator_return_param_update.yml
+++ b/changelogs/fragments/2492_zos_operator_return_param_update.yml
@@ -1,3 +1,8 @@
 breaking_changes:
   - zos_operator - Return value ``content`` is deprecated in favor of ``stdout_lines`` and ``stderr_lines``.
     (https://github.com/ansible-collections/ibm_zos_core/pull/2492)
+
+minor_changes:
+  - zos_operator - New return value ``stdout`` contains the command stdout in raw format.
+    New return value ``stderr`` contains the command stderr in raw format.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2492).

--- a/changelogs/fragments/2492_zos_operator_return_param_update.yml
+++ b/changelogs/fragments/2492_zos_operator_return_param_update.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+  - zos_operator - Return value ``content`` is deprecated in favor of ``stdout_lines`` and ``stderr_lines``.
+    (https://github.com/ansible-collections/ibm_zos_core/pull/2492)

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -156,33 +156,52 @@ time_unit:
     returned: always
     type: str
     sample: s
-content:
+stdout:
     description:
-       The resulting text from the command submitted.
-    returned: on success
+      The standard output from the operator command execution.
+    returned: always
+    type: str
+    sample: |
+        EC33017A   2022244  16:00:49.00             ISF031I CONSOLE OMVS0000 ACTIVATED
+        EC33017A   2022244  16:00:49.00            -D U,ALL
+        EC33017A   2022244  16:00:49.00             IEE457I 16.00.49 UNIT STATUS 645
+                                                   UNIT TYPE STATUS        VOLSER     VOLSTATE      SS
+                                                   0000 3390 F-NRD                        /RSDNT     0
+                                                   0001 3211 OFFLINE                                 0
+stdout_lines:
+    description:
+      The standard output split into individual lines.
+    returned: always
     type: list
+    elements: str
     sample:
-        [ "EC33017A   2022244  16:00:49.00             ISF031I CONSOLE OMVS0000 ACTIVATED",
-          "EC33017A   2022244  16:00:49.00            -D U,ALL ",
-          "EC33017A   2022244  16:00:49.00             IEE457I 16.00.49 UNIT STATUS 645",
-          "                                           UNIT TYPE STATUS        VOLSER     VOLSTATE      SS",
-          "                                           0000 3390 F-NRD                        /RSDNT     0",
-          "                                           0001 3211 OFFLINE                                 0",
-          "                                           0002 3211 OFFLINE                                 0",
-          "                                           0003 3211 OFFLINE                                 0",
-          "                                           0004 3211 OFFLINE                                 0",
-          "                                           0005 3211 OFFLINE                                 0",
-          "                                           0006 3211 OFFLINE                                 0",
-          "                                           0007 3211 OFFLINE                                 0",
-          "                                           0008 3211 OFFLINE                                 0",
-          "                                           0009 3277 OFFLINE                                 0",
-          "                                           000C 2540 A                                       0",
-          "                                           000D 2540 A                                       0",
-          "                                           000E 1403 A                                       0",
-          "                                           000F 1403 A                                       0",
-          "                                           0010 3211 A                                       0",
-          "                                           0011 3211 A                                       0"
-        ]
+        - "EC33017A   2022244  16:00:49.00             ISF031I CONSOLE OMVS0000 ACTIVATED"
+        - "EC33017A   2022244  16:00:49.00            -D U,ALL "
+        - "EC33017A   2022244  16:00:49.00             IEE457I 16.00.49 UNIT STATUS 645"
+        - "                                           UNIT TYPE STATUS        VOLSER     VOLSTATE      SS"
+        - "                                           0000 3390 F-NRD                        /RSDNT     0"
+        - "                                           0001 3211 OFFLINE                                 0"
+        - "                                           0002 3211 OFFLINE                                 0"
+        - "                                           0008 3211 OFFLINE                                 0"
+        - "                                           0009 3277 OFFLINE                                 0"
+        - "                                           000C 2540 A                                       0"
+        - "                                           000E 1403 A                                       0"
+        - "                                           000F 1403 A                                       0"
+        - "                                           0010 3211 A                                       0"
+        - "                                           0011 3211 A                                       0"
+stderr:
+    description:
+      The standard error from the operator command execution.
+    returned: always
+    type: str
+    sample: ""
+stderr_lines:
+    description:
+      The standard error split into individual lines.
+    returned: always
+    type: list
+    elements: str
+    sample: []
 changed:
     description:
       Indicates if any changes were made during module operation.
@@ -308,31 +327,28 @@ def run_module():
         rc_message = run_operator_command(new_params)
         result["rc"] = rc_message.get("rc")
         result["elapsed"] = rc_message.get("elapsed")
-        # This section will build 2 lists of strings: content=>user return, and
-        # short_str, which is the first 5 lines of stdout and stderr.
-        # 5: depending on the shell, there can be 1-2 leading blank lines +
-        # the first few lines of ouput from the operator call will look like this:
-        # .....ISF031I CONSOLE OMVSADM ACTIVATED
-        # .....-actual command run
-        # .....first result of command
-        # text or other output may then follow
-        # short_str is local, and just to check for problem response values.
-        # ssctr is a limit variable so we don't pull more than 5 lines of each.
-        result["content"] = []
+        
+        # Process stdout and stderr
         stdout = rc_message.get("stdout")
+        stderr = rc_message.get("stderr")
+        
+        result["stdout"] = stdout if stdout is not None else ""
+        result["stderr"] = stderr if stderr is not None else ""
+        
+        # Build stdout_lines and stderr_lines
+        result["stdout_lines"] = []
         if stdout is not None:
             for out in stdout.split("\n"):
                 if out:
-                    result["content"].append(out)
-        stderr = rc_message.get("stderr")
-        error = []
+                    result["stdout_lines"].append(out)
+        
+        result["stderr_lines"] = []
         if stderr is not None:
             for err in stderr.split("\n"):
                 if err:
-                    error.append(err)
-                    result["content"].append(err)
+                    result["stderr_lines"].append(err)
+        
         # call is returned from run_operator_command, specifying what was run.
-        # result["cmd"] = new_params.get("cmd")
         result["cmd"] = rc_message.get("call")
         result["wait_time"] = new_params.get("wait_time")
         result["time_unit"] = new_params.get("time_unit")
@@ -340,9 +356,9 @@ def run_module():
 
         # rc=0, something succeeded (the calling script ran),
         # but it could still be a bad/invalid command.
-        # As long as there are more than 2 lines, it's worth looking through.
+        # As long as there are more than 2 lines in stdout, it's worth looking through.
         if int(result["rc"]) == 0:
-            if len(result["content"]) > 2:
+            if len(result["stdout_lines"]) > 2:
                 result["changed"] = True
             else:
                 module.fail_json(msg="Expected response to be more than 2 lines.", **result)
@@ -352,8 +368,10 @@ def run_module():
                              elapsed_time=result["elapsed"],
                              wait_time=result["wait_time"],
                              time_unit=result["time_unit"],
-                             stderr=str(error) if error is not None else result["content"],
-                             stderr_lines=str(error).splitlines() if error is not None else result["content"],
+                             stderr=result["stderr"],
+                             stderr_lines=result["stderr_lines"],
+                             stdout=result["stdout"],
+                             stdout_lines=result["stdout_lines"],
                              changed=result["changed"],)
     except Error as e:
         module.fail_json(msg=to_text(e), **result)

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -162,9 +162,9 @@ stdout:
     returned: always
     type: str
     sample: |
-        EC33017A   2022244  16:00:49.00             ISF031I CONSOLE OMVS0000 ACTIVATED
-        EC33017A   2022244  16:00:49.00            -D U,ALL
-        EC33017A   2022244  16:00:49.00             IEE457I 16.00.49 UNIT STATUS 645
+        EC000000   2022244  16:00:49.00             ISF031I CONSOLE OMVS0000 ACTIVATED
+        EC000000   2022244  16:00:49.00            -D U,ALL
+        EC000000   2022244  16:00:49.00             IEE457I 16.00.49 UNIT STATUS 645
                                                    UNIT TYPE STATUS        VOLSER     VOLSTATE      SS
                                                    0000 3390 F-NRD                        /RSDNT     0
                                                    0001 3211 OFFLINE                                 0
@@ -175,9 +175,9 @@ stdout_lines:
     type: list
     elements: str
     sample:
-        - "EC33017A   2022244  16:00:49.00             ISF031I CONSOLE OMVS0000 ACTIVATED"
-        - "EC33017A   2022244  16:00:49.00            -D U,ALL "
-        - "EC33017A   2022244  16:00:49.00             IEE457I 16.00.49 UNIT STATUS 645"
+        - "EC000000   2022244  16:00:49.00             ISF031I CONSOLE OMVS0000 ACTIVATED"
+        - "EC000000   2022244  16:00:49.00            -D U,ALL "
+        - "EC000000   2022244  16:00:49.00             IEE457I 16.00.49 UNIT STATUS 645"
         - "                                           UNIT TYPE STATUS        VOLSER     VOLSTATE      SS"
         - "                                           0000 3390 F-NRD                        /RSDNT     0"
         - "                                           0001 3211 OFFLINE                                 0"

--- a/plugins/modules/zos_operator.py
+++ b/plugins/modules/zos_operator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2025
+# Copyright (c) IBM Corporation 2019, 2026
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -327,27 +327,27 @@ def run_module():
         rc_message = run_operator_command(new_params)
         result["rc"] = rc_message.get("rc")
         result["elapsed"] = rc_message.get("elapsed")
-        
+
         # Process stdout and stderr
         stdout = rc_message.get("stdout")
         stderr = rc_message.get("stderr")
-        
+
         result["stdout"] = stdout if stdout is not None else ""
         result["stderr"] = stderr if stderr is not None else ""
-        
+
         # Build stdout_lines and stderr_lines
         result["stdout_lines"] = []
         if stdout is not None:
             for out in stdout.split("\n"):
                 if out:
                     result["stdout_lines"].append(out)
-        
+
         result["stderr_lines"] = []
         if stderr is not None:
             for err in stderr.split("\n"):
                 if err:
                     result["stderr_lines"].append(err)
-        
+
         # call is returned from run_operator_command, specifying what was run.
         result["cmd"] = rc_message.get("call")
         result["wait_time"] = new_params.get("wait_time")

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2019, 2025
+# Copyright (c) IBM Corporation 2019, 2026
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/functional/modules/test_zos_operator_func.py
+++ b/tests/functional/modules/test_zos_operator_func.py
@@ -112,7 +112,6 @@ def test_zos_operator_various_command(ansible_zos_module):
         hosts = ansible_zos_module
         results = hosts.all.zos_operator(cmd=command)
         for result in results.contacted.values():
-            print(result)
             assert result.get("rc") == expected_rc
             assert result.get("changed") is changed
             assert result.get("msg", False) is False
@@ -120,21 +119,24 @@ def test_zos_operator_various_command(ansible_zos_module):
             assert result.get("elapsed") is not None
             assert result.get("wait_time") is not None
             assert result.get("time_unit") == "s"
-            assert result.get("content") is not None
+            assert result.get("stderr") == ""
+            assert result.get("stdout") is not None
+            assert result.get("stdout_lines") is not None
 
 
 def test_zos_operator_invalid_command(ansible_zos_module):
     hosts = ansible_zos_module
     results = hosts.all.zos_operator(cmd="invalid,command", verbose=False)
     for result in results.contacted.values():
-        print(result)
         assert result.get("changed") is True
         assert result.get("rc") == 0
         assert result.get("cmd") is not None
         assert result.get("elapsed") is not None
         assert result.get("wait_time") is not None
         assert result.get("time_unit") == "s"
-        assert result.get("content") is not None
+        assert result.get("stderr") == ""
+        assert result.get("stdout") is not None
+        assert result.get("stdout_lines") is not None
 
 
 def test_zos_operator_invalid_command_to_ensure_transparency(ansible_zos_module):
@@ -147,9 +149,11 @@ def test_zos_operator_invalid_command_to_ensure_transparency(ansible_zos_module)
         assert result.get("elapsed") is not None
         assert result.get("wait_time") is not None
         assert result.get("time_unit") == "s"
-        assert result.get("content") is not None
+        assert result.get("stderr") == ""
+        assert result.get("stdout") is not None
+        assert result.get("stdout_lines") is not None
         transparency = False
-        if any('DUMP COMMAND' in str for str in result.get("content")):
+        if any('DUMP COMMAND' in str for str in result.get("stdout_lines")):
             transparency = True
         assert transparency
 
@@ -166,7 +170,9 @@ def test_zos_operator_positive_path(ansible_zos_module):
         assert result.get("elapsed") is not None
         assert result.get("wait_time") is not None
         assert result.get("time_unit") == "s"
-        assert result.get("content") is not None
+        assert result.get("stderr") == ""
+        assert result.get("stdout") is not None
+        assert result.get("stdout_lines") is not None
 
 
 def test_zos_operator_positive_path_verbose(ansible_zos_module):
@@ -180,10 +186,12 @@ def test_zos_operator_positive_path_verbose(ansible_zos_module):
         assert result.get("elapsed") is not None
         assert result.get("wait_time") is not None
         assert result.get("time_unit") == "s"
-        assert result.get("content") is not None
-        # Traverse the content list for a known verbose keyword and track state
+        assert result.get("stdout") is not None
+        assert result.get("stdout_lines") is not None
+        assert result.get("stderr_lines") is not None
+        # Traverse the stdout_lines list for a known verbose keyword and track state
         is_verbose = False
-        if any('BGYSC0804I' in str for str in result.get("content")):
+        if any('BGYSC0804I' in str for str in result.get("stderr_lines")):
             is_verbose = True
         assert is_verbose
 
@@ -204,7 +212,8 @@ def test_zos_operator_positive_verbose_with_full_delay(ansible_zos_module):
         assert result.get("elapsed") > wait_time
         assert result.get("wait_time") is not None
         assert result.get("time_unit") == "s"
-        assert result.get("content") is not None
+        assert result.get("stdout") is not None
+        assert result.get("stdout_lines") is not None
 
 
 def test_zos_operator_positive_verbose_with_quick_delay(ansible_zos_module):
@@ -222,7 +231,8 @@ def test_zos_operator_positive_verbose_with_quick_delay(ansible_zos_module):
         assert result.get("elapsed") <= (2 * wait_time)
         assert result.get("wait_time") is not None
         assert result.get("time_unit") == "s"
-        assert result.get("content") is not None
+        assert result.get("stdout") is not None
+        assert result.get("stdout_lines") is not None
 
 
 def test_zos_operator_positive_verbose_blocking(ansible_zos_module):
@@ -241,7 +251,8 @@ def test_zos_operator_positive_verbose_blocking(ansible_zos_module):
             assert result.get("elapsed") >= wait_time
             assert result.get("wait_time") is not None
             assert result.get("time_unit") == "s"
-            assert result.get("content") is not None
+            assert result.get("stdout") is not None
+            assert result.get("stdout_lines") is not None
 
 
 def test_zos_operator_positive_path_preserve_case(ansible_zos_module):
@@ -261,11 +272,12 @@ def test_zos_operator_positive_path_preserve_case(ansible_zos_module):
         assert result.get("wait_time") is not None
         assert result.get("elapsed") is not None
         assert result.get("time_unit") == "s"
-        assert result.get("content") is not None
+        assert result.get("stdout") is not None
+        assert result.get("stdout_lines") is not None
         # Making sure the output from opercmd logged the command
         # exactly as it was written.
-        assert len(result.get("content")) > 1
-        assert command in result.get("content")[1]
+        assert len(result.get("stdout_lines")) > 1
+        assert command in result.get("stdout_lines")[1]
 
 
 def test_response_come_back_complete(ansible_zos_module):
@@ -281,11 +293,12 @@ def test_response_come_back_complete(ansible_zos_module):
         assert result.get("wait_time") is not None
         assert result.get("elapsed") is not None
         assert result.get("time_unit") == "s"
-        assert result.get("content") is not None
-        stdout = result.get('content')
+        assert result.get("stdout") is not None
+        assert result.get("stdout_lines") is not None
+        stdout_lines = result.get('stdout_lines')
         # HASP646 Only appears in the last line that before did not appears
-        last_line = len(stdout)
-        assert "HASP646" in stdout[last_line - 1]
+        last_line = len(stdout_lines)
+        assert "HASP646" in stdout_lines[last_line - 1]
 
 
 def test_operator_sentiseconds(ansible_zos_module):
@@ -299,7 +312,8 @@ def test_operator_sentiseconds(ansible_zos_module):
         assert result.get("elapsed") is not None
         assert result.get("wait_time") is not None
         assert result.get("time_unit") == "cs"
-        assert result.get("content") is not None
+        assert result.get("stdout") is not None
+        assert result.get("stdout_lines") is not None
 
 
 def test_zos_operator_parallel_terminal(get_config):


### PR DESCRIPTION
##### SUMMARY
replaced content with stdout and stderr in response

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
zos_operator

##### ADDITIONAL INFORMATION
- Introduced new response params stdout, stdout_lines, stderr, stderr_lines
- Removed the content response parameter and separated its data into stdout and stderr outputs.
