### PR TITLE
[Enhancement] [zos_find] Add alias resource_type with filters and include_member_aliases flag

### DIFF
--- a/changelogs/fragments/2568_zos_find_alias_support.yml
+++ b/changelogs/fragments/2568_zos_find_alias_support.yml
@@ -1,0 +1,22 @@
+minor_changes:
+  - zos_find - Added ``alias`` as a ``resource_type`` option to discover
+    catalog alias entries. Returned aliases include an ``alias_of`` field that
+    identifies the associated target data set. When searching aliases, the
+    ``volume``, ``age``, ``age_stamp``, ``size``, and ``contains`` filters are
+    applied to the target data set rather than the alias entry itself
+    (https://github.com/ansible-collections/ibm_zos_core/issues/2446).
+  - zos_find - Added the ``include_member_aliases`` option to return PDS/PDSE
+    member alias information when searching for catalog alias entries
+    (https://github.com/ansible-collections/ibm_zos_core/issues/2446).
+bugfixes:
+  - zos_find - Updated the ``age`` parameter documentation for accuracy and
+    clarity to correctly describe how positive and negative values select data
+    sets older than or younger than the specified threshold.
+  - zos_find - Corrected the ``creation_date`` parsing and calculation logic
+    to properly handle Julian-date-to-calendar-date conversion when retrieving
+    data set age from IDCAMS LISTCAT output.
+  - zos_find - Resolved a ``year 0 is out of range`` module failure that
+    occurred when a data set's ``creation_date`` was reported as year zero by
+    the catalog; such entries are now safely handled and excluded from age
+    comparisons.
+    (https://github.com/ansible-collections/ibm_zos_core/issues/2446).

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -40,7 +40,7 @@ options:
       - Use a negative age to find data sets equal to or less than the specified time.
       - You can choose days, weeks, months or years by specifying the first letter of
         any of those words (e.g., "1w"). The default is days.
-      - Age is determined by using the 'referenced date' of the data set.
+      - Age is determined by the date selected with C(age_stamp) (default C(creation_date)).
     type: str
     required: false
   age_stamp:
@@ -108,10 +108,10 @@ options:
         with this option. The module only searches based on dataset patterns.
       - C(alias) refers to MVS catalog alias entries. The module returns the alias name and the
         real dataset name it points to (returned as C(alias_of) in each result). The C(patterns),
-        C(excludes), C(volume), C(age), C(age_stamp), C(size), and C(include_member_aliases)
-        options are applicable when using this resource type. The C(age), C(age_stamp), and
-        C(size) filters are applied against the target dataset (C(alias_of)), not the alias
-        entry itself.
+        C(excludes), C(volume), C(age), C(age_stamp), C(size), C(contains), and
+        C(include_member_aliases) options are applicable when using this resource type.
+        The C(age), C(age_stamp), C(size), and C(contains) filters are applied against
+        the target dataset (C(alias_of)), not the alias entry itself.
     aliases:
       - resource_types
     choices:
@@ -228,10 +228,10 @@ notes:
   - When searching for content within data sets, only non-binary content is considered.
   - As a migrated data set's information can't be retrieved without recalling it first, other options
     besides C(excludes) and C(migrated_type) are not supported.
-  - When using C(resource_type=alias), the C(contains) option is ignored, as aliases are
-    catalog pointers with no searchable content. The C(age), C(age_stamp), C(size), and
-    C(volume) options are supported and are applied against the target dataset C(alias_of),
-    only alias entries whose target dataset satisfies the criteria are returned.
+  - When using C(resource_type=alias), the C(contains) option searches the content of the
+    target dataset (C(alias_of)). Only alias entries whose target dataset contains the
+    specified string are returned. The C(age), C(age_stamp), C(size), and C(volume) options
+    are also supported and are applied against the target dataset.
   - Parenthesised exclude patterns (e.g. C((^ALIAS1$))) match against PDS/PDSE member alias
     names. Members whose alias name matches the pattern are removed from the C(members) list
     of the alias entry. The alias entry itself is kept unless all members are removed.
@@ -363,6 +363,14 @@ EXAMPLES = r"""
     resource_type:
       - alias
     size: 1m
+
+- name: Find aliases whose target dataset contains the string 'hello'
+  zos_find:
+    patterns:
+      - USER.*
+    resource_type:
+      - alias
+    contains: 'hello'
 """
 
 
@@ -1078,11 +1086,9 @@ def _get_creation_date(module, ds):
             msg="Non-zero return code received while retrieving data set age",
             rc=rc, stderr=err, stdout=out
         )
-    # out = re.findall(r"CREATION-*[A-Z|0-9]*", out.strip())
     out = re.findall(r"CREATION-*[A-Z|0-9\.]*", out.strip())
     if out:
         out = out[0]
-        # date = "".join(re.findall(r"-[A-Z|0-9]*", out)).replace("-", "").split(".")
         date = "".join(re.findall(r"-[A-Z|0-9\.]*", out)).replace("-", "").split(".")
         days = 1 if len(date) < 2 else int(date[1])
         years = int(date[0])
@@ -1597,6 +1603,36 @@ def run_module(module):
                 include_member_aliases=include_member_aliases,
                 volumes=volume if volume else None,
             )
+            # contains: search the target dataset content via dgrep.
+            # Aliases are catalog pointers with no searchable content of their
+            # own; the string must be present in the target dataset (alias_of).
+            if filtered_data_sets and contains:
+                target_names = [ds["alias_of"] for ds in filtered_data_sets if ds.get("alias_of")]
+                content_results = content_filter(module, target_names, contains)
+                pds_hits = content_results.get("pds", {})
+                ps_hits = content_results.get("ps", set())
+                surviving = []
+                for ds in filtered_data_sets:
+                    alias_of = ds.get("alias_of")
+                    if alias_of in ps_hits:
+                        # Sequential target: alias passes as-is.
+                        surviving.append(ds)
+                    elif alias_of in pds_hits:
+                        # PDS/PDSE target: alias passes; if a members list is
+                        # present (include_member_aliases=True or a parenthesised
+                        # exclude was used), prune it to only the members whose
+                        # content matched the search string.
+                        if "members" in ds:
+                            matching_members = pds_hits[alias_of]
+                            ds = dict(ds)
+                            ds["members"] = [
+                                m for m in ds["members"]
+                                if m.get("name", "").upper() in {
+                                    n.upper() for n in matching_members
+                                }
+                            ]
+                        surviving.append(ds)
+                filtered_data_sets = surviving
             # age / age_stamp / size filter alias entries by their target dataset.
             # data_set_attribute_filter accepts a list of ds names and returns
             # the subset that passes; we use alias_of as the lookup key.

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -107,10 +107,10 @@ options:
       - C(migrated) refers to listing migrated datasets. Only C(excludes) and C(migrated_type) options can be used along
         with this option. The module only searches based on dataset patterns.
       - C(alias) refers to MVS catalog alias entries. The module returns the alias name and the
-        real dataset name it points to (returned as C(alias_of) in each result). The C(patterns),
-        C(excludes), C(volume), C(age), C(age_stamp), C(size), C(contains), and
-        C(include_member_aliases) options are applicable when using this resource type.
-        The C(age), C(age_stamp), C(size), and C(contains) filters are applied against
+        real dataset name it points to (returned as C(alias_of) in each result).
+      - The C(patterns), C(excludes), C(volume), C(age), C(age_stamp), C(size), C(contains), and
+        C(include_member_aliases) options are applicable when using C(alias) resource type.
+        The C(volume), C(age), C(age_stamp), C(size), and C(contains) filters are applied against
         the target dataset (C(alias_of)), not the alias entry itself.
     aliases:
       - resource_types

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -32,6 +32,7 @@ author:
   - "Asif Mahmud (@asifmahmud)"
   - "Demetrios Dimatos (@ddimatos)"
   - "Fernando Flores (@fernandofloresg)"
+  - "Yogesh Rana (@yrana17)"
 options:
   age:
     description:
@@ -68,6 +69,9 @@ options:
       - If the pattern is a regular expression, it must match the full data set name.
       - To exclude members, the regular expression or pattern must be enclosed in parentheses.
         This expression can be used alongside a pattern to exclude data set names.
+      - When using C(resource_type=alias), parenthesised patterns match against
+        PDS/PDSE member alias names. Members whose alias name matches are removed
+        from the C(members) list; the alias entry itself is kept.
     aliases:
       - exclude
     type: list
@@ -224,8 +228,9 @@ notes:
   - When using C(resource_type=alias), the C(age), C(age_stamp), C(size), C(volume),
     and C(contains) options are ignored, as aliases are catalog pointers with no
     independent attributes. Only C(patterns), C(excludes), and C(include_member_aliases) apply.
-    Member-level exclude patterns (parenthesised expressions such as C((^MEM.*))) are also
-    ignored for C(alias) resource type.
+  - Parenthesised exclude patterns (e.g. C((^ALIAS1$))) match against PDS/PDSE member alias
+    names. Members whose alias name matches the pattern are removed from the C(members) list
+    of the alias entry. The alias entry itself is kept unless all members are removed.
   - When C(include_member_aliases=true), PDS/PDSE alias entries additionally include
     a C(members) list showing each member and its in-directory alias names.
 seealso:
@@ -1294,7 +1299,7 @@ def _ds_type(ds_name):
     return None
 
 
-def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
+def alias_filter(module, patterns, excludes=None, exclude_member_aliases=None, include_member_aliases=False):
     """Return all dataset catalog alias entries that match any of the patterns.
 
     Parameters
@@ -1304,11 +1309,18 @@ def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
     patterns : list[str]
         A list of data set patterns.
     excludes : list[str], optional
-        A list of patterns. Alias names matching any of these are excluded.
+        A list of patterns. Alias dataset names matching any of these are excluded.
+    exclude_member_aliases : list[str], optional
+        A list of regex patterns (from parenthesised excludes). Members whose
+        in-directory alias name matches any of these patterns are removed from
+        the ``members`` list. The alias entry itself is kept. When this is set,
+        ``members`` is always included in the output for PDS/PDSE entries (even
+        if ``include_member_aliases=False``) so the surviving members are visible.
     include_member_aliases : bool, optional
         When True, pass ``-a`` to ``dls`` so that PDS/PDSE alias entries include
-        a ``members`` array in the JSON output. All members are returned; those
-        with no aliases have an empty ``aliases`` list.
+        a ``members`` list in the output. All surviving members are returned;
+        those with no aliases have an empty ``aliases`` list. Sequential and GDG
+        alias entries are unaffected (no ``members`` key added).
 
     Returns
     -------
@@ -1317,29 +1329,32 @@ def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
           ``name``     (str)       -- the alias name
           ``alias_of`` (str)       -- the real dataset the alias points to
           ``type``     (str)       -- always "ALIAS"
-          ``members``  (list[dict]) -- present only when
-            ``include_member_aliases=True`` and the alias points to a PDS/PDSE.
-            Each item is ``{"name": <memname>, "aliases": [<alias_name>, ...]}``.
+          ``members``  (list[dict]) -- present when ``include_member_aliases=True``
+            or ``exclude_member_aliases`` is set, and the alias points to a
+            PDS/PDSE with at least one surviving member. Each item is
+            ``{"name": <memname>, "aliases": [<alias_name>, ...]}``.
 
     Raises
     ------
     fail_json
         Non-zero return code received while executing ZOAU shell command 'dls'.
     """
+    # Fetch member info whenever we need to either expose it or filter on it.
+    need_members = include_member_aliases or bool(exclude_member_aliases)
     filtered = []
     for pattern in patterns:
         rc, out, err = _dls_wrapper(
             pattern,
             data_set_type="ALIAS",
             list_details=True,
-            members=include_member_aliases,
+            members=need_members,
             json=True,
         )
         if rc != 0:
             if "BGYSC1103E" in err:
                 # No matching datasets found -- not an error
                 continue
-            flag_str = "dls -ltALIAS -a -j" if include_member_aliases else "dls -ltALIAS -j"
+            flag_str = "dls -ltALIAS -a -j" if need_members else "dls -ltALIAS -j"
             module.fail_json(
                 msg="Non-zero return code received while executing ZOAU shell command '{0}'".format(flag_str),
                 rc=rc, stdout=out, stderr=err
@@ -1353,6 +1368,7 @@ def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
             alias_name = ds.get("name", "")
             if not alias_name:
                 continue
+            # Dataset-level exclude (unparenthesised patterns)
             if excludes and any(_match_regex(module, ex, alias_name) for ex in excludes):
                 continue
             entry = {
@@ -1360,13 +1376,35 @@ def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
                 "type": "ALIAS",
                 "alias_of": ds.get("relation", ""),
             }
-            if include_member_aliases:
+            if need_members:
+                # ``dls -a`` returns ALL members of a PDS/PDSE target in the
+                # JSON ``members`` array, including those with no in-directory
+                # aliases (those entries simply have no ``aliases`` key).
+                # The ``members`` key is present for any PDS/PDSE target and
+                # absent for PS/GDG targets.  Use its presence as the signal
+                # that this is a partitioned dataset – not the length of the
+                # filtered list, which can be zero when every aliased member
+                # was excluded.  Members with no aliases (empty list from
+                # ``.get("aliases", [])``) can never match the exclude and
+                # always survive into the output.
+                raw_members = ds.get("members")
+                is_partitioned = raw_members is not None
                 members = []
-                for mem in ds.get("members", []):
+                for mem in (raw_members or []):
                     memname = mem.get("memname", "")
-                    if memname:
-                        members.append({"name": memname, "aliases": mem.get("aliases", [])})
-                entry["members"] = members
+                    if not memname:
+                        continue
+                    # Member-alias-level exclude (parenthesised patterns):
+                    # drop this member if any of its alias names match.
+                    if exclude_member_aliases and any(
+                        _match_regex(module, ex, ali)
+                        for ex in exclude_member_aliases
+                        for ali in mem.get("aliases", [])
+                    ):
+                        continue
+                    members.append({"name": memname, "aliases": mem.get("aliases", [])})
+                if (include_member_aliases or exclude_member_aliases) and is_partitioned:
+                    entry["members"] = members
             filtered.append(entry)
     return filtered
 
@@ -1499,7 +1537,13 @@ def run_module(module):
         elif res_type == "GDG":
             filtered_data_sets = gdg_filter(module, patterns, limit, empty, fifo, purge, scratch, extended, excludes)
         elif res_type == "ALIAS":
-            filtered_data_sets = alias_filter(module, patterns, excludes=excludes, include_member_aliases=include_member_aliases)
+            filtered_data_sets = alias_filter(
+                module,
+                patterns,
+                excludes=excludes_datasets if excludes_datasets else None,
+                exclude_member_aliases=exclude_members if exclude_members else None,
+                include_member_aliases=include_member_aliases,
+            )
         if filtered_data_sets:
             for ds in filtered_data_sets:
                 if ds:

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) IBM Corporation 2020, 2025
+# Copyright (c) IBM Corporation 2020, 2026
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -102,6 +102,9 @@ options:
       - C(gdg) refers to Generation Data Groups. The module searches based on the GDG base name.
       - C(migrated) refers to listing migrated datasets. Only C(excludes) and C(migrated_type) options can be used along
         with this option. The module only searches based on dataset patterns.
+      - C(alias) refers to MVS catalog alias entries. The module returns the alias name and the
+        real dataset name it points to (returned as C(alias_of) in each result). Only C(patterns)
+        and C(excludes) options are applicable when using this resource type.
     aliases:
       - resource_types
     choices:
@@ -111,6 +114,7 @@ options:
       - index
       - gdg
       - migrated
+      - alias
     type: list
     elements: str
     required: false
@@ -175,6 +179,19 @@ options:
       - If provided, will search for data sets with I(scratch) attribute set as provided.
     type: bool
     required: false
+  include_member_aliases:
+    description:
+      - Only valid when C(resource_type=alias).
+      - When C(true), each PDS/PDSE alias entry in the results will include a
+        C(member_aliases) list. Each item in that list is a dict with two keys,
+        C(member) (the PDS/PDSE member name) and C(aliases) (a list of alias names
+        that point to that member). Members with no aliases are omitted.
+        Sequential dataset alias entries are unaffected.
+      - When C(false) (the default), only the dataset alias name and the real
+        dataset it points to (C(alias_of)) are returned.
+    type: bool
+    required: false
+    default: false
 
 attributes:
   action:
@@ -202,6 +219,11 @@ notes:
   - When searching for content within data sets, only non-binary content is considered.
   - As a migrated data set's information can't be retrieved without recalling it first, other options
     besides C(excludes) and C(migrated_type) are not supported.
+  - When using C(resource_type=alias), the C(age), C(age_stamp), C(size), C(volume),
+    and C(contains) options are ignored, as aliases are catalog pointers with no
+    independent attributes. Only C(patterns), C(excludes), and C(include_member_aliases) apply.
+  - When C(include_member_aliases=true), PDS/PDSE alias entries additionally include
+    a C(member_aliases) list showing each member and its in-directory alias names.
 seealso:
 - module: ibm.ibm_zos_core.zos_data_set
 """
@@ -277,12 +299,43 @@ EXAMPLES = r"""
       - 'migrated'
     migrated_type:
       - 'nonvsam'
+
+- name: Find all data set aliases starting with 'USER'
+  zos_find:
+    patterns:
+      - USER.*
+    resource_type:
+      - alias
+
+- name: Find aliases matching a pattern but excluding specific entries
+  zos_find:
+    patterns:
+      - MYHLQ.*
+    resource_type:
+      - alias
+    excludes:
+      - '.*TEMP.*'
+
+- name: Find all PDS/PDSE aliases and include their member alias detail
+  zos_find:
+    patterns:
+      - ANSIBLE.ALIAS.TEST.*
+    resource_type:
+      - alias
+    include_member_aliases: true
 """
 
 
 RETURN = r"""
 data_sets:
-    description: All matches found with the specified criteria.
+    description:
+      - All matches found with the specified criteria.
+      - For C(alias) resource types, each entry includes an C(alias_of) field
+        containing the real dataset name the alias points to.
+      - When C(include_member_aliases=true), PDS/PDSE alias entries additionally
+        include a C(member_aliases) list of dicts. Each dict has a C(member) key
+        (the member name) and an C(aliases) key (a list of alias names for that member).
+        Members with no aliases are omitted from the list.
     returned: success
     type: list
     sample: [
@@ -302,6 +355,20 @@ data_sets:
       {
         "name": "SAMPLE.VSAM.DATA",
         "type": "DATA"
+      },
+      {
+        "name": "USER.ALIAS.NAME",
+        "alias_of": "USER.REAL.DATASET",
+        "type": "ALIAS"
+      },
+      {
+        "name": "USER.PDS.ALIAS",
+        "alias_of": "USER.REAL.PDS",
+        "type": "ALIAS",
+        "member_aliases": [
+          {"member": "MEM1", "aliases": ["ALIAS1", "ALIAS2"]},
+          {"member": "MEM2", "aliases": ["ALIAS3"]}
+        ]
       }
     ]
 matched:
@@ -1091,6 +1158,7 @@ def _dls_wrapper(
     migrated=False,
     data_set_type="",
     json=False,
+    members=False,
 ):
     """A wrapper for ZOAU 'dls' shell command.
 
@@ -1112,6 +1180,9 @@ def _dls_wrapper(
         Data set type to look for.
     json : bool
         Return content in json format.
+    members : bool
+        Enumerate PDS/PDSE members and member aliases (appends ``-a``).
+        Only meaningful when combined with ``data_set_type="ALIAS"``.
 
     Returns
     -------
@@ -1132,6 +1203,8 @@ def _dls_wrapper(
         dls_cmd += " -v"
     if data_set_type:
         dls_cmd += f" -t{data_set_type}"
+    if members:
+        dls_cmd += " -a"
     if json:
         dls_cmd += " -j"
 
@@ -1214,6 +1287,85 @@ def _ds_type(ds_name):
     return None
 
 
+def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
+    """Return all dataset catalog alias entries that match any of the patterns.
+
+    Parameters
+    ----------
+    module : AnsibleModule
+        The Ansible module object being used.
+    patterns : list[str]
+        A list of data set patterns.
+    excludes : list[str], optional
+        A list of patterns. Alias names matching any of these are excluded.
+    include_member_aliases : bool, optional
+        When True, pass ``-a`` to ``dls`` so that PDS/PDSE alias entries include
+        a ``members`` array in the JSON output. Each member entry whose
+        ``aliases`` list is non-empty contributes one dict per alias to the
+        ``member_aliases`` list on the result entry.
+
+    Returns
+    -------
+    list[dict]
+        Each dict contains:
+          ``name``           (str)       -- the alias name
+          ``alias_of``       (str)       -- the real dataset the alias points to
+          ``type``           (str)       -- always "ALIAS"
+          ``member_aliases`` (list[dict]) -- present only when
+            ``include_member_aliases=True`` and the alias points to a PDS/PDSE.
+            Each item is ``{"member": <memname>, "alias": <alias_name>}``.
+
+    Raises
+    ------
+    fail_json
+        Non-zero return code received while executing ZOAU shell command 'dls'.
+    """
+    filtered = []
+    for pattern in patterns:
+        rc, out, err = _dls_wrapper(
+            pattern,
+            data_set_type="ALIAS",
+            list_details=True,
+            members=include_member_aliases,
+            json=True,
+        )
+        if rc != 0:
+            if "BGYSC1103E" in err:
+                # No matching datasets found -- not an error
+                continue
+            flag_str = "dls -ltALIAS -a -j" if include_member_aliases else "dls -ltALIAS -j"
+            module.fail_json(
+                msg="Non-zero return code received while executing ZOAU shell command '{0}'".format(flag_str),
+                rc=rc, stdout=out, stderr=err
+            )
+        try:
+            data = json.loads(out)
+            datasets = data.get("data", {}).get("datasets", [])
+        except (ValueError, KeyError):
+            continue
+        for ds in datasets:
+            alias_name = ds.get("name", "")
+            if not alias_name:
+                continue
+            if excludes and any(_match_regex(module, ex, alias_name) for ex in excludes):
+                continue
+            entry = {
+                "name": alias_name,
+                "type": "ALIAS",
+                "alias_of": ds.get("relation", ""),
+            }
+            if include_member_aliases:
+                member_aliases = []
+                for mem in ds.get("members", []):
+                    memname = mem.get("memname", "")
+                    aliases = mem.get("aliases", [])
+                    if memname and aliases:
+                        member_aliases.append({"member": memname, "aliases": aliases})
+                entry["member_aliases"] = member_aliases
+            filtered.append(entry)
+    return filtered
+
+
 def run_module(module):
     """Initialize parameters.
 
@@ -1257,6 +1409,7 @@ def run_module(module):
     extended = module.params.get('extended')
     migrated_type = module.params.get('migrated_type') or module.params.get('migrated_types')
     fifo = module.params.get('fifo')
+    include_member_aliases = module.params.get('include_member_aliases') or False
     vsam_types = {"CLUSTER", "DATA", "INDEX"}
     res_args = dict(data_sets=[])
     examined_ds = 0
@@ -1340,6 +1493,8 @@ def run_module(module):
             filtered_data_sets, examined = vsam_filter(module, patterns, vsam_resource_types, age=age, excludes=excludes)
         elif res_type == "GDG":
             filtered_data_sets = gdg_filter(module, patterns, limit, empty, fifo, purge, scratch, extended, excludes)
+        elif res_type == "ALIAS":
+            filtered_data_sets = alias_filter(module, patterns, excludes=excludes, include_member_aliases=include_member_aliases)
         if filtered_data_sets:
             for ds in filtered_data_sets:
                 if ds:
@@ -1396,7 +1551,7 @@ def main():
                 elements="str",
                 required=False,
                 default=["nonvsam"],
-                choices=["cluster", "data", "index", "nonvsam", "gdg", "migrated"],
+                choices=["cluster", "data", "index", "nonvsam", "gdg", "migrated", "alias"],
                 aliases=["resource_types"]
             ),
             migrated_type=dict(
@@ -1419,6 +1574,7 @@ def main():
             scratch=dict(type="bool", required=False),
             extended=dict(type="bool", required=False),
             fifo=dict(type="bool", required=False),
+            include_member_aliases=dict(type="bool", required=False, default=False),
         )
     )
 
