### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.21 and is scheduled for removal in 2.24.

--- a/plugins/action/zos_copy.py
+++ b/plugins/action/zos_copy.py
@@ -22,7 +22,6 @@ from tempfile import mkstemp
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
-from ansible.module_utils.six import string_types
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
@@ -72,7 +71,7 @@ class ActionModule(ActionBase):
         self.tmp_dir = None
 
         if dest:
-            if not isinstance(dest, string_types):
+            if not isinstance(dest, str):
                 msg = "Invalid type supplied for 'dest' option, it must be a string"
                 return self._exit_action(result, msg, failed=True)
             else:
@@ -86,7 +85,7 @@ class ActionModule(ActionBase):
                 msg = "Either 'src' or 'content' can be provided; not both."
                 return self._exit_action(result, msg, failed=True)
 
-            elif not isinstance(src, string_types):
+            elif not isinstance(src, str):
                 msg = "Invalid type supplied for 'src' option, it must be a string"
                 return self._exit_action(result, msg, failed=True)
 

--- a/plugins/action/zos_fetch.py
+++ b/plugins/action/zos_fetch.py
@@ -19,7 +19,6 @@ import re
 from hashlib import sha256
 # from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.common.text.converters import to_bytes, to_text
-from ansible.module_utils.six import string_types
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
@@ -137,9 +136,9 @@ class ActionModule(ActionBase):
         msg = None
         if src is None or dest is None:
             msg = "Source and destination are required"
-        elif not isinstance(src, string_types):
+        elif not isinstance(src, str):
             msg = "Invalid type supplied for 'source' option, value must be a string"
-        elif not isinstance(dest, string_types):
+        elif not isinstance(dest, str):
             msg = (
                 "Invalid type supplied for 'destination' option, value must be a string"
             )

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -947,10 +947,11 @@ import tempfile
 import traceback
 from hashlib import sha256
 from re import IGNORECASE
+import pathlib
+from re import fullmatch
 
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import PY3
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils import (
     backup, better_arg_parser, copy, data_set, encode, validation)
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import \
@@ -968,12 +969,6 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.dependency_checke
 )
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.log import SingletonLogger
 
-
-if PY3:
-    import pathlib
-    from re import fullmatch
-else:
-    from re import match as fullmatch
 
 try:
     from zoautil_py import datasets, gdgs
@@ -1680,22 +1675,9 @@ class USSCopyHandler(CopyHandler):
         else:
             norm_dest = os.path.normpath(dest)
             dest_parent_dir, tail = os.path.split(norm_dest)
-            if PY3:
-                path_helper = pathlib.Path(dest_parent_dir)
-                if dest_parent_dir != "/" and not path_helper.exists():
-                    path_helper.mkdir(parents=True, exist_ok=True)
-            else:
-                # When using Python 2, instead of using pathlib, we'll use os.makedirs.
-                # pathlib is not available in Python 2.
-                try:
-                    if dest_parent_dir != "/" and not os.path.exists(dest_parent_dir):
-                        os.makedirs(dest_parent_dir)
-                except os.error as err:
-                    # os.makedirs throws an error whether the directories were already
-                    # present or their creation failed. There's no exist_ok to tell it
-                    # to ignore the first case, so we ignore it manually.
-                    if "File exists" not in err:
-                        raise CopyOperationError(msg=to_native(err))
+            path_helper = pathlib.Path(dest_parent_dir)
+            if dest_parent_dir != "/" and not path_helper.exists():
+                path_helper.mkdir(parents=True, exist_ok=True)
 
             if os.path.isfile(conv_path or src):
                 dest = self._copy_to_file(src, dest, content_copy, conv_path)


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. Two uses in this collection:

```python
-from ansible.module_utils.six import string_types   -> isinstance(dest, str)
-from ansible.module_utils.six import PY3
```

`string_types` is `(str,)` on Python 3, so the `isinstance` checks in the `zos_copy` and `zos_fetch` action plugins are equivalent.

The `PY3` import guarded two blocks in `zos_copy.py`, both of which now use the Python 3 branch unconditionally: `import pathlib` / `from re import fullmatch`, and the `pathlib.Path(...).mkdir(parents=True, exist_ok=True)` directory creation. The Python 2 branches were already unreachable, since this module has used f-strings and zero-argument `super()` for some time, and the managed node requires IBM Open Enterprise SDK for Python 3 with ZOAU. The single `fullmatch()` call site uses a pattern anchored `^...$`, so it is unaffected by the `re.match` alias the dead branch used. A changelog fragment is included.

One thing left alone: `plugins/module_utils/system.py` has a commented-out six import inside a larger commented-out block. It is not live code, and editing one line of it would leave the block internally inconsistent, so it seemed better untouched.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

zos_copy, zos_fetch
