### PR TITLE
[Bug] [zos_ping] fix unpack error on ansible-core 2.19

### DIFF
--- a/changelogs/fragments/2564_zos_ping_ansible_core_2_19_compatability.yml
+++ b/changelogs/fragments/2564_zos_ping_ansible_core_2_19_compatability.yml
@@ -1,5 +1,6 @@
 bugfixes:
-  - zos_ping - Fixed an unpack error introduced by ansible-core 2.19, which
-    changed the return format of the internal module configuration step, breaking
-    the shebang injection required for REXX modules on z/OS.
+  - zos_ping - Fixed a failure when running against z/OS targets with
+    ansible-core 2.19 or later, where the module would error with
+    ``not enough values to unpack``. The module now works correctly
+    across all supported ansible-core versions.
     (https://github.com/ansible-collections/ibm_zos_core/issues/2356).

--- a/changelogs/fragments/2564_zos_ping_ansible_core_2_19_compatability.yml
+++ b/changelogs/fragments/2564_zos_ping_ansible_core_2_19_compatability.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - zos_ping - Fixed an unpack error introduced by ansible-core 2.19, which
+    changed the return format of the internal module configuration step, breaking
+    the shebang injection required for REXX modules on z/OS.
+    (https://github.com/ansible-collections/ibm_zos_core/issues/2356).

--- a/plugins/action/zos_ping.py
+++ b/plugins/action/zos_ping.py
@@ -100,9 +100,29 @@ class ActionModule(ActionBase):
         return result
 
     def _configure_module(self, module_name, module_args, task_vars=None):
-        module_style, module_shebang, module_data, module_path = super(
-            ActionModule, self
-        )._configure_module(module_name, module_args, task_vars)
-        if not module_shebang:
-            module_shebang = " "
-        return (module_style, module_shebang, module_data, module_path)
+        # ansible-core 2.19+ changed _configure_module to return a 2-tuple of
+        # (_BuiltModule dataclass, module_path) instead of the previous flat
+        # 4-tuple (module_style, module_shebang, module_data, module_path).
+        # We detect the version and handle both shapes so the shebang override
+        # (required for REXX modules that carry no shebang line) works across
+        # all supported ansible-core releases.
+        version_inf = cli.CLI.version_info(False)
+        version_major = version_inf['major']
+        version_minor = version_inf['minor']
+
+        if version_major == 2 and version_minor >= 19:
+            import dataclasses
+            module_bits, module_path = super(
+                ActionModule, self
+            )._configure_module(module_name, module_args, task_vars)
+            if not module_bits.shebang:
+                # _BuiltModule is a frozen dataclass; use replace() to patch shebang
+                module_bits = dataclasses.replace(module_bits, shebang=" ")
+            return module_bits, module_path
+        else:
+            module_style, module_shebang, module_data, module_path = super(
+                ActionModule, self
+            )._configure_module(module_name, module_args, task_vars)
+            if not module_shebang:
+                module_shebang = " "
+            return (module_style, module_shebang, module_data, module_path)

--- a/plugins/action/zos_ping.py
+++ b/plugins/action/zos_ping.py
@@ -1,6 +1,6 @@
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 # Copyright (c) 2017 Ansible Project
-# Copyright IBM Corporation 2020, 2022
+# Copyright IBM Corporation 2020, 2026
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)


### PR DESCRIPTION
##### SUMMARY
The zos_ping action plugin overrides _configure_module to inject a shebang line required by REXX modules. In ansible-core 2.19, _configure_module changed its return shape from the flat 4-tuple (module_style, module_shebang, module_data, module_path) to a 2-tuple (_BuiltModule dataclass, module_path), causing an "not enough values to unpack (expected 4, got 2)" fatal error at runtime.

The fix adds version detection inside _configure_module() to branch on the return shape:

- ansible-core ≥ 2.19 — unpacks the 2-tuple, patches the frozen _BuiltModule dataclass via dataclasses.replace() when shebang is empty, and returns the 2-tuple unchanged.
- ansible-core ≤ 2.18 — retains the existing 4-tuple unpack and shebang string override.


* Fixes: #2356 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
zos_ping

##### ADDITIONAL INFORMATION
**Playbook:**
```paste below
     - name: Test ibm.ibm_zos_core zos_ping
        ibm.ibm_zos_core.zos_ping:
        register: result

      - name: Print result
        ansible.builtin.debug:
          msg: "{{ result }}"
```
**Before Fix: Reproduce Result (ansible-core 2.19):**
```
TASK [Test ibm.ibm_zos_core zos_ping] ****************************************************************************************************************************
[ERROR]: Task failed: not enough values to unpack (expected 4, got 2)

11   tasks:
12
13       - name: Test ibm.ibm_zos_core zos_ping
           ^ column 9

fatal: [zos_host]: FAILED! => {"changed": false, "msg": "Task failed: not enough values to unpack (expected 4, got 2)"}
```
**After Fix:**
```
TASK [Test ibm.ibm_zos_core zos_ping] ****************************************************************************************************************************
ok: [zos_host] => {"changed": false, "ping": "pong"}

TASK [Print result] ****************************************************************************************************************************
ok: [zos_host] => {
    "msg": {
        "changed": false,
        "failed": false,
        "ping": "pong"
    }
}

```