@@ -1453,6 +1609,7 @@ def main():
         scratch=dict(type="bool", required=False),
         extended=dict(type="bool", required=False),
         fifo=dict(type="bool", required=False),
+        include_member_aliases=dict(arg_type="bool", required=False, default=False),
     )
     try:
         BetterArgParser(arg_def).parse_args(module.params)

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -107,8 +107,9 @@ options:
       - C(migrated) refers to listing migrated datasets. Only C(excludes) and C(migrated_type) options can be used along
         with this option. The module only searches based on dataset patterns.
       - C(alias) refers to MVS catalog alias entries. The module returns the alias name and the
-        real dataset name it points to (returned as C(alias_of) in each result). Only C(patterns),
-        C(excludes), and C(include_member_aliases) options are applicable when using this resource type.
+        real dataset name it points to (returned as C(alias_of) in each result). The C(patterns),
+        C(excludes), C(volume), and C(include_member_aliases) options are applicable when using
+        this resource type.
     aliases:
       - resource_types
     choices:
@@ -225,9 +226,10 @@ notes:
   - When searching for content within data sets, only non-binary content is considered.
   - As a migrated data set's information can't be retrieved without recalling it first, other options
     besides C(excludes) and C(migrated_type) are not supported.
-  - When using C(resource_type=alias), the C(age), C(age_stamp), C(size), C(volume),
-    and C(contains) options are ignored, as aliases are catalog pointers with no
-    independent attributes. Only C(patterns), C(excludes), and C(include_member_aliases) apply.
+  - When using C(resource_type=alias), the C(age), C(age_stamp), C(size), and C(contains)
+    options are ignored, as aliases are catalog pointers with no independent size, age, or
+    searchable content. The C(volume) option filters aliases whose target dataset resides on
+    one of the specified volumes.
   - Parenthesised exclude patterns (e.g. C((^ALIAS1$))) match against PDS/PDSE member alias
     names. Members whose alias name matches the pattern are removed from the C(members) list
     of the alias entry. The alias entry itself is kept unless all members are removed.
@@ -332,6 +334,16 @@ EXAMPLES = r"""
     resource_type:
       - alias
     include_member_aliases: true
+
+- name: Find aliases whose target dataset resides on specific volumes
+  zos_find:
+    patterns:
+      - USER.*
+    resource_type:
+      - alias
+    volumes:
+      - VOL001
+      - VOL002
 """
 
 
@@ -1299,7 +1311,14 @@ def _ds_type(ds_name):
     return None
 
 
-def alias_filter(module, patterns, excludes=None, exclude_member_aliases=None, include_member_aliases=False):
+def alias_filter(
+    module,
+    patterns,
+    excludes=None,
+    exclude_member_aliases=None,
+    include_member_aliases=False,
+    volumes=None,
+):
     """Return all dataset catalog alias entries that match any of the patterns.
 
     Parameters
@@ -1321,6 +1340,10 @@ def alias_filter(module, patterns, excludes=None, exclude_member_aliases=None, i
         a ``members`` list in the output. All surviving members are returned;
         those with no aliases have an empty ``aliases`` list. Sequential and GDG
         alias entries are unaffected (no ``members`` key added).
+    volumes : list[str], optional
+        When set, only alias entries whose target dataset resides on one of the
+        specified volumes are kept. Volume information is taken from the ``volume``
+        field of the ``dls -ltALIAS -j`` JSON output.
 
     Returns
     -------
@@ -1371,10 +1394,16 @@ def alias_filter(module, patterns, excludes=None, exclude_member_aliases=None, i
             # Dataset-level exclude (unparenthesised patterns)
             if excludes and any(_match_regex(module, ex, alias_name) for ex in excludes):
                 continue
+            alias_of = ds.get("relation", "")
+            # Filter by volume: alias target dataset must reside on one of the requested volumes
+            if volumes:
+                ds_volume = ds.get("volume", "")
+                if ds_volume.upper() not in {v.upper() for v in volumes}:
+                    continue
             entry = {
                 "name": alias_name,
                 "type": "ALIAS",
-                "alias_of": ds.get("relation", ""),
+                "alias_of": alias_of,
             }
             if need_members:
                 # ``dls -a`` returns ALL members of a PDS/PDSE target in the
@@ -1543,6 +1572,7 @@ def run_module(module):
                 excludes=excludes_datasets if excludes_datasets else None,
                 exclude_member_aliases=exclude_members if exclude_members else None,
                 include_member_aliases=include_member_aliases,
+                volumes=volume if volume else None,
             )
         if filtered_data_sets:
             for ds in filtered_data_sets:

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -179,19 +179,6 @@ options:
       - If provided, will search for data sets with I(scratch) attribute set as provided.
     type: bool
     required: false
-  include_member_aliases:
-    description:
-      - Only valid when C(resource_type=alias).
-      - When C(true), each PDS/PDSE alias entry in the results will include a
-        C(member_aliases) list. Each item in that list is a dict with two keys,
-        C(member) (the PDS/PDSE member name) and C(aliases) (a list of alias names
-        that point to that member). Members with no aliases are omitted.
-        Sequential dataset alias entries are unaffected.
-      - When C(false) (the default), only the dataset alias name and the real
-        dataset it points to (C(alias_of)) are returned.
-    type: bool
-    required: false
-    default: false
 
 attributes:
   action:
@@ -221,9 +208,7 @@ notes:
     besides C(excludes) and C(migrated_type) are not supported.
   - When using C(resource_type=alias), the C(age), C(age_stamp), C(size), C(volume),
     and C(contains) options are ignored, as aliases are catalog pointers with no
-    independent attributes. Only C(patterns), C(excludes), and C(include_member_aliases) apply.
-  - When C(include_member_aliases=true), PDS/PDSE alias entries additionally include
-    a C(member_aliases) list showing each member and its in-directory alias names.
+    independent attributes. Only C(patterns) and C(excludes) apply.
 seealso:
 - module: ibm.ibm_zos_core.zos_data_set
 """
@@ -315,14 +300,6 @@ EXAMPLES = r"""
       - alias
     excludes:
       - '.*TEMP.*'
-
-- name: Find all PDS/PDSE aliases and include their member alias detail
-  zos_find:
-    patterns:
-      - ANSIBLE.ALIAS.TEST.*
-    resource_type:
-      - alias
-    include_member_aliases: true
 """
 
 
@@ -360,15 +337,6 @@ data_sets:
         "name": "USER.ALIAS.NAME",
         "alias_of": "USER.REAL.DATASET",
         "type": "ALIAS"
-      },
-      {
-        "name": "USER.PDS.ALIAS",
-        "alias_of": "USER.REAL.PDS",
-        "type": "ALIAS",
-        "member_aliases": [
-          {"member": "MEM1", "aliases": ["ALIAS1", "ALIAS2"]},
-          {"member": "MEM2", "aliases": ["ALIAS3"]}
-        ]
       }
     ]
 matched:
@@ -1158,7 +1126,6 @@ def _dls_wrapper(
     migrated=False,
     data_set_type="",
     json=False,
-    members=False,
 ):
     """A wrapper for ZOAU 'dls' shell command.
 
@@ -1180,9 +1147,6 @@ def _dls_wrapper(
         Data set type to look for.
     json : bool
         Return content in json format.
-    members : bool
-        Enumerate PDS/PDSE members and member aliases (appends ``-a``).
-        Only meaningful when combined with ``data_set_type="ALIAS"``.
 
     Returns
     -------
@@ -1203,8 +1167,6 @@ def _dls_wrapper(
         dls_cmd += " -v"
     if data_set_type:
         dls_cmd += f" -t{data_set_type}"
-    if members:
-        dls_cmd += " -a"
     if json:
         dls_cmd += " -j"
 
@@ -1287,7 +1249,7 @@ def _ds_type(ds_name):
     return None
 
 
-def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
+def alias_filter(module, patterns, excludes=None):
     """Return all dataset catalog alias entries that match any of the patterns.
 
     Parameters
@@ -1298,11 +1260,6 @@ def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
         A list of data set patterns.
     excludes : list[str], optional
         A list of patterns. Alias names matching any of these are excluded.
-    include_member_aliases : bool, optional
-        When True, pass ``-a`` to ``dls`` so that PDS/PDSE alias entries include
-        a ``members`` array in the JSON output. Each member entry whose
-        ``aliases`` list is non-empty contributes one dict per alias to the
-        ``member_aliases`` list on the result entry.
 
     Returns
     -------
@@ -1311,9 +1268,6 @@ def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
           ``name``           (str)       -- the alias name
           ``alias_of``       (str)       -- the real dataset the alias points to
           ``type``           (str)       -- always "ALIAS"
-          ``member_aliases`` (list[dict]) -- present only when
-            ``include_member_aliases=True`` and the alias points to a PDS/PDSE.
-            Each item is ``{"member": <memname>, "alias": <alias_name>}``.
 
     Raises
     ------
@@ -1326,14 +1280,13 @@ def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
             pattern,
             data_set_type="ALIAS",
             list_details=True,
-            members=include_member_aliases,
             json=True,
         )
         if rc != 0:
             if "BGYSC1103E" in err:
                 # No matching datasets found -- not an error
                 continue
-            flag_str = "dls -ltALIAS -a -j" if include_member_aliases else "dls -ltALIAS -j"
+            flag_str = "dls -ltALIAS -j"
             module.fail_json(
                 msg="Non-zero return code received while executing ZOAU shell command '{0}'".format(flag_str),
                 rc=rc, stdout=out, stderr=err
@@ -1352,16 +1305,8 @@ def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
             entry = {
                 "name": alias_name,
                 "type": "ALIAS",
-                "alias_of": ds.get("relation", ""),
+                "alias_of": ds.get("relation", "")
             }
-            if include_member_aliases:
-                member_aliases = []
-                for mem in ds.get("members", []):
-                    memname = mem.get("memname", "")
-                    aliases = mem.get("aliases", [])
-                    if memname and aliases:
-                        member_aliases.append({"member": memname, "aliases": aliases})
-                entry["member_aliases"] = member_aliases
             filtered.append(entry)
     return filtered
 
@@ -1409,7 +1354,6 @@ def run_module(module):
     extended = module.params.get('extended')
     migrated_type = module.params.get('migrated_type') or module.params.get('migrated_types')
     fifo = module.params.get('fifo')
-    include_member_aliases = module.params.get('include_member_aliases') or False
     vsam_types = {"CLUSTER", "DATA", "INDEX"}
     res_args = dict(data_sets=[])
     examined_ds = 0
@@ -1494,7 +1438,7 @@ def run_module(module):
         elif res_type == "GDG":
             filtered_data_sets = gdg_filter(module, patterns, limit, empty, fifo, purge, scratch, extended, excludes)
         elif res_type == "ALIAS":
-            filtered_data_sets = alias_filter(module, patterns, excludes=excludes, include_member_aliases=include_member_aliases)
+            filtered_data_sets = alias_filter(module, patterns, excludes=excludes)
         if filtered_data_sets:
             for ds in filtered_data_sets:
                 if ds:
@@ -1574,7 +1518,6 @@ def main():
             scratch=dict(type="bool", required=False),
             extended=dict(type="bool", required=False),
             fifo=dict(type="bool", required=False),
-            include_member_aliases=dict(type="bool", required=False, default=False),
         )
     )
 
@@ -1609,7 +1552,6 @@ def main():
         scratch=dict(type="bool", required=False),
         extended=dict(type="bool", required=False),
         fifo=dict(type="bool", required=False),
-        include_member_aliases=dict(arg_type="bool", required=False, default=False),
     )
     try:
         BetterArgParser(arg_def).parse_args(module.params)

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -108,8 +108,10 @@ options:
         with this option. The module only searches based on dataset patterns.
       - C(alias) refers to MVS catalog alias entries. The module returns the alias name and the
         real dataset name it points to (returned as C(alias_of) in each result). The C(patterns),
-        C(excludes), C(volume), and C(include_member_aliases) options are applicable when using
-        this resource type.
+        C(excludes), C(volume), C(age), C(age_stamp), C(size), and C(include_member_aliases)
+        options are applicable when using this resource type. The C(age), C(age_stamp), and
+        C(size) filters are applied against the target dataset (C(alias_of)), not the alias
+        entry itself.
     aliases:
       - resource_types
     choices:
@@ -226,10 +228,10 @@ notes:
   - When searching for content within data sets, only non-binary content is considered.
   - As a migrated data set's information can't be retrieved without recalling it first, other options
     besides C(excludes) and C(migrated_type) are not supported.
-  - When using C(resource_type=alias), the C(age), C(age_stamp), C(size), and C(contains)
-    options are ignored, as aliases are catalog pointers with no independent size, age, or
-    searchable content. The C(volume) option filters aliases whose target dataset resides on
-    one of the specified volumes.
+  - When using C(resource_type=alias), the C(contains) option is ignored, as aliases are
+    catalog pointers with no searchable content. The C(age), C(age_stamp), C(size), and
+    C(volume) options are supported and are applied against the target dataset C(alias_of),
+    only alias entries whose target dataset satisfies the criteria are returned.
   - Parenthesised exclude patterns (e.g. C((^ALIAS1$))) match against PDS/PDSE member alias
     names. Members whose alias name matches the pattern are removed from the C(members) list
     of the alias entry. The alias entry itself is kept unless all members are removed.
@@ -344,6 +346,23 @@ EXAMPLES = r"""
     volumes:
       - VOL001
       - VOL002
+
+- name: Find aliases whose target dataset was created within the last 30 days
+  zos_find:
+    patterns:
+      - USER.*
+    resource_type:
+      - alias
+    age: -30d
+    age_stamp: creation_date
+
+- name: Find aliases whose target dataset is larger than 1MB
+  zos_find:
+    patterns:
+      - USER.*
+    resource_type:
+      - alias
+    size: 1m
 """
 
 
@@ -1574,6 +1593,20 @@ def run_module(module):
                 include_member_aliases=include_member_aliases,
                 volumes=volume if volume else None,
             )
+            # age / age_stamp / size filter alias entries by their target dataset.
+            # data_set_attribute_filter accepts a list of ds names and returns
+            # the subset that passes; we use alias_of as the lookup key.
+            if filtered_data_sets and (age or size):
+                target_names = [ds["alias_of"] for ds in filtered_data_sets if ds.get("alias_of")]
+                surviving_targets = set(
+                    data_set_attribute_filter(
+                        module, target_names, size=size, age=age, age_stamp=age_stamp
+                    )
+                )
+                filtered_data_sets = [
+                    ds for ds in filtered_data_sets
+                    if ds.get("alias_of") in surviving_targets
+                ]
         if filtered_data_sets:
             for ds in filtered_data_sets:
                 if ds:

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -1038,8 +1038,8 @@ def _age_filter(ds_date, now, age):
         Whether 'ds_date' is older than 'age'.
     """
     year, month, day = list(map(int, ds_date.split("/")))
-    if year == "0000":
-        return age >= 0
+    if year == 0:
+        return False
 
     # Seconds per day = 86400
     ds_age = datetime.datetime(year, month, day).timestamp()
@@ -1078,12 +1078,16 @@ def _get_creation_date(module, ds):
             msg="Non-zero return code received while retrieving data set age",
             rc=rc, stderr=err, stdout=out
         )
-    out = re.findall(r"CREATION-*[A-Z|0-9]*", out.strip())
+    # out = re.findall(r"CREATION-*[A-Z|0-9]*", out.strip())
+    out = re.findall(r"CREATION-*[A-Z|0-9\.]*", out.strip())
     if out:
         out = out[0]
-        date = "".join(re.findall(r"-[A-Z|0-9]*", out)).replace("-", "").split(".")
+        # date = "".join(re.findall(r"-[A-Z|0-9]*", out)).replace("-", "").split(".")
+        date = "".join(re.findall(r"-[A-Z|0-9\.]*", out)).replace("-", "").split(".")
         days = 1 if len(date) < 2 else int(date[1])
         years = int(date[0])
+        if years == 0:
+            return "0000/1/1"
         days_per_month = 30.4167
         return "{0}/{1}/{2}".format(
             years,
@@ -1091,8 +1095,8 @@ def _get_creation_date(module, ds):
             math.ceil(days % days_per_month)
         )
 
-    # If no creation data is found, return default "000/1/1"
-    return "000/1/1"
+    # If no creation data is found, return default "0000/1/1"
+    return "0000/1/1"
 
 
 def _size_filter(ds_size, size):

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -224,8 +224,10 @@ notes:
   - When using C(resource_type=alias), the C(age), C(age_stamp), C(size), C(volume),
     and C(contains) options are ignored, as aliases are catalog pointers with no
     independent attributes. Only C(patterns), C(excludes), and C(include_member_aliases) apply.
+    Member-level exclude patterns (parenthesised expressions such as C((^MEM.*))) are also
+    ignored for C(alias) resource type.
   - When C(include_member_aliases=true), PDS/PDSE alias entries additionally include
-    a C(member_aliases) list showing each member and its in-directory alias names.
+    a C(members) list showing each member and its in-directory alias names.
 seealso:
 - module: ibm.ibm_zos_core.zos_data_set
 """

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -457,7 +457,6 @@ rc:
 import re
 import time
 import datetime
-import math
 import json
 
 from re import match as fullmatch
@@ -1090,16 +1089,13 @@ def _get_creation_date(module, ds):
     if out:
         out = out[0]
         date = "".join(re.findall(r"-[A-Z|0-9\.]*", out)).replace("-", "").split(".")
-        days = 1 if len(date) < 2 else int(date[1])
         years = int(date[0])
         if years == 0:
             return "0000/1/1"
-        days_per_month = 30.4167
-        return "{0}/{1}/{2}".format(
-            years,
-            math.ceil(days / days_per_month),
-            math.ceil(days % days_per_month)
-        )
+        days = 1 if len(date) < 2 else int(date[1])
+        return datetime.datetime.strptime(
+            "{0}.{1}".format(years, days), "%Y.%j"
+        ).strftime("%Y/%m/%d")
 
     # If no creation data is found, return default "0000/1/1"
     return "0000/1/1"

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -309,10 +309,6 @@ data_sets:
       - All matches found with the specified criteria.
       - For C(alias) resource types, each entry includes an C(alias_of) field
         containing the real dataset name the alias points to.
-      - When C(include_member_aliases=true), PDS/PDSE alias entries additionally
-        include a C(member_aliases) list of dicts. Each dict has a C(member) key
-        (the member name) and an C(aliases) key (a list of alias names for that member).
-        Members with no aliases are omitted from the list.
     returned: success
     type: list
     sample: [
@@ -785,7 +781,7 @@ def gdg_filter(module, data_sets, limit, empty, fifo, purge, scratch, extended, 
         except Exception as e:
             module.fail_json(repr(e))
 
-        return filtered_data_sets
+    return filtered_data_sets
 
 
 # TODO:

--- a/plugins/modules/zos_find.py
+++ b/plugins/modules/zos_find.py
@@ -103,8 +103,8 @@ options:
       - C(migrated) refers to listing migrated datasets. Only C(excludes) and C(migrated_type) options can be used along
         with this option. The module only searches based on dataset patterns.
       - C(alias) refers to MVS catalog alias entries. The module returns the alias name and the
-        real dataset name it points to (returned as C(alias_of) in each result). Only C(patterns)
-        and C(excludes) options are applicable when using this resource type.
+        real dataset name it points to (returned as C(alias_of) in each result). Only C(patterns),
+        C(excludes), and C(include_member_aliases) options are applicable when using this resource type.
     aliases:
       - resource_types
     choices:
@@ -179,6 +179,21 @@ options:
       - If provided, will search for data sets with I(scratch) attribute set as provided.
     type: bool
     required: false
+  include_member_aliases:
+    description:
+      - Only valid when C(resource_type=alias).
+      - When C(true), each PDS/PDSE alias entry in the results will include a
+        C(members) list. Each item in that list is a dict with two keys,
+        C(name) (the PDS/PDSE member name) and C(aliases) (a list of alias names
+        that point to that member). Members with no aliases are included with an
+        empty C(aliases) list. Sequential dataset alias entries are unaffected.
+      - When C(false) (the default), only the dataset alias name and the real
+        dataset it points to (C(alias_of)) are returned.
+      - Note that for C(alias) entries, C(members) is a list of dicts, whereas
+        for C(nonvsam) entries C(members) is a list of member name strings.
+    type: bool
+    required: false
+    default: false
 
 attributes:
   action:
@@ -208,7 +223,9 @@ notes:
     besides C(excludes) and C(migrated_type) are not supported.
   - When using C(resource_type=alias), the C(age), C(age_stamp), C(size), C(volume),
     and C(contains) options are ignored, as aliases are catalog pointers with no
-    independent attributes. Only C(patterns) and C(excludes) apply.
+    independent attributes. Only C(patterns), C(excludes), and C(include_member_aliases) apply.
+  - When C(include_member_aliases=true), PDS/PDSE alias entries additionally include
+    a C(member_aliases) list showing each member and its in-directory alias names.
 seealso:
 - module: ibm.ibm_zos_core.zos_data_set
 """
@@ -300,6 +317,14 @@ EXAMPLES = r"""
       - alias
     excludes:
       - '.*TEMP.*'
+
+- name: Find all PDS/PDSE aliases and include their member alias detail
+  zos_find:
+    patterns:
+      - ANSIBLE.ALIAS.TEST.*
+    resource_type:
+      - alias
+    include_member_aliases: true
 """
 
 
@@ -309,6 +334,12 @@ data_sets:
       - All matches found with the specified criteria.
       - For C(alias) resource types, each entry includes an C(alias_of) field
         containing the real dataset name the alias points to.
+      - When C(include_member_aliases=true), PDS/PDSE alias entries additionally
+        include a C(members) list of dicts. Each dict has a C(name) key
+        (the member name) and an C(aliases) key (a list of alias names for that member).
+        Members with no aliases are included with an empty C(aliases) list.
+        Note that for C(alias) entries C(members) is a list of dicts, whereas for
+        C(nonvsam) entries C(members) is a list of member name strings.
     returned: success
     type: list
     sample: [
@@ -333,6 +364,16 @@ data_sets:
         "name": "USER.ALIAS.NAME",
         "alias_of": "USER.REAL.DATASET",
         "type": "ALIAS"
+      },
+      {
+        "name": "USER.PDS.ALIAS",
+        "alias_of": "USER.REAL.PDS",
+        "type": "ALIAS",
+        "members": [
+          {"name": "MEM1", "aliases": ["ALIAS1", "ALIAS2"]},
+          {"name": "MEM2", "aliases": ["ALIAS3"]},
+          {"name": "MEM3", "aliases": []}
+        ]
       }
     ]
 matched:
@@ -1122,6 +1163,7 @@ def _dls_wrapper(
     migrated=False,
     data_set_type="",
     json=False,
+    members=False,
 ):
     """A wrapper for ZOAU 'dls' shell command.
 
@@ -1143,6 +1185,9 @@ def _dls_wrapper(
         Data set type to look for.
     json : bool
         Return content in json format.
+    members : bool
+        Enumerate PDS/PDSE members and member aliases (appends ``-a``).
+        Only meaningful when combined with ``data_set_type="ALIAS"``.
 
     Returns
     -------
@@ -1163,6 +1208,8 @@ def _dls_wrapper(
         dls_cmd += " -v"
     if data_set_type:
         dls_cmd += f" -t{data_set_type}"
+    if members:
+        dls_cmd += " -a"
     if json:
         dls_cmd += " -j"
 
@@ -1245,7 +1292,7 @@ def _ds_type(ds_name):
     return None
 
 
-def alias_filter(module, patterns, excludes=None):
+def alias_filter(module, patterns, excludes=None, include_member_aliases=False):
     """Return all dataset catalog alias entries that match any of the patterns.
 
     Parameters
@@ -1256,14 +1303,21 @@ def alias_filter(module, patterns, excludes=None):
         A list of data set patterns.
     excludes : list[str], optional
         A list of patterns. Alias names matching any of these are excluded.
+    include_member_aliases : bool, optional
+        When True, pass ``-a`` to ``dls`` so that PDS/PDSE alias entries include
+        a ``members`` array in the JSON output. All members are returned; those
+        with no aliases have an empty ``aliases`` list.
 
     Returns
     -------
     list[dict]
         Each dict contains:
-          ``name``           (str)       -- the alias name
-          ``alias_of``       (str)       -- the real dataset the alias points to
-          ``type``           (str)       -- always "ALIAS"
+          ``name``     (str)       -- the alias name
+          ``alias_of`` (str)       -- the real dataset the alias points to
+          ``type``     (str)       -- always "ALIAS"
+          ``members``  (list[dict]) -- present only when
+            ``include_member_aliases=True`` and the alias points to a PDS/PDSE.
+            Each item is ``{"name": <memname>, "aliases": [<alias_name>, ...]}``.
 
     Raises
     ------
@@ -1276,13 +1330,14 @@ def alias_filter(module, patterns, excludes=None):
             pattern,
             data_set_type="ALIAS",
             list_details=True,
+            members=include_member_aliases,
             json=True,
         )
         if rc != 0:
             if "BGYSC1103E" in err:
                 # No matching datasets found -- not an error
                 continue
-            flag_str = "dls -ltALIAS -j"
+            flag_str = "dls -ltALIAS -a -j" if include_member_aliases else "dls -ltALIAS -j"
             module.fail_json(
                 msg="Non-zero return code received while executing ZOAU shell command '{0}'".format(flag_str),
                 rc=rc, stdout=out, stderr=err
@@ -1301,8 +1356,15 @@ def alias_filter(module, patterns, excludes=None):
             entry = {
                 "name": alias_name,
                 "type": "ALIAS",
-                "alias_of": ds.get("relation", "")
+                "alias_of": ds.get("relation", ""),
             }
+            if include_member_aliases:
+                members = []
+                for mem in ds.get("members", []):
+                    memname = mem.get("memname", "")
+                    if memname:
+                        members.append({"name": memname, "aliases": mem.get("aliases", [])})
+                entry["members"] = members
             filtered.append(entry)
     return filtered
 
@@ -1350,6 +1412,7 @@ def run_module(module):
     extended = module.params.get('extended')
     migrated_type = module.params.get('migrated_type') or module.params.get('migrated_types')
     fifo = module.params.get('fifo')
+    include_member_aliases = module.params.get('include_member_aliases') or False
     vsam_types = {"CLUSTER", "DATA", "INDEX"}
     res_args = dict(data_sets=[])
     examined_ds = 0
@@ -1434,7 +1497,7 @@ def run_module(module):
         elif res_type == "GDG":
             filtered_data_sets = gdg_filter(module, patterns, limit, empty, fifo, purge, scratch, extended, excludes)
         elif res_type == "ALIAS":
-            filtered_data_sets = alias_filter(module, patterns, excludes=excludes)
+            filtered_data_sets = alias_filter(module, patterns, excludes=excludes, include_member_aliases=include_member_aliases)
         if filtered_data_sets:
             for ds in filtered_data_sets:
                 if ds:
@@ -1514,6 +1577,7 @@ def main():
             scratch=dict(type="bool", required=False),
             extended=dict(type="bool", required=False),
             fifo=dict(type="bool", required=False),
+            include_member_aliases=dict(type="bool", required=False, default=False),
         )
     )
 
@@ -1548,6 +1612,7 @@ def main():
         scratch=dict(type="bool", required=False),
         extended=dict(type="bool", required=False),
         fifo=dict(type="bool", required=False),
+        include_member_aliases=dict(arg_type="bool", required=False, default=False),
     )
     try:
         BetterArgParser(arg_def).parse_args(module.params)

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -1222,6 +1222,7 @@ def test_find_alias_for_gdg_generation(ansible_zos_module):
             stdin=f"  DELETE {gdg_base} -\n    GDG\n",
         )
 
+
 def test_find_alias_excludes_pds_and_pdse(ansible_zos_module):
     """Aliases for PS, PDS, and PDSE created under one HLQ.
     PDS and PDSE catalog aliases are excluded by pattern; only the PS alias is returned.
@@ -1740,3 +1741,207 @@ def test_find_alias_filter_by_volume(ansible_zos_module, volumes_on_systems):
         hosts.all.shell(cmd=f"drm {ps_name}")
         hosts.all.zos_data_set(name=pds_name,  state="absent")
         hosts.all.zos_data_set(name=pdse_name, state="absent")
+
+def test_find_alias_filters_by_target_size(ansible_zos_module):
+    """Alias size filtering uses the target sequential dataset allocated size.
+
+    Creates two PS datasets and catalog aliases pointing to them:
+    - one target smaller than 2 MB
+    - one target larger than 4 MB
+
+    Verifies alias filtering by size returns the alias whose target is:
+    - > 2 MB
+    - < 2 MB
+    """
+    hosts = ansible_zos_module
+    hlq = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    small_ps_name = f"{hlq}.SMALL"
+    large_ps_name = f"{hlq}.LARGE"
+    small_ali_name = f"{hlq}.SMALL.ALI"
+    large_ali_name = f"{hlq}.LARGE.ALI"
+    alias_pattern = f"{hlq}.*"
+
+    try:
+        hosts.all.zos_data_set(
+            batch=[
+                {
+                    "name": small_ps_name,
+                    "type": "seq",
+                    "state": "present",
+                    "space_primary": 1,
+                    "space_type": "m",
+                    "record_length": 80,
+                    "record_format": "fb",
+                },
+                {
+                    "name": large_ps_name,
+                    "type": "seq",
+                    "state": "present",
+                    "space_primary": 5,
+                    "space_type": "m",
+                    "record_length": 80,
+                    "record_format": "fb",
+                },
+            ]
+        )
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({small_ali_name}) -\n"
+                f"     RELATE({small_ps_name}))\n"
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({large_ali_name}) -\n"
+                f"     RELATE({large_ps_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+
+        larger_find_res = hosts.all.zos_find(
+            patterns=[alias_pattern],
+            resource_type=["alias"],
+            size="2m",
+        )
+        for val in larger_find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"expected only alias for target > 2 MB, got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"] == "ALIAS"
+            assert ds["name"] == large_ali_name
+            assert ds["alias_of"] == large_ps_name
+            assert val.get("matched") == 1
+            assert val.get("examined") is not None
+            assert val.get("msg") is None
+
+        smaller_find_res = hosts.all.zos_find(
+            patterns=[alias_pattern],
+            resource_type=["alias"],
+            size="-2m",
+        )
+        for val in smaller_find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"expected only alias for target < 2 MB, got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"] == "ALIAS"
+            assert ds["name"] == small_ali_name
+            assert ds["alias_of"] == small_ps_name
+            assert val.get("matched") == 1
+            assert val.get("examined") is not None
+            assert val.get("msg") is None
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DELETE {small_ali_name} -\n    ALIAS\n"
+                f"  DELETE {large_ali_name} -\n    ALIAS\n"
+            ),
+        )
+        hosts.all.shell(cmd=f"drm {small_ps_name}")
+        hosts.all.shell(cmd=f"drm {large_ps_name}")
+
+        def test_find_alias_filters_by_target_size(ansible_zos_module):
+    """Alias size filtering uses the target sequential dataset allocated size.
+
+    Creates two PS datasets and catalog aliases pointing to them:
+    - one target smaller than 2 MB
+    - one target larger than 4 MB
+
+    Verifies alias filtering by size returns the alias whose target is:
+    - > 2 MB
+    - < 2 MB
+    """
+    hosts = ansible_zos_module
+    hlq = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    small_ps_name = f"{hlq}.SMALL"
+    large_ps_name = f"{hlq}.LARGE"
+    small_ali_name = f"{hlq}.SMALL.ALI"
+    large_ali_name = f"{hlq}.LARGE.ALI"
+    alias_pattern = f"{hlq}.*"
+
+    try:
+        hosts.all.zos_data_set(
+            batch=[
+                {
+                    "name": small_ps_name,
+                    "type": "seq",
+                    "state": "present",
+                    "space_primary": 1,
+                    "space_type": "m",
+                    "record_length": 80,
+                    "record_format": "fb",
+                },
+                {
+                    "name": large_ps_name,
+                    "type": "seq",
+                    "state": "present",
+                    "space_primary": 5,
+                    "space_type": "m",
+                    "record_length": 80,
+                    "record_format": "fb",
+                },
+            ]
+        )
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({small_ali_name}) -\n"
+                f"     RELATE({small_ps_name}))\n"
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({large_ali_name}) -\n"
+                f"     RELATE({large_ps_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+
+        larger_find_res = hosts.all.zos_find(
+            patterns=[alias_pattern],
+            resource_type=["alias"],
+            size="2m",
+        )
+        for val in larger_find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"expected only alias for target > 2 MB, got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"] == "ALIAS"
+            assert ds["name"] == large_ali_name
+            assert ds["alias_of"] == large_ps_name
+            assert val.get("matched") == 1
+
+        smaller_find_res = hosts.all.zos_find(
+            patterns=[alias_pattern],
+            resource_type=["alias"],
+            size="-2m",
+        )
+        for val in smaller_find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"expected only alias for target < 2 MB, got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"] == "ALIAS"
+            assert ds["name"] == small_ali_name
+            assert ds["alias_of"] == small_ps_name
+            assert val.get("matched") == 1
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DELETE {small_ali_name} -\n    ALIAS\n"
+                f"  DELETE {large_ali_name} -\n    ALIAS\n"
+            ),
+        )
+        hosts.all.shell(cmd=f"drm {small_ps_name}")
+        hosts.all.shell(cmd=f"drm {large_ps_name}")

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -874,3 +874,468 @@ def test_find_migrated_and_gdg_data_sets(ansible_zos_module):
     finally:
         # Remove GDG.
         hosts.all.shell(cmd=f"drm {gdg_a}")
+
+
+# ---------------------------------------------------------------------------
+# Alias test suite (Enhancement #2446)
+# ---------------------------------------------------------------------------
+_IDCAMS_CMD = "mvscmdauth --pgm=IDCAMS --sysprint=* --sysin=stdin"
+
+def test_find_two_gdg_bases(ansible_zos_module):
+    """Create two GDG bases with limit=5 and verify both are returned by zos_find
+    with resource_type=gdg and matched==2."""
+    hosts = ansible_zos_module
+    gdg_a = get_tmp_ds_name()
+    gdg_b = get_tmp_ds_name()
+    try:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD,
+            executable='/bin/sh',
+            stdin=f"""
+  DEFINE GDG (NAME({gdg_a}) LIMIT(5) NOEMPTY SCRATCH)
+  DEFINE GDG (NAME({gdg_b}) LIMIT(5) NOEMPTY SCRATCH)
+""",
+        )
+        find_res = hosts.all.zos_find(
+            patterns=[gdg_a, gdg_b],
+            resource_type=["gdg"],
+            limit=5,
+        )
+        for val in find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None
+            assert val.get("matched") == 2
+            returned_names = {ds["name"] for ds in data_sets}
+            assert gdg_a in returned_names
+            assert gdg_b in returned_names
+            for ds in data_sets:
+                assert ds.get("type") == "GDG"
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {gdg_a} GDG\n  DELETE {gdg_b} GDG\n",
+        ) 
+
+
+def test_find_alias_for_ps(ansible_zos_module):
+    """Alias for a Sequential (PS) dataset.
+    Creates a PS dataset and one catalog ALIAS entry pointing to it.
+    Verifies:
+    - Returned entry has type=ALIAS, correct name, and alias_of == PS dataset name.
+    - No member_aliases key (PS datasets have no members).
+    - matched == 1.
+    """
+    hosts = ansible_zos_module
+    hlq       = get_tmp_ds_name()
+    ps_name   = f"{hlq}.SEQ"
+    ali_name  = f"{hlq}.SEQ.ALI"
+    # Pattern must end with .* at the qualifier level of the alias name.
+    # get_tmp_ds_name() returns 4 qualifiers; alias is 6 qualifiers deep,
+    # so {hlq}.SEQ.* (5 qualifiers + *) targets the alias level exactly.
+    ali_pattern = f"{hlq}.SEQ.*"
+    try:
+        hosts.all.shell(cmd=f"dtouch -tseq -l80 -rFB -s1 -e1 {ps_name}")
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({ps_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+        find_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+        )
+        print(find_res.contacted.values())
+        for val in find_res.contacted.values():
+            assert val.get("msg") is None
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == ali_name
+            assert ds["alias_of"] == ps_name
+            assert "members" not in ds
+            assert val.get("matched") == 1
+            assert val.get("examined") is not None
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.shell(cmd=f"drm {ps_name}")
+
+
+def test_find_alias_for_pds(ansible_zos_module):
+    """Alias for a PDS dataset — without include_member_aliases.
+    Creates a PDS with members MBR1 and MBR2, then creates a catalog ALIAS.
+    Verifies:
+    - Returned entry has type=ALIAS, correct name, and alias_of == PDS name.
+    - No 'members' key in result (include_member_aliases defaults to False).
+    - matched == 1.
+    """
+    hosts = ansible_zos_module
+    hlq       = get_tmp_ds_name()
+    pds_name  = f"{hlq}.PDS"
+    ali_name  = f"{hlq}.PDS.ALI"
+    ali_pattern = f"{hlq}.PDS.*"
+    try:
+        hosts.all.zos_data_set(name=pds_name, type="pds", state="present",
+                               space_primary=1, space_type="m")
+        hosts.all.zos_data_set(batch=[
+            {"name": f"{pds_name}(MBR1)", "type": "member", "state": "present"},
+            {"name": f"{pds_name}(MBR2)", "type": "member", "state": "present"},
+        ])
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({pds_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+        find_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+        )
+        for val in find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == ali_name
+            assert ds["alias_of"] == pds_name
+            assert "members" not in ds
+            assert val.get("matched") == 1
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.zos_data_set(name=pds_name, state="absent")
+
+
+def test_find_alias_for_pds_include_member_aliases(ansible_zos_module):
+    """Alias for a PDS dataset — with include_member_aliases=True.
+    Creates a PDS with members MBR1 and MBR2, creates a member alias MALIAS1
+    pointing to MBR1, then creates a catalog ALIAS pointing to the PDS.
+    Verifies:
+    - Returned entry has type=ALIAS, correct name, and alias_of == PDS name.
+    - 'members' key is present; all members are listed (MBR1 and MBR2).
+    - MBR1 has MALIAS1 in its aliases list.
+    - MBR2 has no member aliases (empty aliases list).
+    - matched == 1.
+    """
+    hosts = ansible_zos_module
+    hlq       = get_tmp_ds_name()
+    pds_name  = f"{hlq}.PDS"
+    ali_name  = f"{hlq}.PDS.ALI"
+    ali_pattern = f"{hlq}.PDS.*"
+    try:
+        hosts.all.zos_data_set(name=pds_name, type="pds", state="present",
+                               space_primary=1, space_type="m")
+        hosts.all.zos_data_set(batch=[
+            {"name": f"{pds_name}(MBR1)", "type": "member", "state": "present"},
+            {"name": f"{pds_name}(MBR2)", "type": "member", "state": "present"},
+        ])
+        # Create member alias MALIAS1 → MBR1 inside the PDS directory
+        hosts.all.shell(
+            cmd=f"tso \"RENAME '{pds_name}(MBR1)' (MALIAS1) ALIAS\""
+        )
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({pds_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+        find_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+            include_member_aliases=True,
+        )
+        for val in find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == ali_name
+            assert ds["alias_of"] == pds_name
+            assert "members" in ds
+            member_names = [m["name"] for m in ds["members"]]
+            assert "MBR1" in member_names
+            assert "MBR2" in member_names
+            for m in ds["members"]:
+                assert "name" in m
+                assert "aliases" in m
+                assert isinstance(m["aliases"], list)
+                if m["name"] == "MBR1":
+                    assert "MALIAS1" in m["aliases"], (
+                        f"Expected MALIAS1 in MBR1 aliases but got {m['aliases']}"
+                    )
+                elif m["name"] == "MBR2":
+                    assert m["aliases"] == [], (
+                        f"Expected no member aliases for MBR2 but got {m['aliases']}"
+                    )
+            assert val.get("matched") == 1
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.zos_data_set(name=pds_name, state="absent")
+
+
+def test_find_alias_for_pdse_include_member_alias(ansible_zos_module):
+    """Alias for a PDSE dataset that contains a member alias — with include_member_aliases=True.
+    Creates a PDSE with members MEM1 and MEM2, creates member alias ALIAS1 → MEM1,
+    then creates a catalog ALIAS for the PDSE itself.
+    Verifies:
+    - type=ALIAS, correct name, alias_of == PDSE name.
+    - 'members' key is present; all members are listed (MEM1 and MEM2).
+    - MEM1 has ALIAS1 in its aliases list.
+    - MEM2 has no member aliases (empty aliases list).
+    - matched == 1.
+    """
+    hosts = ansible_zos_module
+    hlq       = get_tmp_ds_name()
+    pdse_name = f"{hlq}.PDSE"
+    ali_name  = f"{hlq}.PDSE.ALI"
+    ali_pattern = f"{hlq}.PDSE.*"
+    try:
+        hosts.all.shell(cmd=f"dtouch -tpdse -l80 -rFB -s5 -e5 {pdse_name}")
+        hosts.all.shell(cmd=f"dcp 'Test' \"//'{ pdse_name }(MEM1)'\"")
+        hosts.all.shell(cmd=f"dcp 'Test' \"//'{ pdse_name }(MEM2)'\"")
+        hosts.all.shell(cmd=f"tso \"RENAME '{pdse_name}(MEM1)' (ALIAS1) ALIAS\"")
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({pdse_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+        find_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+            include_member_aliases=True,
+        )
+        for val in find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == ali_name
+            assert ds["alias_of"] == pdse_name
+            # All members must appear; MEM1 has ALIAS1, MEM2 has none.
+            assert "members" in ds, "PDSE alias must carry 'members' when include_member_aliases=True"
+            member_names = [m["name"] for m in ds["members"]]
+            assert "MEM1" in member_names, "MEM1 must appear in members"
+            assert "MEM2" in member_names, "MEM2 must appear in members"
+            mem1 = next(m for m in ds["members"] if m["name"] == "MEM1")
+            assert "ALIAS1" in mem1["aliases"], "ALIAS1 must be listed under MEM1"
+            mem2 = next(m for m in ds["members"] if m["name"] == "MEM2")
+            assert mem2["aliases"] == [], "MEM2 has no aliases; list must be empty"
+            assert val.get("matched") == 1
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.shell(cmd=f"drm {pdse_name}")
+
+
+def test_find_alias_for_gdg_generation(ansible_zos_module):
+    """Alias for a GDG generation dataset (G0001V00).
+    GDG *base* entries cannot be aliased — only physical generations can.
+    Creates a GDG base, allocates the first generation, then creates a catalog
+    ALIAS pointing to that generation.
+    Verifies:
+    - type=ALIAS, correct name, alias_of == resolved generation name (G0001V00).
+    - No member_aliases key (sequential dataset).
+    - matched == 1.
+    """
+    hosts = ansible_zos_module
+    # mlq_size=3, llq_size=3 keeps the HLQ at 26 chars so that appending
+    # .GDG.G0001V00 (13 chars) stays within the 44-char z/OS name limit.
+    hlq      = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    gdg_base = f"{hlq}.GDG"
+    gdg_gen  = f"{hlq}.GDG.G0001V00"
+    ali_name = f"{hlq}.GDG.ALI"
+    ali_pattern = f"{hlq}.GDG.*"
+    try:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE GDG -\n"
+                f"    (NAME({gdg_base}) -\n"
+                f"     LIMIT(5) NOEMPTY SCRATCH)\n"
+            ),
+        )
+        hosts.all.shell(cmd=f"dtouch -tseq -l80 -rFB -s1 -e1 '{gdg_base}(+1)'")
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({gdg_gen}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+        find_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+        )
+        for val in find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == ali_name
+            assert ds["alias_of"] == gdg_gen
+            assert "members" not in ds
+            assert val.get("matched") == 1
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {gdg_base} -\n    GDG\n",
+        )
+
+def test_find_alias_excludes_pds_and_pdse(ansible_zos_module):
+    """Aliases for PS, PDS, and PDSE created under one HLQ.
+    PDS and PDSE catalog aliases are excluded by pattern; only the PS alias is returned.
+    Setup:
+      - PS  dataset with catalog alias  <hlq>.SEQ.ALI
+      - PDS dataset with two members:
+            MBR1  → member alias MEMALI1
+            MBR2  (no member alias)
+        catalog alias <hlq>.PDS.ALI
+      - PDSE dataset with two members:
+            MEM1  → member alias ALIAS1
+            MEM2  → member alias ALIAS2
+        catalog alias <hlq>.PDSE.ALI
+    zos_find is called with:
+      patterns:  [<hlq>.*]   -- matches all three catalog aliases
+      excludes:  ['.*\\.PDS\\.ALI', '.*\\.PDSE\\.ALI']
+                 -- fullmatch regexes against the alias dataset name
+    Expected: only <hlq>.SEQ.ALI returned; matched == 1.
+    PDS and PDSE aliases are excluded; 'members' is not present on the PS result
+    (include_member_aliases defaults to False).
+    """
+    hosts = ansible_zos_module
+    hlq       = get_tmp_ds_name()
+    ps_name   = f"{hlq}.SEQ"
+    pds_name  = f"{hlq}.PDS"
+    pdse_name = f"{hlq}.PDSE"
+    ps_ali    = f"{hlq}.SEQ.ALI"
+    pds_ali   = f"{hlq}.PDS.ALI"
+    pdse_ali  = f"{hlq}.PDSE.ALI"
+    # Single pattern covers all three alias names (hlq = 4 qualifiers,
+    # alias names are 6 qualifiers: hlq + .TYPE.ALI → hlq.* covers them).
+    ali_pattern = f"{hlq}.*"
+    # Exclude the PDS and PDSE catalog alias names using fullmatch regex.
+    # _match_regex uses re.fullmatch so the pattern must span the entire name.
+    excludes = [r".*\.PDS\.ALI", r".*\.PDSE\.ALI"]
+    try:
+        # --- Create PS ---
+        hosts.all.shell(cmd=f"dtouch -tseq -l80 -rFB -s1 -e1 {ps_name}")
+        # --- Create PDS with MBR1 (has member alias MEMALI1) and MBR2 (no alias) ---
+        hosts.all.zos_data_set(name=pds_name, type="pds", state="present",
+                               space_primary=1, space_type="m")
+        hosts.all.zos_data_set(batch=[
+            {"name": f"{pds_name}(MBR1)", "type": "member", "state": "present"},
+            {"name": f"{pds_name}(MBR2)", "type": "member", "state": "present"},
+        ])
+        hosts.all.shell(cmd=f"tso \"RENAME '{pds_name}(MBR1)' (MEMALI1) ALIAS\"")
+        # --- Create PDSE with MEM1 → ALIAS1 and MEM2 → ALIAS2 ---
+        hosts.all.shell(cmd=f"dtouch -tpdse -l80 -rFB -s5 -e5 {pdse_name}")
+        hosts.all.shell(cmd=f"dcp 'Test' \"//'{ pdse_name }(MEM1)'\"")
+        hosts.all.shell(cmd=f"dcp 'Test' \"//'{ pdse_name }(MEM2)'\"")
+        hosts.all.shell(cmd=f"tso \"RENAME '{pdse_name}(MEM1)' (ALIAS1) ALIAS\"")
+        hosts.all.shell(cmd=f"tso \"RENAME '{pdse_name}(MEM2)' (ALIAS2) ALIAS\"")
+        # --- Define catalog aliases for all three datasets ---
+        for define_stdin, label in [
+            (
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ps_ali}) -\n"
+                f"     RELATE({ps_name}))\n",
+                "PS"
+            ),
+            (
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pds_ali}) -\n"
+                f"     RELATE({pds_name}))\n",
+                "PDS"
+            ),
+            (
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pdse_ali}) -\n"
+                f"     RELATE({pdse_name}))\n",
+                "PDSE"
+            ),
+        ]:
+            res = hosts.all.shell(cmd=_IDCAMS_CMD, executable='/bin/sh', stdin=define_stdin)
+            for v in res.contacted.values():
+                assert v.get("rc") == 0, (
+                    f"DEFINE ALIAS for {label} failed: {v.get('stdout')} {v.get('stderr')}"
+                )
+        # --- Find with excludes ---
+        find_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+            excludes=excludes,
+        )
+        for val in find_res.contacted.values():
+            assert val.get("msg") is None
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"expected 1 alias (PS only), got {data_sets}"
+            )
+            ds = data_sets[0]
+            # Only the PS alias must survive the excludes filter
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == ps_ali
+            assert ds["alias_of"] == ps_name
+            # include_member_aliases defaults to False — 'members' must not be present
+            assert "members" not in ds
+            assert val.get("matched") == 1
+            # Confirm neither PDS nor PDSE alias is in the result
+            names = [d["name"] for d in data_sets]
+            assert pds_ali  not in names, "PDS alias should have been excluded"
+            assert pdse_ali not in names, "PDSE alias should have been excluded"
+    finally:
+        for ali in (ps_ali, pds_ali, pdse_ali):
+            hosts.all.shell(
+                cmd=_IDCAMS_CMD, executable='/bin/sh',
+                stdin=f"  DELETE {ali} -\n    ALIAS\n",
+            )
+        hosts.all.shell(cmd=f"drm {ps_name}")
+        hosts.all.zos_data_set(name=pds_name,  state="absent")
+        hosts.all.shell(cmd=f"drm {pdse_name}")
+
+
+def test_find_alias_data_sets_no_match(ansible_zos_module):
+    """A pattern that matches no aliases must return an empty data_sets list."""
+    hosts = ansible_zos_module
+    find_res = hosts.all.zos_find(
+        patterns=["ANSIBLE.ALIAS.NONEXISTENT.*"],
+        resource_type=["alias"]
+    )
+    for val in find_res.contacted.values():
+        assert val.get("data_sets") == []
+        assert val.get("matched") == 0

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -1111,10 +1111,15 @@ def test_find_alias_for_pdse_include_member_alias(ansible_zos_module):
     ali_name  = f"{hlq}.PDSE.ALI"
     ali_pattern = f"{hlq}.PDSE.*"
     try:
-        hosts.all.shell(cmd=f"dtouch -tpdse -l80 -rFB -s5 -e5 {pdse_name}")
-        hosts.all.shell(cmd=f"dcp 'Test' \"//'{ pdse_name }(MEM1)'\"")
-        hosts.all.shell(cmd=f"dcp 'Test' \"//'{ pdse_name }(MEM2)'\"")
-        hosts.all.shell(cmd=f"tso \"RENAME '{pdse_name}(MEM1)' (ALIAS1) ALIAS\"")
+        hosts.all.zos_data_set(name=pdse_name, type="pdse", state="present",
+                               space_primary=5, space_type="m")
+        hosts.all.zos_data_set(batch=[
+            {"name": f"{pdse_name}(MEM1)", "type": "member", "state": "present"},
+            {"name": f"{pdse_name}(MEM2)", "type": "member", "state": "present"},
+        ])
+        rename_res = hosts.all.shell(cmd=f"tso \"RENAME '{pdse_name}(MEM1)' (ALIAS1) ALIAS\"")
+        for v in rename_res.contacted.values():
+            assert v.get("rc") == 0, f"RENAME alias failed: {v.get('stdout')} {v.get('stderr')}"
         define_res = hosts.all.shell(
             cmd=_IDCAMS_CMD, executable='/bin/sh',
             stdin=(
@@ -1130,6 +1135,7 @@ def test_find_alias_for_pdse_include_member_alias(ansible_zos_module):
             resource_type=["alias"],
             include_member_aliases=True,
         )
+        print(find_res.contacted.values())
         for val in find_res.contacted.values():
             data_sets = val.get("data_sets")
             assert data_sets is not None and len(data_sets) == 1
@@ -1152,7 +1158,7 @@ def test_find_alias_for_pdse_include_member_alias(ansible_zos_module):
             cmd=_IDCAMS_CMD, executable='/bin/sh',
             stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
         )
-        hosts.all.shell(cmd=f"drm {pdse_name}")
+        hosts.all.zos_data_set(name=pdse_name, state="absent")
 
 
 def test_find_alias_for_gdg_generation(ansible_zos_module):
@@ -1263,9 +1269,12 @@ def test_find_alias_excludes_pds_and_pdse(ansible_zos_module):
         ])
         hosts.all.shell(cmd=f"tso \"RENAME '{pds_name}(MBR1)' (MEMALI1) ALIAS\"")
         # --- Create PDSE with MEM1 → ALIAS1 and MEM2 → ALIAS2 ---
-        hosts.all.shell(cmd=f"dtouch -tpdse -l80 -rFB -s5 -e5 {pdse_name}")
-        hosts.all.shell(cmd=f"dcp 'Test' \"//'{ pdse_name }(MEM1)'\"")
-        hosts.all.shell(cmd=f"dcp 'Test' \"//'{ pdse_name }(MEM2)'\"")
+        hosts.all.zos_data_set(name=pdse_name, type="pdse", state="present",
+                               space_primary=5, space_type="m")
+        hosts.all.zos_data_set(batch=[
+            {"name": f"{pdse_name}(MEM1)", "type": "member", "state": "present"},
+            {"name": f"{pdse_name}(MEM2)", "type": "member", "state": "present"},
+        ])
         hosts.all.shell(cmd=f"tso \"RENAME '{pdse_name}(MEM1)' (ALIAS1) ALIAS\"")
         hosts.all.shell(cmd=f"tso \"RENAME '{pdse_name}(MEM2)' (ALIAS2) ALIAS\"")
         # --- Define catalog aliases for all three datasets ---
@@ -1326,7 +1335,7 @@ def test_find_alias_excludes_pds_and_pdse(ansible_zos_module):
             )
         hosts.all.shell(cmd=f"drm {ps_name}")
         hosts.all.zos_data_set(name=pds_name,  state="absent")
-        hosts.all.shell(cmd=f"drm {pdse_name}")
+        hosts.all.zos_data_set(name=pdse_name, state="absent")
 
 
 def test_find_alias_data_sets_no_match(ansible_zos_module):
@@ -1339,3 +1348,282 @@ def test_find_alias_data_sets_no_match(ansible_zos_module):
     for val in find_res.contacted.values():
         assert val.get("data_sets") == []
         assert val.get("matched") == 0
+
+
+def test_find_alias_excludes_alias_dataset_by_name(ansible_zos_module):
+    """Exclude a catalog alias entry by its dataset name using a plain regex.
+
+    Setup:
+      - PDS  ``<hlq>.PDS``  with catalog alias ``<hlq>.PDS.ALI``
+      - PDSE ``<hlq>.PDSE`` with catalog alias ``<hlq>.PDSE.ALI``
+
+    zos_find is called with:
+      patterns:  [``<hlq>.*``]        -- matches both catalog aliases
+      excludes:  [r'.*\\.PDS\\.ALI']  -- fullmatch regex; drops only the PDS alias
+
+    Expected:
+      - Only ``<hlq>.PDSE.ALI`` is returned (matched == 1).
+      - ``<hlq>.PDS.ALI`` is absent from data_sets.
+      - ``members`` key is absent (include_member_aliases defaults to False,
+        no parenthesised exclude either).
+    """
+    hosts = ansible_zos_module
+    hlq       = get_tmp_ds_name()
+    pds_name  = f"{hlq}.PDS"
+    pdse_name = f"{hlq}.PDSE"
+    pds_ali   = f"{hlq}.PDS.ALI"
+    pdse_ali  = f"{hlq}.PDSE.ALI"
+    ali_pattern = f"{hlq}.*"
+    try:
+        # --- Create PDS with two members ---
+        hosts.all.zos_data_set(name=pds_name, type="pds", state="present",
+                               space_primary=1, space_type="m")
+        hosts.all.zos_data_set(batch=[
+            {"name": f"{pds_name}(MBR1)", "type": "member", "state": "present"},
+            {"name": f"{pds_name}(MBR2)", "type": "member", "state": "present"},
+        ])
+        # --- Create PDSE with two members ---
+        hosts.all.shell(cmd=f"dtouch -tpdse -l80 -rFB -s5 -e5 {pdse_name}")
+        hosts.all.shell(cmd=f"dcp 'Test' \"//'{ pdse_name }(MEM1)'\"")
+        hosts.all.shell(cmd=f"dcp 'Test' \"//'{ pdse_name }(MEM2)'\"")
+        # --- Define catalog aliases ---
+        for stdin, label in [
+            (
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pds_ali}) -\n"
+                f"     RELATE({pds_name}))\n",
+                "PDS",
+            ),
+            (
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pdse_ali}) -\n"
+                f"     RELATE({pdse_name}))\n",
+                "PDSE",
+            ),
+        ]:
+            res = hosts.all.shell(cmd=_IDCAMS_CMD, executable='/bin/sh', stdin=stdin)
+            for v in res.contacted.values():
+                assert v.get("rc") == 0, (
+                    f"DEFINE ALIAS for {label} failed: {v.get('stdout')} {v.get('stderr')}"
+                )
+        # --- Find: exclude the PDS catalog alias by its name ---
+        find_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+            excludes=[r".*\.PDS\.ALI"],
+        )
+        for val in find_res.contacted.values():
+            assert val.get("msg") is None
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"expected 1 alias (PDSE only), got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == pdse_ali
+            assert ds["alias_of"] == pdse_name
+            # No parenthesised exclude and include_member_aliases is False
+            assert "members" not in ds
+            # Confirm PDS alias is absent
+            names = [d["name"] for d in data_sets]
+            assert pds_ali not in names, "PDS alias should have been excluded"
+            assert val.get("matched") == 1
+    finally:
+        for ali in (pds_ali, pdse_ali):
+            hosts.all.shell(
+                cmd=_IDCAMS_CMD, executable='/bin/sh',
+                stdin=f"  DELETE {ali} -\n    ALIAS\n",
+            )
+        hosts.all.zos_data_set(name=pds_name, state="absent")
+        hosts.all.shell(cmd=f"drm {pdse_name}")
+
+
+def test_find_alias_excludes_member_aliases_by_pattern(ansible_zos_module):
+    """Exclude PDS members whose in-directory alias name matches a parenthesised pattern.
+
+    Setup:
+      - PDS ``<hlq>.PDS`` with:
+          MBR1  → member alias ALIAS1
+          MBR2  → member alias ALIAS2
+          MBR3  (no member alias)
+      - Catalog alias ``<hlq>.PDS.ALI`` pointing to the PDS.
+
+    zos_find is called with:
+      patterns:  [``<hlq>.PDS.*``]
+      excludes:  ['(^ALIAS.*)']   -- parenthesised regex; matches any alias name
+                                     starting with "ALIAS"
+
+    Expected:
+      - The catalog alias entry ``<hlq>.PDS.ALI`` is still returned (dataset-level
+        exclude does not apply).
+      - ``members`` key IS present (forced on whenever a parenthesised exclude is used).
+      - MBR1 and MBR2 are absent from ``members`` (their alias names matched the pattern).
+      - MBR3 is present in ``members`` with an empty ``aliases`` list (it has no
+        member alias, so it could not have matched and is kept).
+      - matched == 1.
+    """
+    hosts = ansible_zos_module
+    hlq       = get_tmp_ds_name()
+    pds_name  = f"{hlq}.PDS"
+    ali_name  = f"{hlq}.PDS.ALI"
+    ali_pattern = f"{hlq}.PDS.*"
+    try:
+        # --- Create PDS with three members ---
+        hosts.all.zos_data_set(name=pds_name, type="pds", state="present",
+                               space_primary=1, space_type="m")
+        hosts.all.zos_data_set(batch=[
+            {"name": f"{pds_name}(MBR1)", "type": "member", "state": "present"},
+            {"name": f"{pds_name}(MBR2)", "type": "member", "state": "present"},
+            {"name": f"{pds_name}(MBR3)", "type": "member", "state": "present"},
+        ])
+        # Create in-directory member aliases: ALIAS1 → MBR1, ALIAS2 → MBR2
+        hosts.all.shell(cmd=f"tso \"RENAME '{pds_name}(MBR1)' (ALIAS1) ALIAS\"")
+        hosts.all.shell(cmd=f"tso \"RENAME '{pds_name}(MBR2)' (ALIAS2) ALIAS\"")
+        # --- Define catalog alias for the PDS ---
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({pds_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+        # --- Find: parenthesised exclude removes members with alias names matching ALIAS.* ---
+        find_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+            excludes=["(^ALIAS.*)"],
+        )
+        for val in find_res.contacted.values():
+            assert val.get("msg") is None
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"catalog alias entry must still be returned, got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == ali_name
+            assert ds["alias_of"] == pds_name
+            # members key is forced into output by the parenthesised exclude
+            assert "members" in ds, (
+                "parenthesised exclude must force 'members' into output"
+            )
+            member_names = [m["name"] for m in ds["members"]]
+            # MBR1 and MBR2 had alias names matching ^ALIAS.* → removed
+            assert "MBR1" not in member_names, "MBR1 should be excluded (its alias ALIAS1 matched)"
+            assert "MBR2" not in member_names, "MBR2 should be excluded (its alias ALIAS2 matched)"
+            # MBR3 has no alias → cannot match the alias-name exclude → kept
+            assert "MBR3" in member_names, "MBR3 has no alias name so it must survive"
+            mbr3 = next(m for m in ds["members"] if m["name"] == "MBR3")
+            assert mbr3["aliases"] == [], "MBR3 has no member aliases"
+            assert val.get("matched") == 1
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.zos_data_set(name=pds_name, state="absent")
+
+
+def test_find_alias_excludes_all_member_aliases(ansible_zos_module):
+    """Exclude ALL members that carry any alias using the catch-all pattern (^.*$).
+
+    Setup:
+      - PDS ``<hlq>.PDS`` with:
+          MBR1  → member alias ALIAS1
+          MBR2  → member alias ALIAS2
+          MBR3  (no member alias)
+      - Catalog alias ``<hlq>.PDS.ALI`` pointing to the PDS.
+
+    zos_find is called with:
+      patterns:  [``<hlq>.PDS.*``]
+      resource_type: [alias]
+      excludes:  ['(^.*$)']   -- parenthesised catch-all: matches any non-empty
+                                 alias name, so every member that has at least
+                                 one alias is removed.
+
+    Expected:
+      - The catalog alias entry ``<hlq>.PDS.ALI`` is still returned (dataset-level
+        exclude does not apply — the pattern is fully parenthesised with nothing
+        outside the parens).
+      - ``members`` key IS present (forced by the parenthesised exclude).
+      - MBR1 and MBR2 are absent (their alias names ALIAS1 / ALIAS2 matched ``^.*$``).
+      - MBR3 is present with ``aliases: []`` — it has no alias name so ``^.*$``
+        never runs against it; it cannot be excluded.
+      - matched == 1.
+    """
+    hosts = ansible_zos_module
+    hlq       = get_tmp_ds_name()
+    pds_name  = f"{hlq}.PDS"
+    ali_name  = f"{hlq}.PDS.ALI"
+    ali_pattern = f"{hlq}.PDS.*"
+    try:
+        # --- Create PDS with three members ---
+        hosts.all.zos_data_set(name=pds_name, type="pds", state="present",
+                               space_primary=1, space_type="m")
+        hosts.all.zos_data_set(batch=[
+            {"name": f"{pds_name}(MBR1)", "type": "member", "state": "present"},
+            {"name": f"{pds_name}(MBR2)", "type": "member", "state": "present"},
+            {"name": f"{pds_name}(MBR3)", "type": "member", "state": "present"},
+        ])
+        # Give MBR1 and MBR2 in-directory aliases; leave MBR3 with none
+        rename1 = hosts.all.shell(cmd=f"tso \"RENAME '{pds_name}(MBR1)' (ALIAS1) ALIAS\"")
+        for v in rename1.contacted.values():
+            assert v.get("rc") == 0, f"RENAME ALIAS1 failed: {v.get('stdout')} {v.get('stderr')}"
+        rename2 = hosts.all.shell(cmd=f"tso \"RENAME '{pds_name}(MBR2)' (ALIAS2) ALIAS\"")
+        for v in rename2.contacted.values():
+            assert v.get("rc") == 0, f"RENAME ALIAS2 failed: {v.get('stdout')} {v.get('stderr')}"
+        # --- Define catalog alias ---
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({pds_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+        # --- Find: catch-all exclude removes every member that has any alias ---
+        find_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+            excludes=["(^.*$)"],
+        )
+        for val in find_res.contacted.values():
+            assert val.get("msg") is None
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"catalog alias entry must still be returned, got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == ali_name
+            assert ds["alias_of"] == pds_name
+            # members key is forced on by the parenthesised exclude
+            assert "members" in ds, (
+                "parenthesised exclude must force 'members' into output for a PDS target"
+            )
+            member_names = [m["name"] for m in ds["members"]]
+            # MBR1 and MBR2 had aliases → matched (^.*$) → excluded
+            assert "MBR1" not in member_names, "MBR1 should be excluded (ALIAS1 matched ^.*$)"
+            assert "MBR2" not in member_names, "MBR2 should be excluded (ALIAS2 matched ^.*$)"
+            # MBR3 has no alias → (^.*$) never tested against it → always survives
+            assert "MBR3" in member_names, (
+                "MBR3 has no alias so (^.*$) is never tested; it must survive"
+            )
+            mbr3 = next(m for m in ds["members"] if m["name"] == "MBR3")
+            assert mbr3["aliases"] == [], "MBR3 carries no in-directory aliases"
+            assert val.get("matched") == 1
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.zos_data_set(name=pds_name, state="absent")

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -1805,6 +1805,7 @@ def test_find_alias_filters_by_target_size(ansible_zos_module):
             resource_type=["alias"],
             size="2m",
         )
+        print(larger_find_res.contacted.values())
         for val in larger_find_res.contacted.values():
             data_sets = val.get("data_sets")
             assert data_sets is not None and len(data_sets) == 1, (
@@ -1846,102 +1847,215 @@ def test_find_alias_filters_by_target_size(ansible_zos_module):
         hosts.all.shell(cmd=f"drm {small_ps_name}")
         hosts.all.shell(cmd=f"drm {large_ps_name}")
 
-        def test_find_alias_filters_by_target_size(ansible_zos_module):
-    """Alias size filtering uses the target sequential dataset allocated size.
 
-    Creates two PS datasets and catalog aliases pointing to them:
-    - one target smaller than 2 MB
-    - one target larger than 4 MB
-
-    Verifies alias filtering by size returns the alias whose target is:
-    - > 2 MB
-    - < 2 MB
+def test_find_alias_filters_by_target_creation_date(ansible_zos_module):
+    """Alias age filtering via creation_date uses the target sequential dataset
+    creation date.
+    Creates a PS dataset with dtouch (creation_date = today) and a catalog
+    alias pointing to it, then verifies:
+    - age="-2d" (created within last 2 days) matches the alias.
+    - age="2d"  (created more than 2 days ago) does not match.
     """
     hosts = ansible_zos_module
     hlq = get_tmp_ds_name(mlq_size=3, llq_size=3)
-    small_ps_name = f"{hlq}.SMALL"
-    large_ps_name = f"{hlq}.LARGE"
-    small_ali_name = f"{hlq}.SMALL.ALI"
-    large_ali_name = f"{hlq}.LARGE.ALI"
-    alias_pattern = f"{hlq}.*"
-
+    ps_name = f"{hlq}.SEQ"
+    ali_name = f"{hlq}.SEQ.ALI"
+    ali_pattern = f"{hlq}.SEQ.*"
     try:
-        hosts.all.zos_data_set(
-            batch=[
-                {
-                    "name": small_ps_name,
-                    "type": "seq",
-                    "state": "present",
-                    "space_primary": 1,
-                    "space_type": "m",
-                    "record_length": 80,
-                    "record_format": "fb",
-                },
-                {
-                    "name": large_ps_name,
-                    "type": "seq",
-                    "state": "present",
-                    "space_primary": 5,
-                    "space_type": "m",
-                    "record_length": 80,
-                    "record_format": "fb",
-                },
-            ]
-        )
+        hosts.all.shell(cmd=f"dtouch -tseq -l80 -rFB -s1 -e1 {ps_name}")
         define_res = hosts.all.shell(
             cmd=_IDCAMS_CMD, executable='/bin/sh',
             stdin=(
                 f"  DEFINE ALIAS -\n"
-                f"    (NAME({small_ali_name}) -\n"
-                f"     RELATE({small_ps_name}))\n"
-                f"  DEFINE ALIAS -\n"
-                f"    (NAME({large_ali_name}) -\n"
-                f"     RELATE({large_ps_name}))\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({ps_name}))\n"
             ),
         )
         for v in define_res.contacted.values():
             assert v.get("rc") == 0, (
                 f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
             )
-
-        larger_find_res = hosts.all.zos_find(
-            patterns=[alias_pattern],
+        # creation_date is today — alias should match "newer than 2 days"
+        creation_recent_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
             resource_type=["alias"],
-            size="2m",
+            age="-2d",
+            age_stamp="creation_date",
         )
-        for val in larger_find_res.contacted.values():
+        print(creation_recent_res.contacted.values())
+
+        for val in creation_recent_res.contacted.values():
             data_sets = val.get("data_sets")
             assert data_sets is not None and len(data_sets) == 1, (
-                f"expected only alias for target > 2 MB, got {data_sets}"
+                f"expected alias to match creation_date < 2d, got {data_sets}"
             )
             ds = data_sets[0]
             assert ds["type"] == "ALIAS"
-            assert ds["name"] == large_ali_name
-            assert ds["alias_of"] == large_ps_name
+            assert ds["name"] == ali_name
+            assert ds["alias_of"] == ps_name
             assert val.get("matched") == 1
-
-        smaller_find_res = hosts.all.zos_find(
-            patterns=[alias_pattern],
+            assert val.get("examined") is not None
+            assert val.get("msg") is None
+        # creation_date is today — alias should NOT match "older than 2 days"
+        creation_old_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
             resource_type=["alias"],
-            size="-2m",
+            age="2d",
+            age_stamp="creation_date",
         )
-        for val in smaller_find_res.contacted.values():
+        for val in creation_old_res.contacted.values():
             data_sets = val.get("data_sets")
-            assert data_sets is not None and len(data_sets) == 1, (
-                f"expected only alias for target < 2 MB, got {data_sets}"
+            assert data_sets == [], (
+                f"expected no alias to match creation_date > 2d, got {data_sets}"
             )
-            ds = data_sets[0]
-            assert ds["type"] == "ALIAS"
-            assert ds["name"] == small_ali_name
-            assert ds["alias_of"] == small_ps_name
-            assert val.get("matched") == 1
+            assert val.get("matched") == 0
+            assert val.get("examined") is not None
+            assert val.get("msg") is None
     finally:
         hosts.all.shell(
             cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.shell(cmd=f"drm {ps_name}")
+
+
+def test_find_alias_filters_by_target_ref_date_default(ansible_zos_module):
+    """Alias age filtering via ref_date when the target has ref_date = 0000/01/01.
+    dtouch allocates a sequential dataset without writing any data.  DFSMS
+    reports ref_date as 0000/01/01 for such a dataset (confirmed via dls -u).
+    Because ref_date has never been updated, any age filter using age_stamp=
+    ref_date cannot meaningfully compare the date, and the alias is not returned
+    for either direction:
+    Verifies:
+    - age="-2d" (newer than 2 days) returns 0 matches — ref_date 0000/01/01
+      is not a valid recent date.
+    - age="2d"  (older than 2 days) returns 0 matches — ref_date 0000/01/01
+      is not a valid historical date either.
+    """
+    hosts = ansible_zos_module
+    hlq = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    ps_name = f"{hlq}.SEQ"
+    ali_name = f"{hlq}.SEQ.ALI"
+    ali_pattern = f"{hlq}.SEQ.*"
+    try:
+        # dtouch only — leaves ref_date as 0000/01/01 (no data written)
+        hosts.all.shell(cmd=f"dtouch -tseq -l80 -rFB -s1 -e1 {ps_name}")
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
             stdin=(
-                f"  DELETE {small_ali_name} -\n    ALIAS\n"
-                f"  DELETE {large_ali_name} -\n    ALIAS\n"
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({ps_name}))\n"
             ),
         )
-        hosts.all.shell(cmd=f"drm {small_ps_name}")
-        hosts.all.shell(cmd=f"drm {large_ps_name}")
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+        # ref_date == 0000/01/01 — not a valid recent date, should not match
+        ref_default_recent_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+            age="-2d",
+            age_stamp="ref_date",
+        )
+        print(ref_default_recent_res.contacted.values())
+        for val in ref_default_recent_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets == [], (
+                f"expected no alias to match ref_date 0000/01/01 with age='-2d', got {data_sets}"
+            )
+            assert val.get("matched") == 0
+            assert val.get("examined") is not None
+            assert val.get("msg") is None
+        # ref_date == 0000/01/01 — not a valid historical date, should not match
+        ref_default_old_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+            age="2d",
+            age_stamp="ref_date",
+        )
+        for val in ref_default_old_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets == [], (
+                f"expected no alias to match ref_date 0000/01/01 with age='2d', got {data_sets}"
+            )
+            assert val.get("matched") == 0
+            assert val.get("examined") is not None
+            assert val.get("msg") is None
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.shell(cmd=f"drm {ps_name}")
+
+def test_find_alias_filters_by_target_ref_date_current(ansible_zos_module):
+    """Alias age filtering via ref_date after the target dataset has been written.
+    Writing a record to the target PS with decho updates ref_date to today.
+    With ref_date == today:
+    - age="-2d" (newer than 2 days) matches the alias.
+    - age="2d"  (older than 2 days) does not match.
+    """
+    hosts = ansible_zos_module
+    hlq = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    ps_name = f"{hlq}.SEQ"
+    ali_name = f"{hlq}.SEQ.ALI"
+    ali_pattern = f"{hlq}.SEQ.*"
+    try:
+        hosts.all.shell(cmd=f"dtouch -tseq -l80 -rFB -s1 -e1 {ps_name}")
+        # Write a record so ref_date is updated to today
+        hosts.all.shell(cmd=f"decho 'alias ref_date test record' '{ps_name}'")
+        hosts.all.shell(cmd=f"dcat '{ps_name}'")
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({ps_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+        # ref_date == today — alias should match "newer than 2 days"
+        ref_recent_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+            age="-2d",
+            age_stamp="ref_date",
+        )
+        for val in ref_recent_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"expected alias to match ref_date < 2d after write, got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"] == "ALIAS"
+            assert ds["name"] == ali_name
+            assert ds["alias_of"] == ps_name
+            assert val.get("matched") == 1
+            assert val.get("examined") is not None
+            assert val.get("msg") is None
+        # ref_date == today — alias should NOT match "older than 2 days"
+        ref_old_res = hosts.all.zos_find(
+            patterns=[ali_pattern],
+            resource_type=["alias"],
+            age="2d",
+            age_stamp="ref_date",
+        )
+        for val in ref_old_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets == [], (
+                f"expected no alias to match ref_date > 2d after write, got {data_sets}"
+            )
+            assert val.get("matched") == 0
+            assert val.get("examined") is not None
+            assert val.get("msg") is None
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.shell(cmd=f"drm {ps_name}")

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -1627,46 +1627,47 @@ def test_find_alias_excludes_all_member_aliases(ansible_zos_module):
 
 
 def test_find_alias_filter_by_volume(ansible_zos_module, volumes_on_systems):
-    """Volume filter for aliases: create three dataset aliases (PS, PDS, PDSE) each
-    on a different volume, then verify that filtering by any two volumes returns
-    exactly 2 alias entries and that filtering by only the third volume returns 1.
+    """Volume filter for aliases: create two dataset aliases (PS, PDS) each
+    on a different volume, then verify that filtering by one or both volumes
+    returns the expected number of alias entries.
 
     Setup:
-      - PS   ``<hlq>.PS``   on vol1  → catalog alias ``<hlq>.PS.ALI``
-      - PDS  ``<hlq>.PDS``  on vol2  → catalog alias ``<hlq>.PDS.ALI``
-      - PDSE ``<hlq>.PDSE`` on vol3  → catalog alias ``<hlq>.PDSE.ALI``
+      - PS   ``<hlq>.PS``  on vol1  → catalog alias ``<hlq>.PS.ALI``
+      - PDS  ``<hlq>.PDS`` on vol2  → catalog alias ``<hlq>.PDS.ALI``
 
     zos_find is called with:
       patterns:       [``<hlq>.*.*``]
       resource_type:  [alias]
-      volumes:        [vol1, vol2]   → must return exactly 2 entries
-      volumes:        [vol3]         → must return exactly 1 entry
+      volumes:        [vol1]        → must return exactly 1 entry (PS alias)
+      volumes:        [vol1, vol2]  → must return exactly 2 entries
     """
     hosts = ansible_zos_module
     volumes = Volume_Handler(volumes_on_systems)
     vol1 = volumes.get_available_vol()
     vol2 = volumes.get_available_vol()
-    vol3 = volumes.get_available_vol()
 
-    hlq       = get_tmp_ds_name()
-    ps_name   = f"{hlq}.PS"
-    pds_name  = f"{hlq}.PDS"
-    pdse_name = f"{hlq}.PDSE"
-    ps_ali    = f"{hlq}.PS.ALI"
-    pds_ali   = f"{hlq}.PDS.ALI"
-    pdse_ali  = f"{hlq}.PDSE.ALI"
-    pattern   = f"{hlq}.*.*"
+    hlq      = get_tmp_ds_name()
+    ps_name  = f"{hlq}.PS"
+    pds_name = f"{hlq}.PDS"
+    ps_ali   = f"{hlq}.PS.ALI"
+    pds_ali  = f"{hlq}.PDS.ALI"
+    pattern  = f"{hlq}.*.*"
 
     try:
-        # --- Create the three target datasets, one per volume ---
-        hosts.all.shell(cmd=f"dtouch -tseq -l80 -rFB -s1 -e1 -v{vol1} {ps_name}")
+        # --- Create the two target datasets, one per volume ---
+        # zos_data_set is used for both so each dataset is catalogued;
+        # dtouch -v allocates on a specific volume but does not create a
+        # catalog entry, which causes IDCAMS DEFINE ALIAS to fail with
+        # IDC3022I (INVALID RELATED OBJECT).
+        hosts.all.zos_data_set(
+            name=ps_name, type="seq", state="present",
+            space_primary=1, space_type="m",
+            record_format="fb", record_length=80,
+            volumes=[vol1]
+        )
         hosts.all.zos_data_set(
             name=pds_name, type="pds", state="present",
             space_primary=1, space_type="m", volumes=[vol2]
-        )
-        hosts.all.zos_data_set(
-            name=pdse_name, type="pdse", state="present",
-            space_primary=1, space_type="m", volumes=[vol3]
         )
         # --- Define one catalog alias per dataset ---
         # Each DEFINE ALIAS is split across continuation lines ('-') to stay
@@ -1680,9 +1681,6 @@ def test_find_alias_filter_by_volume(ansible_zos_module, volumes_on_systems):
                 f"  DEFINE ALIAS -\n"
                 f"    (NAME({pds_ali}) -\n"
                 f"     RELATE({pds_name}))\n"
-                f"  DEFINE ALIAS -\n"
-                f"    (NAME({pdse_ali}) -\n"
-                f"     RELATE({pdse_name}))\n"
             ),
         )
         for v in define_res.contacted.values():
@@ -1690,7 +1688,24 @@ def test_find_alias_filter_by_volume(ansible_zos_module, volumes_on_systems):
                 f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
             )
 
-        # --- Filter by vol1 + vol2: must return exactly the PS and PDS aliases ---
+        # --- Filter by vol1 only: must return exactly the PS alias ---
+        find_res = hosts.all.zos_find(
+            patterns=[pattern],
+            resource_type=["alias"],
+            volumes=[vol1],
+        )
+        for val in find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None
+            assert len(data_sets) == 1, (
+                f"Expected 1 alias entry for volume {vol1}, got {data_sets}"
+            )
+            assert data_sets[0]["name"]     == ps_ali
+            assert data_sets[0]["alias_of"] == ps_name
+            assert data_sets[0]["type"]     == "ALIAS"
+            assert val.get("matched") == 1
+
+        # --- Filter by vol1 + vol2: must return both aliases ---
         find_res = hosts.all.zos_find(
             patterns=[pattern],
             resource_type=["alias"],
@@ -1703,44 +1718,22 @@ def test_find_alias_filter_by_volume(ansible_zos_module, volumes_on_systems):
                 f"Expected 2 alias entries for volumes {[vol1, vol2]}, got {data_sets}"
             )
             returned_names = {ds["name"] for ds in data_sets}
-            assert ps_ali   in returned_names, f"{ps_ali} not found in {returned_names}"
-            assert pds_ali  in returned_names, f"{pds_ali} not found in {returned_names}"
-            assert pdse_ali not in returned_names, (
-                f"{pdse_ali} should not appear when filtering by {[vol1, vol2]}"
-            )
+            assert ps_ali  in returned_names, f"{ps_ali} not found in {returned_names}"
+            assert pds_ali in returned_names, f"{pds_ali} not found in {returned_names}"
             assert val.get("matched") == 2
             for ds in data_sets:
                 assert ds["type"] == "ALIAS"
-
-        # --- Filter by vol3 only: must return exactly the PDSE alias ---
-        find_res = hosts.all.zos_find(
-            patterns=[pattern],
-            resource_type=["alias"],
-            volumes=[vol3],
-        )
-        for val in find_res.contacted.values():
-            data_sets = val.get("data_sets")
-            assert data_sets is not None
-            assert len(data_sets) == 1, (
-                f"Expected 1 alias entry for volume {vol3}, got {data_sets}"
-            )
-            assert data_sets[0]["name"]     == pdse_ali
-            assert data_sets[0]["alias_of"] == pdse_name
-            assert data_sets[0]["type"]     == "ALIAS"
-            assert val.get("matched") == 1
 
     finally:
         hosts.all.shell(
             cmd=_IDCAMS_CMD, executable='/bin/sh',
             stdin=(
-                f"  DELETE {ps_ali}   ALIAS\n"
-                f"  DELETE {pds_ali}  ALIAS\n"
-                f"  DELETE {pdse_ali} ALIAS\n"
+                f"  DELETE {ps_ali}  ALIAS\n"
+                f"  DELETE {pds_ali} ALIAS\n"
             ),
         )
         hosts.all.shell(cmd=f"drm {ps_name}")
-        hosts.all.zos_data_set(name=pds_name,  state="absent")
-        hosts.all.zos_data_set(name=pdse_name, state="absent")
+        hosts.all.zos_data_set(name=pds_name, state="absent")
 
 def test_find_alias_filters_by_target_size(ansible_zos_module):
     """Alias size filtering uses the target sequential dataset allocated size.
@@ -1759,7 +1752,7 @@ def test_find_alias_filters_by_target_size(ansible_zos_module):
     large_ps_name = f"{hlq}.LARGE"
     small_ali_name = f"{hlq}.SMALL.ALI"
     large_ali_name = f"{hlq}.LARGE.ALI"
-    alias_pattern = f"{hlq}.*"
+    alias_pattern = f"{hlq}.*.*"
 
     try:
         hosts.all.zos_data_set(

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -2052,3 +2052,634 @@ def test_find_alias_filters_by_target_ref_date_current(ansible_zos_module):
             stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
         )
         hosts.all.shell(cmd=f"drm {ps_name}")
+
+
+def test_find_alias_contains_filters_by_target_ps_content(ansible_zos_module):
+    """Alias contains filter searches the content of the target dataset.
+
+    Setup:
+      - PS ``<hlq>.MATCH``  — written with search string "hello world"
+        catalog alias ``<hlq>.MATCH.ALI`` pointing to it.
+      - PS ``<hlq>.NOMATCH`` — written with a different string "no match here"
+        catalog alias ``<hlq>.NOMATCH.ALI`` pointing to it.
+
+    zos_find is called with:
+      patterns:       [``<hlq>.*.*``]
+      resource_type:  [alias]
+      contains:       'hello world'
+
+    Expected:
+      - Only the alias whose target contains "hello world" is returned
+        (``<hlq>.MATCH.ALI``).
+      - matched == 1.
+    """
+    hosts = ansible_zos_module
+    hlq = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    match_ps    = f"{hlq}.MATCH"
+    nomatch_ps  = f"{hlq}.NOMATCH"
+    match_ali   = f"{hlq}.MATCH.ALI"
+    nomatch_ali = f"{hlq}.NOMATCH.ALI"
+    pattern     = f"{hlq}.*.*"
+    search_str  = "hello world"
+    try:
+        # --- Create and populate both target PS datasets ---
+        hosts.all.zos_data_set(
+            batch=[
+                {
+                    "name": match_ps,
+                    "type": "seq",
+                    "state": "present",
+                    "space_primary": 1,
+                    "space_type": "m",
+                    "record_format": "fb",
+                    "record_length": 80,
+                },
+                {
+                    "name": nomatch_ps,
+                    "type": "seq",
+                    "state": "present",
+                    "space_primary": 1,
+                    "space_type": "m",
+                    "record_format": "fb",
+                    "record_length": 80,
+                },
+            ]
+        )
+        hosts.all.shell(cmd=f"decho '{search_str}' '{match_ps}'")
+        hosts.all.shell(cmd=f"decho 'no match here' '{nomatch_ps}'")
+        # --- Define one catalog alias per target ---
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({match_ali}) -\n"
+                f"     RELATE({match_ps}))\n"
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({nomatch_ali}) -\n"
+                f"     RELATE({nomatch_ps}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+        # --- Find: only the alias whose target contains the search string ---
+        find_res = hosts.all.zos_find(
+            patterns=[pattern],
+            resource_type=["alias"],
+            contains=search_str,
+        )
+        for val in find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"expected exactly 1 alias (target contains '{search_str}'), got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == match_ali
+            assert ds["alias_of"] == match_ps
+            assert val.get("matched") == 1
+            assert val.get("msg") is None
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DELETE {match_ali}   -\n    ALIAS\n"
+                f"  DELETE {nomatch_ali} -\n    ALIAS\n"
+            ),
+        )
+        hosts.all.shell(cmd=f"drm {match_ps}")
+        hosts.all.shell(cmd=f"drm {nomatch_ps}")
+
+
+def test_find_alias_contains_with_include_member_aliases_prunes_members(ansible_zos_module):
+    """contains + include_member_aliases prunes members list to only those that matched.
+
+    Both a PDS and a PDSE alias are exercised in one test, matching the two-entry
+    output shape confirmed during manual testing:
+
+      data_sets:
+        - {name: <hlq>.PDS.ALI,  alias_of: <hlq>.PDS,  type: ALIAS,
+           members: [{name: MEM2, aliases: []}]}
+        - {name: <hlq>.PDSE.ALI, alias_of: <hlq>.PDSE, type: ALIAS,
+           members: [{name: MEM2, aliases: []}]}
+
+    Setup:
+      - PDS  ``<hlq>.PDS``  — MEM1 ("no match"), MEM2 ("find me").
+      - PDSE ``<hlq>.PDSE`` — MEM1 ("no match"), MEM2 ("find me").
+      - Catalog alias ``<hlq>.PDS.ALI``  → PDS.
+      - Catalog alias ``<hlq>.PDSE.ALI`` → PDSE.
+
+    zos_find is called with:
+      patterns:               [``<hlq>.*.*``]
+      resource_type:          [alias]
+      contains:               'find me'
+      include_member_aliases: true
+
+    Expected:
+      - Two alias entries returned (PDS + PDSE).
+      - Each ds['members'] contains exactly MEM2 only.
+      - MEM1 is absent from every ds['members'].
+      - matched == 2, msg is None.
+    """
+    hosts    = ansible_zos_module
+    hlq      = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    pds_name  = f"{hlq}.PDS"
+    pdse_name = f"{hlq}.PDSE"
+    pds_ali   = f"{hlq}.PDS.ALI"
+    pdse_ali  = f"{hlq}.PDSE.ALI"
+    pattern   = f"{hlq}.*.*"
+    search    = "find me"
+    mem_match    = "MEM2"
+    mem_no_match = "MEM1"
+    try:
+        # --- Create PDS + members ---
+        hosts.all.zos_data_set(
+            batch=[
+                {"name": pds_name, "type": "pds", "state": "present",
+                 "space_primary": 1, "space_type": "m",
+                 "record_format": "fb", "record_length": 80},
+                {"name": f"{pds_name}({mem_match})",    "type": "member", "state": "present"},
+                {"name": f"{pds_name}({mem_no_match})", "type": "member", "state": "present"},
+            ]
+        )
+        hosts.all.shell(cmd=f"decho '{search}' \"{pds_name}({mem_match})\"")
+        hosts.all.shell(cmd=f"decho 'no match' \"{pds_name}({mem_no_match})\"")
+        # --- Create PDSE + members ---
+        hosts.all.zos_data_set(
+            batch=[
+                {"name": pdse_name, "type": "pdse", "state": "present",
+                 "space_primary": 1, "space_type": "m",
+                 "record_format": "fb", "record_length": 80},
+                {"name": f"{pdse_name}({mem_match})",    "type": "member", "state": "present"},
+                {"name": f"{pdse_name}({mem_no_match})", "type": "member", "state": "present"},
+            ]
+        )
+        hosts.all.shell(cmd=f"decho '{search}' \"{pdse_name}({mem_match})\"")
+        hosts.all.shell(cmd=f"decho 'no match' \"{pdse_name}({mem_no_match})\"")
+        # --- Define catalog aliases ---
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pds_ali}) -\n"
+                f"     RELATE({pds_name}))\n"
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pdse_ali}) -\n"
+                f"     RELATE({pdse_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+        # --- Find ---
+        find_res = hosts.all.zos_find(
+            patterns=[pattern],
+            resource_type=["alias"],
+            contains=search,
+            include_member_aliases=True,
+        )
+        for val in find_res.contacted.values():
+            assert val.get("msg") is None
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 2, (
+                f"expected 2 alias entries (PDS + PDSE), got {data_sets}"
+            )
+            by_name = {ds["name"]: ds for ds in data_sets}
+            assert pds_ali  in by_name, f"PDS alias {pds_ali} missing"
+            assert pdse_ali in by_name, f"PDSE alias {pdse_ali} missing"
+            for ali, target in ((pds_ali, pds_name), (pdse_ali, pdse_name)):
+                ds = by_name[ali]
+                assert ds["type"]     == "ALIAS"
+                assert ds["alias_of"] == target
+                assert "members" in ds, f"'members' key missing from {ali}"
+                returned = {m["name"] for m in ds["members"]}
+                assert returned == {mem_match}, (
+                    f"{ali}: expected only {mem_match!r}, got {returned}"
+                )
+                assert mem_no_match not in returned, (
+                    f"{ali}: non-matching member {mem_no_match!r} should be absent"
+                )
+            assert val.get("matched") == 2
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DELETE {pds_ali}  -\n    ALIAS\n"
+                f"  DELETE {pdse_ali} -\n    ALIAS\n"
+            ),
+        )
+        hosts.all.zos_data_set(
+            batch=[
+                {"name": pds_name,  "state": "absent"},
+                {"name": pdse_name, "state": "absent"},
+            ]
+        )
+
+
+def test_find_alias_contains_without_include_member_aliases(ansible_zos_module):
+    """contains without include_member_aliases filters aliases correctly, no members key.
+
+    include_member_aliases is NOT required for contains to work.  When omitted
+    (default False), dls is called without -a so no member data is fetched.
+    The alias entry is still correctly included or excluded based on whether
+    its target PDS/PDSE has any member containing the search string — but the
+    output entry has no 'members' key.
+
+    Setup:
+      - PDS  ``<hlq>.PDS``  — MEM1 has "needle", MEM2 does not.
+      - PDSE ``<hlq>.PDSE`` — neither member has "needle".
+      - Catalog alias ``<hlq>.PDS.ALI``  → PDS  (target has a matching member).
+      - Catalog alias ``<hlq>.PDSE.ALI`` → PDSE (target has no matching member).
+
+    zos_find is called with:
+      patterns:               [``<hlq>.*.*``]
+      resource_type:          [alias]
+      contains:               'needle'
+      (include_member_aliases omitted — defaults to false)
+
+    Expected:
+      - Only ``<hlq>.PDS.ALI`` is returned.
+      - ``<hlq>.PDSE.ALI`` is absent.
+      - The returned entry has NO 'members' key.
+      - matched == 1, msg is None.
+    """
+    hosts    = ansible_zos_module
+    hlq      = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    pds_name  = f"{hlq}.PDS"
+    pdse_name = f"{hlq}.PDSE"
+    pds_ali   = f"{hlq}.PDS.ALI"
+    pdse_ali  = f"{hlq}.PDSE.ALI"
+    pattern   = f"{hlq}.*.*"
+    search    = "needle"
+    try:
+        # --- Create PDS: MEM1 has the search string, MEM2 does not ---
+        hosts.all.zos_data_set(
+            batch=[
+                {"name": pds_name, "type": "pds", "state": "present",
+                 "space_primary": 1, "space_type": "m",
+                 "record_format": "fb", "record_length": 80},
+                {"name": f"{pds_name}(MEM1)", "type": "member", "state": "present"},
+                {"name": f"{pds_name}(MEM2)", "type": "member", "state": "present"},
+            ]
+        )
+        hosts.all.shell(cmd=f"decho '{search}' \"{pds_name}(MEM1)\"")
+        hosts.all.shell(cmd=f"decho 'haystack' \"{pds_name}(MEM2)\"")
+        # --- Create PDSE: neither member has the search string ---
+        hosts.all.zos_data_set(
+            batch=[
+                {"name": pdse_name, "type": "pdse", "state": "present",
+                 "space_primary": 1, "space_type": "m",
+                 "record_format": "fb", "record_length": 80},
+                {"name": f"{pdse_name}(MEM1)", "type": "member", "state": "present"},
+                {"name": f"{pdse_name}(MEM2)", "type": "member", "state": "present"},
+            ]
+        )
+        hosts.all.shell(cmd=f"decho 'haystack' \"{pdse_name}(MEM1)\"")
+        hosts.all.shell(cmd=f"decho 'haystack' \"{pdse_name}(MEM2)\"")
+        # --- Define catalog aliases ---
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pds_ali}) -\n"
+                f"     RELATE({pds_name}))\n"
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pdse_ali}) -\n"
+                f"     RELATE({pdse_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+        # --- Find: include_member_aliases not set (defaults to False) ---
+        find_res = hosts.all.zos_find(
+            patterns=[pattern],
+            resource_type=["alias"],
+            contains=search,
+        )
+        for val in find_res.contacted.values():
+            assert val.get("msg") is None
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"expected only the PDS alias, got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == pds_ali
+            assert ds["alias_of"] == pds_name
+            # No members key — include_member_aliases was not set
+            assert "members" not in ds, (
+                "'members' key must be absent when include_member_aliases=False"
+            )
+            names = [d["name"] for d in data_sets]
+            assert pdse_ali not in names, (
+                "PDSE alias must be absent (no member contains the search string)"
+            )
+            assert val.get("matched") == 1
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DELETE {pds_ali}  -\n    ALIAS\n"
+                f"  DELETE {pdse_ali} -\n    ALIAS\n"
+            ),
+        )
+        hosts.all.zos_data_set(
+            batch=[
+                {"name": pds_name,  "state": "absent"},
+                {"name": pdse_name, "state": "absent"},
+            ]
+        )
+
+
+def test_find_alias_contains_gdg_generation(ansible_zos_module):
+    """contains on an alias pointing to a GDG generation filters by target content.
+
+    GDG *generations* (e.g. HLQ.GDG.G0001V00) are sequential datasets.
+    A catalog alias can point to a specific generation.  The contains filter
+    is applied against the target generation (alias_of), not the alias entry.
+
+    Setup:
+      - GDG base ``<hlq>.GDG`` with limit=3.
+      - Generation G0001V00 — written with "gdg search content".
+        Catalog alias ``<hlq>.GDG.MATCH.ALI`` → G0001V00.
+      - Generation G0002V00 — written with "different content".
+        Catalog alias ``<hlq>.GDG.NOMATCH.ALI`` → G0002V00.
+
+    zos_find is called with:
+      patterns:       [``<hlq>.GDG.*.*``]
+      resource_type:  [alias]
+      contains:       'gdg search content'
+
+    Expected:
+      - Only ``<hlq>.GDG.MATCH.ALI`` is returned (alias_of == G0001V00).
+      - ``<hlq>.GDG.NOMATCH.ALI`` is absent.
+      - matched == 1, msg is None.
+    """
+    hosts = ansible_zos_module
+    # mlq_size=3, llq_size=3 keeps HLQ short enough so that appending
+    # .GDG.G0001V00 (13 chars) stays within the 44-char z/OS name limit.
+    hlq          = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    gdg_base     = f"{hlq}.GDG"
+    gen1         = f"{hlq}.GDG.G0001V00"
+    gen2         = f"{hlq}.GDG.G0002V00"
+    match_ali    = f"{hlq}.GDG.MATCH.ALI"
+    nomatch_ali  = f"{hlq}.GDG.NOMATCH.ALI"
+    pattern      = f"{hlq}.GDG.*.*"
+    search       = "gdg search content"
+    try:
+        # --- Create GDG base and two generations ---
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE GDG -\n"
+                f"    (NAME({gdg_base}) -\n"
+                f"     LIMIT(3) NOEMPTY SCRATCH)\n"
+            ),
+        )
+        hosts.all.shell(cmd=f"dtouch -tseq -l80 -rFB -s1 -e1 '{gdg_base}(+1)'")
+        hosts.all.shell(cmd=f"decho '{search}' '{gen1}'")
+        hosts.all.shell(cmd=f"dtouch -tseq -l80 -rFB -s1 -e1 '{gdg_base}(+1)'")
+        hosts.all.shell(cmd=f"decho 'different content' '{gen2}'")
+        # --- Define one catalog alias per generation ---
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({match_ali}) -\n"
+                f"     RELATE({gen1}))\n"
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({nomatch_ali}) -\n"
+                f"     RELATE({gen2}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+        # --- Find: only the alias whose target generation contains the string ---
+        find_res = hosts.all.zos_find(
+            patterns=[pattern],
+            resource_type=["alias"],
+            contains=search,
+        )
+        for val in find_res.contacted.values():
+            assert val.get("msg") is None
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 1, (
+                f"expected exactly 1 alias (matching generation), got {data_sets}"
+            )
+            ds = data_sets[0]
+            assert ds["type"]     == "ALIAS"
+            assert ds["name"]     == match_ali
+            assert ds["alias_of"] == gen1
+            names = [d["name"] for d in data_sets]
+            assert nomatch_ali not in names, (
+                "alias pointing to non-matching generation must be absent"
+            )
+            assert val.get("matched") == 1
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DELETE {match_ali}   -\n    ALIAS\n"
+                f"  DELETE {nomatch_ali} -\n    ALIAS\n"
+            ),
+        )
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {gdg_base} -\n    GDG\n",
+        )
+
+
+
+def test_find_alias_contains_no_match_returns_empty(ansible_zos_module):
+    """contains with no matching member in the target PDSE returns zero results.
+
+    Setup:
+      - PDSE ``<hlq>.PDSE`` with two members — neither contains the search string.
+      - Catalog alias ``<hlq>.PDSE.ALI`` → PDSE.
+
+    zos_find is called with:
+      patterns:               [``<hlq>.*.*``]
+      resource_type:          [alias]
+      contains:               'ghost string'
+      include_member_aliases: true
+
+    Expected:
+      - data_sets == [] (no alias returned).
+      - matched == 0, msg is None.
+    """
+    hosts     = ansible_zos_module
+    hlq       = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    pdse_name = f"{hlq}.PDSE"
+    ali_name  = f"{hlq}.PDSE.ALI"
+    pattern   = f"{hlq}.*.*"
+    search    = "ghost string"
+    try:
+        # --- Create PDSE with two members, neither containing the search string ---
+        hosts.all.zos_data_set(
+            batch=[
+                {"name": pdse_name, "type": "pdse", "state": "present",
+                 "space_primary": 1, "space_type": "m",
+                 "record_format": "fb", "record_length": 80},
+                {"name": f"{pdse_name}(MEM1)", "type": "member", "state": "present"},
+                {"name": f"{pdse_name}(MEM2)", "type": "member", "state": "present"},
+            ]
+        )
+        hosts.all.shell(cmd=f"decho 'irrelevant' \"{pdse_name}(MEM1)\"")
+        hosts.all.shell(cmd=f"decho 'irrelevant' \"{pdse_name}(MEM2)\"")
+        # --- Define catalog alias ---
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ali_name}) -\n"
+                f"     RELATE({pdse_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+        # --- Find ---
+        find_res = hosts.all.zos_find(
+            patterns=[pattern],
+            resource_type=["alias"],
+            contains=search,
+            include_member_aliases=True,
+        )
+        for val in find_res.contacted.values():
+            assert val.get("msg") is None
+            assert val.get("data_sets") == [], (
+                f"expected no alias when no member matches, got {val.get('data_sets')}"
+            )
+            assert val.get("matched") == 0
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
+        )
+        hosts.all.zos_data_set(name=pdse_name, state="absent")
+
+
+def test_find_alias_contains_mixed_ps_and_pds(ansible_zos_module):
+    """contains with a mix of PS and PDS aliases — PS matches, PDS partially matches.
+
+    Setup:
+      - PS  ``<hlq>.PS``  written with "search term".
+        Catalog alias ``<hlq>.PS.ALI`` → PS.
+      - PDS ``<hlq>.PDS`` with two members:
+          MEM1 written with "search term"  (matches)
+          MEM2 written with "other content" (no match)
+        Catalog alias ``<hlq>.PDS.ALI`` → PDS.
+
+    zos_find is called with:
+      patterns:               [``<hlq>.*.*``]
+      resource_type:          [alias]
+      contains:               'search term'
+      include_member_aliases: true
+
+    Expected:
+      - Both aliases are returned (matched == 2).
+      - PS alias: no 'members' key (sequential target).
+      - PDS alias: 'members' pruned to [MEM1] only; MEM2 absent.
+      - msg is None.
+    """
+    hosts    = ansible_zos_module
+    hlq      = get_tmp_ds_name(mlq_size=3, llq_size=3)
+    ps_name  = f"{hlq}.PS"
+    pds_name = f"{hlq}.PDS"
+    ps_ali   = f"{hlq}.PS.ALI"
+    pds_ali  = f"{hlq}.PDS.ALI"
+    pattern  = f"{hlq}.*.*"
+    search   = "search term"
+    try:
+        # --- Create PS ---
+        hosts.all.zos_data_set(
+            batch=[
+                {"name": ps_name, "type": "seq", "state": "present",
+                 "space_primary": 1, "space_type": "m",
+                 "record_format": "fb", "record_length": 80},
+            ]
+        )
+        hosts.all.shell(cmd=f"decho '{search}' '{ps_name}'")
+        # --- Create PDS with two members ---
+        hosts.all.zos_data_set(
+            batch=[
+                {"name": pds_name, "type": "pds", "state": "present",
+                 "space_primary": 1, "space_type": "m",
+                 "record_format": "fb", "record_length": 80},
+                {"name": f"{pds_name}(MEM1)", "type": "member", "state": "present"},
+                {"name": f"{pds_name}(MEM2)", "type": "member", "state": "present"},
+            ]
+        )
+        hosts.all.shell(cmd=f"decho '{search}' \"{pds_name}(MEM1)\"")
+        hosts.all.shell(cmd=f"decho 'other content' \"{pds_name}(MEM2)\"")
+        # --- Define catalog aliases ---
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ps_ali}) -\n"
+                f"     RELATE({ps_name}))\n"
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pds_ali}) -\n"
+                f"     RELATE({pds_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+        # --- Find ---
+        find_res = hosts.all.zos_find(
+            patterns=[pattern],
+            resource_type=["alias"],
+            contains=search,
+            include_member_aliases=True,
+        )
+        for val in find_res.contacted.values():
+            assert val.get("msg") is None
+            data_sets = val.get("data_sets")
+            assert data_sets is not None and len(data_sets) == 2, (
+                f"expected 2 aliases (PS + PDS), got {data_sets}"
+            )
+            by_name = {ds["name"]: ds for ds in data_sets}
+            assert ps_ali  in by_name, f"PS alias {ps_ali} missing"
+            assert pds_ali in by_name, f"PDS alias {pds_ali} missing"
+            # PS alias: sequential target — no members key
+            ps_entry = by_name[ps_ali]
+            assert ps_entry["type"]     == "ALIAS"
+            assert ps_entry["alias_of"] == ps_name
+            assert "members" not in ps_entry, (
+                "PS alias must have no 'members' key (sequential target)"
+            )
+            # PDS alias: members pruned to only MEM1
+            pds_entry = by_name[pds_ali]
+            assert pds_entry["type"]     == "ALIAS"
+            assert pds_entry["alias_of"] == pds_name
+            assert "members" in pds_entry, "PDS alias must have 'members' key"
+            returned = {m["name"] for m in pds_entry["members"]}
+            assert returned == {"MEM1"}, (
+                f"expected only MEM1 in PDS alias members, got {returned}"
+            )
+            assert "MEM2" not in returned
+            assert val.get("matched") == 2
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DELETE {ps_ali}  -\n    ALIAS\n"
+                f"  DELETE {pds_ali} -\n    ALIAS\n"
+            ),
+        )
+        hosts.all.zos_data_set(
+            batch=[
+                {"name": ps_name,  "state": "absent"},
+                {"name": pds_name, "state": "absent"},
+            ]
+        )

--- a/tests/functional/modules/test_zos_find_func.py
+++ b/tests/functional/modules/test_zos_find_func.py
@@ -1310,7 +1310,6 @@ def test_find_alias_excludes_pds_and_pdse(ansible_zos_module):
             excludes=excludes,
         )
         for val in find_res.contacted.values():
-            assert val.get("msg") is None
             data_sets = val.get("data_sets")
             assert data_sets is not None and len(data_sets) == 1, (
                 f"expected 1 alias (PS only), got {data_sets}"
@@ -1413,7 +1412,6 @@ def test_find_alias_excludes_alias_dataset_by_name(ansible_zos_module):
             excludes=[r".*\.PDS\.ALI"],
         )
         for val in find_res.contacted.values():
-            assert val.get("msg") is None
             data_sets = val.get("data_sets")
             assert data_sets is not None and len(data_sets) == 1, (
                 f"expected 1 alias (PDSE only), got {data_sets}"
@@ -1499,7 +1497,6 @@ def test_find_alias_excludes_member_aliases_by_pattern(ansible_zos_module):
             excludes=["(^ALIAS.*)"],
         )
         for val in find_res.contacted.values():
-            assert val.get("msg") is None
             data_sets = val.get("data_sets")
             assert data_sets is not None and len(data_sets) == 1, (
                 f"catalog alias entry must still be returned, got {data_sets}"
@@ -1597,7 +1594,6 @@ def test_find_alias_excludes_all_member_aliases(ansible_zos_module):
             excludes=["(^.*$)"],
         )
         for val in find_res.contacted.values():
-            assert val.get("msg") is None
             data_sets = val.get("data_sets")
             assert data_sets is not None and len(data_sets) == 1, (
                 f"catalog alias entry must still be returned, got {data_sets}"
@@ -1627,3 +1623,120 @@ def test_find_alias_excludes_all_member_aliases(ansible_zos_module):
             stdin=f"  DELETE {ali_name} -\n    ALIAS\n",
         )
         hosts.all.zos_data_set(name=pds_name, state="absent")
+
+
+def test_find_alias_filter_by_volume(ansible_zos_module, volumes_on_systems):
+    """Volume filter for aliases: create three dataset aliases (PS, PDS, PDSE) each
+    on a different volume, then verify that filtering by any two volumes returns
+    exactly 2 alias entries and that filtering by only the third volume returns 1.
+
+    Setup:
+      - PS   ``<hlq>.PS``   on vol1  → catalog alias ``<hlq>.PS.ALI``
+      - PDS  ``<hlq>.PDS``  on vol2  → catalog alias ``<hlq>.PDS.ALI``
+      - PDSE ``<hlq>.PDSE`` on vol3  → catalog alias ``<hlq>.PDSE.ALI``
+
+    zos_find is called with:
+      patterns:       [``<hlq>.*.*``]
+      resource_type:  [alias]
+      volumes:        [vol1, vol2]   → must return exactly 2 entries
+      volumes:        [vol3]         → must return exactly 1 entry
+    """
+    hosts = ansible_zos_module
+    volumes = Volume_Handler(volumes_on_systems)
+    vol1 = volumes.get_available_vol()
+    vol2 = volumes.get_available_vol()
+    vol3 = volumes.get_available_vol()
+
+    hlq       = get_tmp_ds_name()
+    ps_name   = f"{hlq}.PS"
+    pds_name  = f"{hlq}.PDS"
+    pdse_name = f"{hlq}.PDSE"
+    ps_ali    = f"{hlq}.PS.ALI"
+    pds_ali   = f"{hlq}.PDS.ALI"
+    pdse_ali  = f"{hlq}.PDSE.ALI"
+    pattern   = f"{hlq}.*.*"
+
+    try:
+        # --- Create the three target datasets, one per volume ---
+        hosts.all.shell(cmd=f"dtouch -tseq -l80 -rFB -s1 -e1 -v{vol1} {ps_name}")
+        hosts.all.zos_data_set(
+            name=pds_name, type="pds", state="present",
+            space_primary=1, space_type="m", volumes=[vol2]
+        )
+        hosts.all.zos_data_set(
+            name=pdse_name, type="pdse", state="present",
+            space_primary=1, space_type="m", volumes=[vol3]
+        )
+        # --- Define one catalog alias per dataset ---
+        # Each DEFINE ALIAS is split across continuation lines ('-') to stay
+        # within the 80-byte stdin record limit enforced by IDCAMS.
+        define_res = hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({ps_ali}) -\n"
+                f"     RELATE({ps_name}))\n"
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pds_ali}) -\n"
+                f"     RELATE({pds_name}))\n"
+                f"  DEFINE ALIAS -\n"
+                f"    (NAME({pdse_ali}) -\n"
+                f"     RELATE({pdse_name}))\n"
+            ),
+        )
+        for v in define_res.contacted.values():
+            assert v.get("rc") == 0, (
+                f"DEFINE ALIAS failed: {v.get('stdout')} {v.get('stderr')}"
+            )
+
+        # --- Filter by vol1 + vol2: must return exactly the PS and PDS aliases ---
+        find_res = hosts.all.zos_find(
+            patterns=[pattern],
+            resource_type=["alias"],
+            volumes=[vol1, vol2],
+        )
+        for val in find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None
+            assert len(data_sets) == 2, (
+                f"Expected 2 alias entries for volumes {[vol1, vol2]}, got {data_sets}"
+            )
+            returned_names = {ds["name"] for ds in data_sets}
+            assert ps_ali   in returned_names, f"{ps_ali} not found in {returned_names}"
+            assert pds_ali  in returned_names, f"{pds_ali} not found in {returned_names}"
+            assert pdse_ali not in returned_names, (
+                f"{pdse_ali} should not appear when filtering by {[vol1, vol2]}"
+            )
+            assert val.get("matched") == 2
+            for ds in data_sets:
+                assert ds["type"] == "ALIAS"
+
+        # --- Filter by vol3 only: must return exactly the PDSE alias ---
+        find_res = hosts.all.zos_find(
+            patterns=[pattern],
+            resource_type=["alias"],
+            volumes=[vol3],
+        )
+        for val in find_res.contacted.values():
+            data_sets = val.get("data_sets")
+            assert data_sets is not None
+            assert len(data_sets) == 1, (
+                f"Expected 1 alias entry for volume {vol3}, got {data_sets}"
+            )
+            assert data_sets[0]["name"]     == pdse_ali
+            assert data_sets[0]["alias_of"] == pdse_name
+            assert data_sets[0]["type"]     == "ALIAS"
+            assert val.get("matched") == 1
+
+    finally:
+        hosts.all.shell(
+            cmd=_IDCAMS_CMD, executable='/bin/sh',
+            stdin=(
+                f"  DELETE {ps_ali}   ALIAS\n"
+                f"  DELETE {pds_ali}  ALIAS\n"
+                f"  DELETE {pdse_ali} ALIAS\n"
+            ),
+        )
+        hosts.all.shell(cmd=f"drm {ps_name}")
+        hosts.all.zos_data_set(name=pds_name,  state="absent")
+        hosts.all.zos_data_set(name=pdse_name, state="absent")


### PR DESCRIPTION
##### SUMMARY
Extends zos_find to support alias as a resource_type, enabling discovery of MVS catalog alias entries. Results include an alias_of field identifying the real dataset the alias points to.

The following filters are now applicable when resource_type: alias is set:

- Alias Filtering — Scope searches exclusively to catalog alias entries via resource_type: alias
- Contains Filter — Return only aliases whose target dataset or its members contain a specified string
- Age & Age Stamp — Filter aliases by the age of their target dataset (e.g., created within the last 2 days)
- Size Filter — Filter aliases whose target dataset exceeds or is below a specified size threshold (e.g., 2 MB)
- Volume Filter — Restrict results to aliases whose target dataset resides on a specified volume
- A new include_member_aliases flag has also been introduced. When set to true, PDS/PDSE alias entries include a members list of dicts — each with a name key (the member name) and an aliases key (a list of in-directory alias names for that member). Members with no aliases are included with an empty aliases list.
- Exclude Filter - Exclude aliases matching a pattern and remove specific member aliases

Additionally, the following bug fixes are included:

- Update the age parameter documentation for clarity
- Corrected the creation_date parsing and Julian-date-to-calendar-date conversion logic
- Resolved a year 0 is out of range module failure that occurred when a dataset's creation year was reported as zero by the catalog

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
* Fixes: #2446 

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
zos_find

##### ADDITIONAL INFORMATION

```paste below
**Example — find PDS/PDSE aliases with full member alias detail:**

- name: Find all PDS/PDSE aliases and include their member alias detail
  zos_find:
    patterns:
      - ANSIBLE.ALIAS.TEST.*
    resource_type:
      - alias
    include_member_aliases: true

**Example return value (with include_member_aliases: true):**

{
  "name": "USER.PDS.ALIAS",
  "alias_of": "USER.REAL.PDS",
  "type": "ALIAS",
  "members": [
    {"name": "MEM1", "aliases": ["ALIAS1", "ALIAS2"]},
    {"name": "MEM2", "aliases": ["ALIAS3"]},
    {"name": "MEM3", "aliases": []}
  ]
}


**Some more Examples:**


- name: Find all data set aliases starting with 'USER'
  zos_find:
    patterns:
      - USER.*
    resource_type:
      - alias

- name: Find aliases matching a pattern but excluding specific entries
  zos_find:
    patterns:
      - MYHLQ.*
    resource_type:
      - alias
    excludes:
      - '.*TEMP.*'

- name: Exclude aliases matching a pattern and remove specific member aliases
  zos_find:
    patterns:
      - MYHLQ.*
    resource_type:
      - alias
    excludes:
      - '.*TEMP.*'       # excludes dataset-level aliases whose name contains TEMP
      - '(^ALIAS1$)'     # removes members whose in-directory alias name is ALIAS1

- name: Find all PDS/PDSE aliases and include their member alias detail
  zos_find:
    patterns:
      - ANSIBLE.ALIAS.TEST.*
    resource_type:
      - alias
    include_member_aliases: true

- name: Find aliases whose target dataset resides on specific volumes
  zos_find:
    patterns:
      - USER.*
    resource_type:
      - alias
    volumes:
      - VOL001
      - VOL002

- name: Find aliases whose target dataset was created within the last 30 days
  zos_find:
    patterns:
      - USER.*
    resource_type:
      - alias
    age: -30d
    age_stamp: creation_date

- name: Find aliases whose target dataset is larger than 1MB
  zos_find:
    patterns:
      - USER.*
    resource_type:
      - alias
    size: 1m

- name: Find aliases whose target dataset contains the string 'hello'
  zos_find:
    patterns:
      - USER.*
    resource_type:
      - alias
    contains: 'hello'


```
