### PR TITLE
[Bug][zos_copy] Unable to copy PDS to USS dir

### DIFF
--- a/changelogs/fragments/2572_zos_copy_mvs_ds_to_missing_uss.yml
+++ b/changelogs/fragments/2572_zos_copy_mvs_ds_to_missing_uss.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - zos_copy - Added fix to enable MVS data sets (sequential, PDS, PDSE, and GDS), PDS members, and GDGs to
+    successfully copy to a non-existent USS directory.
+    (https://github.com/ansible-collections/ibm_zos_core/issues/2525)

--- a/changelogs/fragments/2572_zos_copy_mvs_ds_to_missing_uss.yml
+++ b/changelogs/fragments/2572_zos_copy_mvs_ds_to_missing_uss.yml
@@ -1,4 +1,4 @@
 bugfixes:
-  - zos_copy - Added fix to enable MVS data sets (sequential, PDS, PDSE, and GDS), PDS members, and GDGs to
-    successfully copy to a non-existent USS directory.
+  - zos_copy - Added fix to enable sequential data sets, partitioned data sets and members, generation data sets, and
+    generations data groups to successfully copy to a non-existent USS directory.
     (https://github.com/ansible-collections/ibm_zos_core/issues/2525)

--- a/plugins/module_utils/copy.py
+++ b/plugins/module_utils/copy.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+import os
 import traceback
 from os import path
 from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.ansible_module import (
@@ -157,6 +158,11 @@ def copy_gdg2uss(src, dest, binary=False, asa_text=False):
 
     if binary or asa_text:
         copy_args["options"] = "-B"
+
+    # dest must exist as a directory before any copy call because
+    # datasets.copy (dcp) writes each generation as a file inside it
+    if not path.exists(dest):
+        os.makedirs(dest)
 
     for gds in generations:
         dest_file = path.join(dest, gds.name)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -104,11 +104,18 @@ options:
       - The remote absolute path or data set where the content should be copied to.
       - C(dest) can be a USS file, USS directory, or MVS data set name.
       - C(dest) can be an alias name of a PS, PDS, or PDSE data set.
-      - If C(dest) has missing parent directories, they will be created.
-      - If C(dest) is a USS path that does not exist and the C(src) is a PDS, PDSE, or
-        GDG, then the C(dest) will be created as a USS directory.
-      - If C(dest) is a USS path that does not exist and the C(src) is a PS, PDS member, GDS,
-        or USS file, then the C(dest) will be created as a USS file.
+      - If C(dest) has a trailing slash, it will be interpreted as a USS directory.
+      - If C(dest) is a USS path with no trailing slash and the C(src) is a PDS, PDSE, or
+        GDG, then the C(src) will be copied to the C(dest) as a USS directory.
+      - If C(dest) is a USS path with no trailing slash and the C(src) is a PS, PDS member, GDS,
+        or USS file, then the C(src) will be copied to the C(dest) as a USS file.
+      - If C(dest) is a USS directory with nonexistent parent directories, they will be created.
+      - If C(dest) is a USS file with nonexistent parent directories, the module will fail unless
+        the C(src) is also a USS path. The user must create the C(dest) parent directories for a USS 
+        file prior to running the zos_copy module if the user is not copying from a USS C(src).
+      - If C(src) and C(dest) are USS paths, any nonexistent C(dest) parent directories will be created.
+      - If the C(dest) has a trailing slash and the C(src) produces a USS file,
+        then the C(src) will be copied as a USS file to the user-specified C(dest) USS directory.
       - If C(dest) is a new USS file or replacement, the file will be appropriately tagged with
         either the system's default locale or the encoding option defined. If the USS file is
         a replacement, the user must have write authority to the file either through ownership,
@@ -1959,10 +1966,12 @@ class USSCopyHandler(CopyHandler):
             When copying the data set into USS fails.
         """
 
-        # Ensure parent directories of the destination exist.
         dest_parent = os.path.dirname(os.path.normpath(dest))
         if dest_parent and dest_parent != "/" and not os.path.exists(dest_parent):
-            os.makedirs(dest_parent)
+            raise CopyOperationError(
+                msg="Destination parent directory {0} does not exist. "
+                    "Create the parent directories before running zos_copy.".format(dest_parent)
+            )
 
         if os.path.isdir(dest):
             # If source is a data set member, destination file should have
@@ -3606,6 +3615,16 @@ def run_module(module, arg_def):
     # characters. We'll only update these variables when they are
     # data sets with record format 'FBA' or 'VBA'.
     src_has_asa_chars = dest_has_asa_chars = False
+
+    # Determine whether this copy produces a USS file (vs. a USS directory).
+    src_produces_uss_file = (
+        (src_ds_type == "USS" and not is_src_dir)          # USS file
+        or (src_ds_type in data_set.DataSet.MVS_SEQ)        # PS / SEQ
+        or (src_member)                                     # PDS member
+        or (is_src_gds)                                     # GDS
+        or (content)                                        # inline content
+    )
+
     try:
         if "/" in src:
             src_ds_type = "USS"
@@ -3674,8 +3693,14 @@ def run_module(module, arg_def):
 
         if is_uss:
             dest_ds_type = "USS"
-            if src_ds_type == "USS" and not is_src_dir and (dest.endswith("/") or os.path.isdir(dest)):
-                src_basename = os.path.basename(src) if not content else "inline_copy"
+            # If the source produces a USS file, create a source basename.
+            if src_produces_uss_file and (dest.endswith("/") or os.path.isdir(dest)):
+                if src_ds_type == "USS" or content:
+                    src_basename = os.path.basename(src) if not content else "inline_copy"
+                else:
+                    # For MVS sources (SEQ, member, GDS), derive the basename from the data set name.
+                    # For SEQ or GDS source, use last qualifier for output file name.
+                    src_basename = data_set.extract_member_name(src) if src_member else data_set.extract_dsname(src).split(".")[-1]
                 dest = os.path.normpath("{0}/{1}".format(dest, src_basename))
                 if dest.startswith("//"):
                     dest = dest.replace("//", "/")
@@ -3819,10 +3844,15 @@ def run_module(module, arg_def):
     # Verify source is a partitioned data set and is not a PDS member,
     # the destination type is USS, and the destination does not exist:
     if (
-        src_ds_type in data_set.DataSet.MVS_PARTITIONED and not src_member
-        and dest_ds_type == 'USS' and not os.path.isdir(dest)
+        dest_ds_type == 'USS' and not os.path.isdir(dest)
+        and (
+            (src_ds_type in data_set.DataSet.MVS_PARTITIONED and not src_member)
+            or raw_dest.endswith('/')
+            or src_ds_type == "GDG"
+        )
     ):
-        # Scenario 1: Attempt to write PDS (not member) to USS file (i.e. a non-directory)
+        # Scenario 1: Module fails if user attempts to write PDS (not member) to 
+        # USS file (i.e. a non-directory)
         if os.path.isfile(dest):
             module.fail_json(
                 msg="Cannot write a partitioned data set (PDS) to a USS file."
@@ -3830,13 +3860,20 @@ def run_module(module, arg_def):
         # Scenario 2: Destination directory is missing and needs to be created
         else:
             try:
+                dir_to_create = dest if not src_produces_uss_file else os.path.dirname(dest)
                 # Will also create nonexistent parent directories in dest path
-                os.makedirs(dest, exist_ok=True)
+                os.makedirs(dir_to_create, exist_ok=True)
                 res_args["dest_created"] = True
                 dest_exists = True
-            except Exception as err:
+            except PermissionError:
                 module.fail_json(
-                    msg="Unable to allocate destination data set: {0}".format(str(err)),
+                    msg="Unable to create USS directory '{0}': permission denied. "
+                        "Verify the Ansible user has write access to the parent directory.".format(dir_to_create),
+                    dest_exists=dest_exists
+                )
+            except OSError as err:
+                module.fail_json(
+                    msg="Unable to create USS directory '{0}': {1}".format(dir_to_create, str(err)),
                     dest_exists=dest_exists
                 )
 

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -107,12 +107,12 @@ options:
       - If C(dest) has a trailing slash, it will be interpreted as a USS directory.
       - If C(dest) is a USS path with no trailing slash and the C(src) is a PDS, PDSE, or
         GDG, then the C(src) will be copied to the C(dest) as a USS directory.
-      - If C(dest) is a USS path with no trailing slash and the C(src) is a PS, PDS member, GDS,
+      - If C(dest) is a USS path with no trailing slash and the C(src) is a PS, PDS/PDSE member, GDS,
         or USS file, then the C(src) will be copied to the C(dest) as a USS file.
       - If C(dest) is a USS directory with nonexistent parent directories, they will be created.
-      - If C(dest) is a USS file with nonexistent parent directories, the module will fail unless
-        the C(src) is a USS path or a GDS. The user must create the C(dest) parent directories for a USS 
-        file prior to running the zos_copy module if the user is not copying from a USS or GDS C(src).
+      - If C(dest) is a USS file with nonexistent parent directories, they will be created unless
+        the source is a PS data set. The user must create the C(dest) parent directories for a USS file 
+        prior to running the zos_copy module if the user is copying from a PS C(src).
       - If C(src) and C(dest) are USS paths, any nonexistent C(dest) parent directories will be created.
       - If the C(dest) has a trailing slash and the C(src) produces a USS file,
         then the C(src) will be copied as a USS file to the user-specified C(dest) USS directory.
@@ -1970,7 +1970,7 @@ class USSCopyHandler(CopyHandler):
 
         dest_parent = os.path.dirname(os.path.normpath(dest))
         if dest_parent and dest_parent != "/" and not os.path.exists(dest_parent):
-            if (is_src_gds):
+            if (is_src_gds or src_member):
                 os.makedirs(dest_parent)
             else:
                 raise CopyOperationError(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1983,20 +1983,6 @@ class USSCopyHandler(CopyHandler):
                         "Create the parent directories before running zos_copy.".format(dest_parent)
                 )
 
-        # Must create destination for sequential data set copy
-        if (
-            src_ds_type in data_set.DataSet.MVS_SEQ
-            and not is_src_gds
-            and not src_member
-            and not os.path.exists(dest)
-            and not os.path.isdir(dest)
-        ):
-            raise CopyOperationError(
-                msg="Destination {0} does not exist. "
-                    "Create the destination file or its parent directories "
-                    "before copying from a sequential data set (PS).".format(dest)
-            )
-
         if os.path.isdir(dest):
             # If source is a data set member, destination file should have
             # the same name as the member.

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1968,6 +1968,7 @@ class USSCopyHandler(CopyHandler):
             When copying the data set into USS fails.
         """
 
+        # Non-existent destination parent directories created for GDS or PDS/PDSE members
         dest_parent = os.path.dirname(os.path.normpath(dest))
         if dest_parent and dest_parent != "/" and not os.path.exists(dest_parent):
             if (is_src_gds or src_member):
@@ -1977,6 +1978,20 @@ class USSCopyHandler(CopyHandler):
                     msg="Destination parent directory {0} does not exist. "
                         "Create the parent directories before running zos_copy.".format(dest_parent)
                 )
+
+        # Must create destination for sequential data set copy
+        if (
+            src_ds_type in data_set.DataSet.MVS_SEQ
+            and not is_src_gds
+            and not src_member
+            and not os.path.exists(dest)
+            and not os.path.isdir(dest)
+        ):
+            raise CopyOperationError(
+                msg="Destination {0} does not exist. "
+                    "Create the destination file or its parent directories "
+                    "before copying from a sequential data set (PS).".format(dest)
+            )
 
         if os.path.isdir(dest):
             # If source is a data set member, destination file should have

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3803,17 +3803,24 @@ def run_module(module, arg_def):
                     + "for USS sources (src) or targets (dest). "
                     + "Try setting executable=True or aliases=False."
             )
-
+    
     # ********************************************************************
-    # Attempt to write PDS (not member) to USS file (i.e. a non-directory)
+    # Handle partitioned data set to USS copy missing destination directory
     # ********************************************************************
+    # Verify destination is a partitioned data set and is not a PDS member, 
+    # the destination type is USS, and the destination does not exist:
     if (
         src_ds_type in data_set.DataSet.MVS_PARTITIONED and not src_member
         and dest_ds_type == 'USS' and not os.path.isdir(dest)
     ):
-        module.fail_json(
-            msg="Cannot write a partitioned data set (PDS) to a USS file."
-        )
+        # Scenario 1: Attempt to write PDS (not member) to USS file (i.e. a non-directory)
+        if os.path.isfile(dest):
+            module.fail_json(
+                msg="Cannot write a partitioned data set (PDS) to a USS file."
+            )
+        # Scenario 2: Destination directory is missing and needs to be created
+        else:
+            os.makedirs(dest, exist_ok=True)
 
     # ********************************************************************
     # Backup should only be performed if dest is an existing file or

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1651,8 +1651,7 @@ class USSCopyHandler(CopyHandler):
         src_member,
         member_name,
         replace,
-        content_copy,
-        is_src_gds
+        content_copy
     ):
         """Copy a file or data set to a USS location.
 
@@ -1687,7 +1686,7 @@ class USSCopyHandler(CopyHandler):
 
         if src_ds_type in data_set.DataSet.MVS_SEQ.union(data_set.DataSet.MVS_PARTITIONED) or src_ds_type == "GDG":
             self._mvs_copy_to_uss(
-                src, dest, src_ds_type, src_member, member_name=member_name, is_src_gds=is_src_gds
+                src, dest, src_ds_type, src_member, member_name=member_name
             )
 
             if self.executable:
@@ -1947,7 +1946,6 @@ class USSCopyHandler(CopyHandler):
         src_ds_type,
         src_member,
         member_name=None,
-        is_src_gds=False
     ):
         """Helper function to copy an MVS data set src to USS dest.
 
@@ -1973,23 +1971,14 @@ class USSCopyHandler(CopyHandler):
             When copying the data set into USS fails.
         """
 
-        # Non-existent destination parent directories are created only for GDS sources.
-        # For PDS/PDSE members and all other sources, missing parent directories are an error.
-        dest_parent = os.path.dirname(os.path.normpath(dest))
-        if dest_parent and dest_parent != "/" and not os.path.exists(dest_parent):
-            if is_src_gds:
-                os.makedirs(dest_parent)
-            else:
-                raise CopyOperationError(
-                    msg="Destination parent directory {0} does not exist. "
-                        "Create the parent directories before running zos_copy.".format(dest_parent)
-                )
-
+        # Create copy targets inside destination directory
         if os.path.isdir(dest):
-            # If source is a data set member, destination file should have
-            # the same name as the member.
+            # Build final destination path
+            #   Member name as file name if source is a PDSE/PDSE member
+            #   Source data set name as file name if source is PDS/PDSE/GDG
             dest = "{0}/{1}".format(dest, member_name or src)
 
+            # Construct new directory if PDS/PDSE/GDG is copied
             if (src_ds_type in data_set.DataSet.MVS_PARTITIONED and not src_member) or src_ds_type == "GDG":
                 try:
                     os.mkdir(dest)
@@ -3705,7 +3694,8 @@ def run_module(module, arg_def):
 
         if is_uss:
             dest_ds_type = "USS"
-            # If the source produces a USS file, create a source basename.
+            # If the source produces a USS file and destination is a directory, create a source basename
+            # to use as the file name added to the destination direcotry.
             if src_produces_uss_file and (dest.endswith("/") or os.path.isdir(dest)):
                 if src_ds_type == "USS" or content:
                     src_basename = os.path.basename(src) if not content else "inline_copy"
@@ -3850,11 +3840,14 @@ def run_module(module, arg_def):
             )
 
     # ********************************************************************
-    # Handle partitioned data set to USS directory copy when destination
+    # Handle PDS/PDSE/GDG to USS directory copy when destination
     # does not exist
     # ********************************************************************
-    # Verify source is a partitioned data set and is not a PDS member,
-    # the destination type is USS, and the destination does not exist:
+    # Verify the destination type is USS and the destination does not exist.
+    # Verify one of the following:
+    #    The source is a partitioned data set 
+    #    The source ends with a trailing slash and is intended to be a directory
+    #    The source is a GDG
     if (
         dest_ds_type == 'USS' and not os.path.isdir(dest)
         and (
@@ -3863,7 +3856,7 @@ def run_module(module, arg_def):
             or src_ds_type == "GDG"
         )
     ):
-        # Scenario 1: Module fails if user attempts to write PDS (not member) to 
+        # Scenario 1: Module fails if user attempts to write data set (not member) to 
         # USS file (i.e. a non-directory)
         if os.path.isfile(dest):
             module.fail_json(
@@ -4071,8 +4064,7 @@ def run_module(module, arg_def):
                 src_member,
                 member_name,
                 replace,
-                bool(content),
-                is_src_gds
+                bool(content)
             )
             res_args['size'] = os.stat(dest).st_size
             remote_checksum = dest_checksum = None

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -106,7 +106,7 @@ options:
       - C(dest) can be an alias name of a PS, PDS, or PDSE data set.
       - If C(dest) has missing parent directories, they will be created.
       - If C(dest) is a USS path that does not exist and the C(src) is a PDS, PDSE, or
-        GDG, then the C(dest) will be created as a USS directory. 
+        GDG, then the C(dest) will be created as a USS directory.
       - If C(dest) is a USS path that does not exist and the C(src) is a PS, PDS member, GDS,
         or USS file, then the C(dest) will be created as a USS file.
       - If C(dest) is a new USS file or replacement, the file will be appropriately tagged with
@@ -3811,12 +3811,12 @@ def run_module(module, arg_def):
                     + "for USS sources (src) or targets (dest). "
                     + "Try setting executable=True or aliases=False."
             )
-    
+
     # ********************************************************************
     # Handle partitioned data set to USS directory copy when destination
     # does not exist
     # ********************************************************************
-    # Verify source is a partitioned data set and is not a PDS member, 
+    # Verify source is a partitioned data set and is not a PDS member,
     # the destination type is USS, and the destination does not exist:
     if (
         src_ds_type in data_set.DataSet.MVS_PARTITIONED and not src_member
@@ -3925,7 +3925,7 @@ def run_module(module, arg_def):
     if converted_src:
         original_src = src
         src = converted_src
-        
+
     # Allocate destination data set
     try:
         if not is_uss:

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -105,6 +105,8 @@ options:
       - C(dest) can be a USS file, directory or MVS data set name.
       - C(dest) can be a alias name of a PS, PDS or PDSE data set.
       - If C(dest) has missing parent directories, they will be created.
+      - If C(dest) is a non-existent USS directory path and the C(src) is a partitioned data set, 
+        the C(dest) is created.
       - If C(dest) is a nonexistent USS file, it will be created.
       - If C(dest) is a new USS file or replacement, the file will be appropriately tagged with
         either the system's default locale or the encoding option defined. If the USS file is
@@ -3805,9 +3807,10 @@ def run_module(module, arg_def):
             )
     
     # ********************************************************************
-    # Handle partitioned data set to USS copy missing destination directory
+    # Handle partitioned data set to USS directory copy when destination
+    # does not exist
     # ********************************************************************
-    # Verify destination is a partitioned data set and is not a PDS member, 
+    # Verify source is a partitioned data set and is not a PDS member, 
     # the destination type is USS, and the destination does not exist:
     if (
         src_ds_type in data_set.DataSet.MVS_PARTITIONED and not src_member
@@ -3820,7 +3823,16 @@ def run_module(module, arg_def):
             )
         # Scenario 2: Destination directory is missing and needs to be created
         else:
-            os.makedirs(dest, exist_ok=True)
+            try:
+                # Will also create nonexistent parent directories in dest path
+                os.makedirs(dest, exist_ok=True)
+                res_args["dest_created"] = True
+                dest_exists = True
+            except Exception as err:
+                module.fail_json(
+                    msg="Unable to allocate destination data set: {0}".format(str(err)),
+                    dest_exists=dest_exists
+                )
 
     # ********************************************************************
     # Backup should only be performed if dest is an existing file or
@@ -3845,8 +3857,9 @@ def run_module(module, arg_def):
                 backup_name = backup_data(dest, dest_ds_type, backup_name, tmphlq)
 
     # ********************************************************************
-    # If destination does not exist, it must be created. To determine
-    # what type of data set destination must be, a couple of simple checks
+    # If destination does not exist, it must be created. To be created,
+    # the destination data set type is required. To determine
+    # what type a data set destination must be, a couple of simple checks
     # can be done. For example:
     # 1. Destination must be a PDS/PDSE if:
     #   - The source is a local directory
@@ -3861,6 +3874,7 @@ def run_module(module, arg_def):
     # is a data set (is_src_dir and is_mvs_dest are true)
     # ********************************************************************
     else:
+        # Set destination data set type
         if not dest_ds_type:
             if (
                 is_pds
@@ -3905,7 +3919,8 @@ def run_module(module, arg_def):
     if converted_src:
         original_src = src
         src = converted_src
-
+        
+    # Allocate destination data set
     try:
         if not is_uss:
             res_args["changed"], res_args["dest_data_set_attrs"], resolved_dest = allocate_destination_data_set(
@@ -3988,7 +4003,7 @@ def run_module(module, arg_def):
 
             original_checksum = None
             if dest_exists:
-                res_args["dest_created"] = False
+                res_args.setdefault("dest_created", False)
                 original_checksum = get_file_checksum(dest)
             else:
                 res_args["dest_created"] = True

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -111,7 +111,9 @@ options:
         as a USS file if the source is a PS, PDS member, GDS, or USS file, and it is interpreted as a USS
         directory if the source is a PDS, PDSE, GDG, or USS directory.
       - If C(dest) is a USS directory with nonexistent parent directories, they will be created.
-      - If C(dest) is a USS file with nonexistent parent directories, copy will fail.
+      - If C(dest) is a USS file with nonexistent parent directories and the C(src) is a USS file, the parent
+        directories will be created.
+      - If C(dest) is a USS file with nonexistent parent directories and the C(src) is not a USS file, copy will fail.
       - If C(dest) is a USS file with existing parent directories but the destination does not exist, it
         will be created.
       - If C(dest) is a USS directory and C(src) is a PS, PDS member, GDS, or USS file, a file with the

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -1945,7 +1945,7 @@ class USSCopyHandler(CopyHandler):
         dest,
         src_ds_type,
         src_member,
-        member_name=None,
+        member_name=None
     ):
         """Helper function to copy an MVS data set src to USS dest.
 
@@ -3863,7 +3863,6 @@ def run_module(module, arg_def):
         dest_ds_type == 'USS' and not os.path.isdir(dest)
         and (
             (src_ds_type in data_set.DataSet.MVS_PARTITIONED and not src_member)
-            # or (raw_dest.endswith('/') and not is_src_dir)
             or (raw_dest.endswith('/') and not is_src_dir and src_ds_type != "USS")
             or src_ds_type == "GDG"
         )
@@ -3879,7 +3878,6 @@ def run_module(module, arg_def):
             try:
                 # Determine whether this copy produces a USS file (vs. a USS directory).
                 src_produces_uss_file = _src_produces_uss_file(src_ds_type, is_src_dir, src_member, is_src_gds, content)
-
                 dir_to_create = dest if not src_produces_uss_file else os.path.dirname(dest)
                 # Will also create nonexistent parent directories in dest path
                 os.makedirs(dir_to_create, exist_ok=True)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -3427,6 +3427,26 @@ def update_result(res_args, original_args):
     return updated_result
 
 
+def _src_produces_uss_file(src_ds_type, is_src_dir, src_member, is_src_gds, content):
+    """Return true when the copy operation produces a single USS file as output.
+
+    A copy produces a USS file (rather than a USS directory tree) when the
+    source is one of the following:
+    - a USS file (not a directory),
+    - a sequential MVS data set,
+    - a PDS member,
+    - a Generation Data Set (GDS), or
+    - inline content supplied via the *content* parameter.
+    """
+    return bool(
+        (src_ds_type == "USS" and not is_src_dir)   # USS file
+        or (src_ds_type in data_set.DataSet.MVS_SEQ) # PS / SEQ
+        or src_member                                # PDS member
+        or is_src_gds                                # GDS
+        or content                                   # inline content
+    )
+
+
 def run_module(module, arg_def):
     """Initialize module
 
@@ -3617,15 +3637,6 @@ def run_module(module, arg_def):
     # data sets with record format 'FBA' or 'VBA'.
     src_has_asa_chars = dest_has_asa_chars = False
 
-    # Determine whether this copy produces a USS file (vs. a USS directory).
-    src_produces_uss_file = (
-        (src_ds_type == "USS" and not is_src_dir)          # USS file
-        or (src_ds_type in data_set.DataSet.MVS_SEQ)        # PS / SEQ
-        or (src_member)                                     # PDS member
-        or (is_src_gds)                                     # GDS
-        or (content)                                        # inline content
-    )
-
     try:
         if "/" in src:
             src_ds_type = "USS"
@@ -3694,15 +3705,15 @@ def run_module(module, arg_def):
 
         if is_uss:
             dest_ds_type = "USS"
-            # If the source produces a USS file and destination is a directory, create a source basename
-            # to use as the file name added to the destination direcotry.
-            if src_produces_uss_file and (dest.endswith("/") or os.path.isdir(dest)):
-                if src_ds_type == "USS" or content:
-                    src_basename = os.path.basename(src) if not content else "inline_copy"
-                else:
-                    # For MVS sources (SEQ, member, GDS), derive the basename from the data set name.
-                    # For SEQ or GDS source, use last qualifier for output file name.
-                    src_basename = data_set.extract_member_name(src) if src_member else data_set.extract_dsname(src).split(".")[-1]
+
+            # Determine whether this copy produces a USS file (vs. a USS directory).
+            src_produces_uss_file = _src_produces_uss_file(src_ds_type, is_src_dir, src_member, is_src_gds, content)
+
+            # Only rewrite dest early for USS-to-USS or content copies.
+            # For MVS sources (SEQ, member, GDS), _mvs_copy_to_uss handles
+            # the basename derivation itself when dest is a directory.
+            if src_produces_uss_file and (src_ds_type == "USS" or content) and (dest.endswith("/") or os.path.isdir(dest)):
+                src_basename = os.path.basename(src) if not content else "inline_copy"
                 dest = os.path.normpath("{0}/{1}".format(dest, src_basename))
                 if dest.startswith("//"):
                     dest = dest.replace("//", "/")
@@ -3852,7 +3863,8 @@ def run_module(module, arg_def):
         dest_ds_type == 'USS' and not os.path.isdir(dest)
         and (
             (src_ds_type in data_set.DataSet.MVS_PARTITIONED and not src_member)
-            or (raw_dest.endswith('/') and not is_src_dir)
+            # or (raw_dest.endswith('/') and not is_src_dir)
+            or (raw_dest.endswith('/') and not is_src_dir and src_ds_type != "USS")
             or src_ds_type == "GDG"
         )
     ):
@@ -3865,6 +3877,9 @@ def run_module(module, arg_def):
         # Scenario 2: Destination directory is missing and needs to be created
         else:
             try:
+                # Determine whether this copy produces a USS file (vs. a USS directory).
+                src_produces_uss_file = _src_produces_uss_file(src_ds_type, is_src_dir, src_member, is_src_gds, content)
+
                 dir_to_create = dest if not src_produces_uss_file else os.path.dirname(dest)
                 # Will also create nonexistent parent directories in dest path
                 os.makedirs(dir_to_create, exist_ok=True)

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -111,8 +111,8 @@ options:
         or USS file, then the C(src) will be copied to the C(dest) as a USS file.
       - If C(dest) is a USS directory with nonexistent parent directories, they will be created.
       - If C(dest) is a USS file with nonexistent parent directories, the module will fail unless
-        the C(src) is also a USS path. The user must create the C(dest) parent directories for a USS 
-        file prior to running the zos_copy module if the user is not copying from a USS C(src).
+        the C(src) is a USS path or a GDS. The user must create the C(dest) parent directories for a USS 
+        file prior to running the zos_copy module if the user is not copying from a USS or GDS C(src).
       - If C(src) and C(dest) are USS paths, any nonexistent C(dest) parent directories will be created.
       - If the C(dest) has a trailing slash and the C(src) produces a USS file,
         then the C(src) will be copied as a USS file to the user-specified C(dest) USS directory.
@@ -1647,6 +1647,7 @@ class USSCopyHandler(CopyHandler):
         member_name,
         replace,
         content_copy,
+        is_src_gds
     ):
         """Copy a file or data set to a USS location.
 
@@ -1681,7 +1682,7 @@ class USSCopyHandler(CopyHandler):
 
         if src_ds_type in data_set.DataSet.MVS_SEQ.union(data_set.DataSet.MVS_PARTITIONED) or src_ds_type == "GDG":
             self._mvs_copy_to_uss(
-                src, dest, src_ds_type, src_member, member_name=member_name
+                src, dest, src_ds_type, src_member, member_name=member_name, is_src_gds=is_src_gds
             )
 
             if self.executable:
@@ -1940,7 +1941,8 @@ class USSCopyHandler(CopyHandler):
         dest,
         src_ds_type,
         src_member,
-        member_name=None
+        member_name=None,
+        is_src_gds=False
     ):
         """Helper function to copy an MVS data set src to USS dest.
 
@@ -1968,10 +1970,13 @@ class USSCopyHandler(CopyHandler):
 
         dest_parent = os.path.dirname(os.path.normpath(dest))
         if dest_parent and dest_parent != "/" and not os.path.exists(dest_parent):
-            raise CopyOperationError(
-                msg="Destination parent directory {0} does not exist. "
-                    "Create the parent directories before running zos_copy.".format(dest_parent)
-            )
+            if (is_src_gds):
+                os.makedirs(dest_parent)
+            else:
+                raise CopyOperationError(
+                    msg="Destination parent directory {0} does not exist. "
+                        "Create the parent directories before running zos_copy.".format(dest_parent)
+                )
 
         if os.path.isdir(dest):
             # If source is a data set member, destination file should have
@@ -3847,7 +3852,7 @@ def run_module(module, arg_def):
         dest_ds_type == 'USS' and not os.path.isdir(dest)
         and (
             (src_ds_type in data_set.DataSet.MVS_PARTITIONED and not src_member)
-            or raw_dest.endswith('/')
+            or (raw_dest.endswith('/') and not is_src_dir)
             or src_ds_type == "GDG"
         )
     ):
@@ -4059,7 +4064,8 @@ def run_module(module, arg_def):
                 src_member,
                 member_name,
                 replace,
-                bool(content)
+                bool(content),
+                is_src_gds
             )
             res_args['size'] = os.stat(dest).st_size
             remote_checksum = dest_checksum = None

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -102,12 +102,13 @@ options:
   dest:
     description:
       - The remote absolute path or data set where the content should be copied to.
-      - C(dest) can be a USS file, directory or MVS data set name.
-      - C(dest) can be a alias name of a PS, PDS or PDSE data set.
+      - C(dest) can be a USS file, USS directory, or MVS data set name.
+      - C(dest) can be an alias name of a PS, PDS, or PDSE data set.
       - If C(dest) has missing parent directories, they will be created.
-      - If C(dest) is a non-existent USS directory path and the C(src) is a partitioned data set, 
-        the C(dest) is created.
-      - If C(dest) is a nonexistent USS file, it will be created.
+      - If C(dest) is a USS path that does not exist and the C(src) is a PDS, PDSE, or
+        GDG, then the C(dest) will be created as a USS directory. 
+      - If C(dest) is a USS path that does not exist and the C(src) is a PS, PDS member, GDS,
+        or USS file, then the C(dest) will be created as a USS file.
       - If C(dest) is a new USS file or replacement, the file will be appropriately tagged with
         either the system's default locale or the encoding option defined. If the USS file is
         a replacement, the user must have write authority to the file either through ownership,
@@ -1957,6 +1958,11 @@ class USSCopyHandler(CopyHandler):
         CopyOperationError
             When copying the data set into USS fails.
         """
+
+        # Ensure parent directories of the destination exist.
+        dest_parent = os.path.dirname(os.path.normpath(dest))
+        if dest_parent and dest_parent != "/" and not os.path.exists(dest_parent):
+            os.makedirs(dest_parent)
 
         if os.path.isdir(dest):
             # If source is a data set member, destination file should have

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -104,18 +104,21 @@ options:
       - The remote absolute path or data set where the content should be copied to.
       - C(dest) can be a USS file, USS directory, or MVS data set name.
       - C(dest) can be an alias name of a PS, PDS, or PDSE data set.
-      - If C(dest) has a trailing slash, it will be interpreted as a USS directory.
-      - If C(dest) is a USS path with no trailing slash and the C(src) is a PDS, PDSE, or
-        GDG, then the C(src) will be copied to the C(dest) as a USS directory.
-      - If C(dest) is a USS path with no trailing slash and the C(src) is a PS, PDS/PDSE member, GDS,
-        or USS file, then the C(src) will be copied to the C(dest) as a USS file.
+      - If C(dest) is a USS path with a trailing slash, it will always be interpreted as a USS directory.
+      - If C(dest) is has a USS path with no trailing slash but the C(dest) exists on the system,
+        the existing destination type is used to determine whether the destination is a USS file or directory.
+      - If C(dest) is a USS path with no trailing slash and the C(dest) does not exist, it is interpreted
+        as a USS file if the source is a PS, PDS member, GDS, or USS file, and it is interpreted as a USS
+        directory if the source is a PDS, PDSE, GDG, or USS directory.
       - If C(dest) is a USS directory with nonexistent parent directories, they will be created.
-      - If C(dest) is a USS file with nonexistent parent directories, they will be created unless
-        the source is a PS data set. The user must create the C(dest) parent directories for a USS file 
-        prior to running the zos_copy module if the user is copying from a PS C(src).
-      - If C(src) and C(dest) are USS paths, any nonexistent C(dest) parent directories will be created.
-      - If the C(dest) has a trailing slash and the C(src) produces a USS file,
-        then the C(src) will be copied as a USS file to the user-specified C(dest) USS directory.
+      - If C(dest) is a USS file with nonexistent parent directories, copy will fail.
+      - If C(dest) is a USS file with existing parent directories but the destination does not exist, it
+        will be created.
+      - If C(dest) is a USS directory and C(src) is a PS, PDS member, GDS, or USS file, a file with the
+        name of the C(src) will be copied into the C(dest).
+      - If C(dest) is a USS directory and C(src) is a PDSE, PDSE, GDG, or USS directory, a directory with
+        the name of the source will be copied into the C(dest).
+      - If C(dest) is a USS file, the C(source) contents will be copied into the C(dest).
       - If C(dest) is a new USS file or replacement, the file will be appropriately tagged with
         either the system's default locale or the encoding option defined. If the USS file is
         a replacement, the user must have write authority to the file either through ownership,
@@ -1968,10 +1971,11 @@ class USSCopyHandler(CopyHandler):
             When copying the data set into USS fails.
         """
 
-        # Non-existent destination parent directories created for GDS or PDS/PDSE members
+        # Non-existent destination parent directories are created only for GDS sources.
+        # For PDS/PDSE members and all other sources, missing parent directories are an error.
         dest_parent = os.path.dirname(os.path.normpath(dest))
         if dest_parent and dest_parent != "/" and not os.path.exists(dest_parent):
-            if (is_src_gds or src_member):
+            if is_src_gds:
                 os.makedirs(dest_parent)
             else:
                 raise CopyOperationError(

--- a/plugins/modules/zos_copy.py
+++ b/plugins/modules/zos_copy.py
@@ -105,16 +105,12 @@ options:
       - C(dest) can be a USS file, USS directory, or MVS data set name.
       - C(dest) can be an alias name of a PS, PDS, or PDSE data set.
       - If C(dest) is a USS path with a trailing slash, it will always be interpreted as a USS directory.
-      - If C(dest) is has a USS path with no trailing slash but the C(dest) exists on the system,
-        the existing destination type is used to determine whether the destination is a USS file or directory.
       - If C(dest) is a USS path with no trailing slash and the C(dest) does not exist, it is interpreted
         as a USS file if the source is a PS, PDS member, GDS, or USS file, and it is interpreted as a USS
         directory if the source is a PDS, PDSE, GDG, or USS directory.
       - If C(dest) is a USS directory with nonexistent parent directories, they will be created.
-      - If C(dest) is a USS file with nonexistent parent directories and the C(src) is a USS file, the parent
-        directories will be created.
-      - If C(dest) is a USS file with nonexistent parent directories and the C(src) is not a USS file, copy will fail.
-      - If C(dest) is a USS file with existing parent directories but the destination does not exist, it
+      - If C(dest) is a USS file, the parent directories specified in the C(dest) path must exist for copy
+        to succeed. However, if both the C(src) and C(dest) is a USS file, nonexistent parent directories
         will be created.
       - If C(dest) is a USS directory and C(src) is a PS, PDS member, GDS, or USS file, a file with the
         name of the C(src) will be copied into the C(dest).
@@ -1974,7 +1970,7 @@ class USSCopyHandler(CopyHandler):
         # Create copy targets inside destination directory
         if os.path.isdir(dest):
             # Build final destination path
-            #   Member name as file name if source is a PDSE/PDSE member
+            #   Member name as file name if source is a PDS/PDSE member
             #   Source data set name as file name if source is PDS/PDSE/GDG
             dest = "{0}/{1}".format(dest, member_name or src)
 
@@ -3439,11 +3435,11 @@ def _src_produces_uss_file(src_ds_type, is_src_dir, src_member, is_src_gds, cont
     - inline content supplied via the *content* parameter.
     """
     return bool(
-        (src_ds_type == "USS" and not is_src_dir)   # USS file
-        or (src_ds_type in data_set.DataSet.MVS_SEQ) # PS / SEQ
-        or src_member                                # PDS member
-        or is_src_gds                                # GDS
-        or content                                   # inline content
+        (src_ds_type == "USS" and not is_src_dir)     # USS file
+        or (src_ds_type in data_set.DataSet.MVS_SEQ)  # PS / SEQ
+        or src_member                                 # PDS member
+        or is_src_gds                                 # GDS
+        or content                                    # inline content
     )
 
 
@@ -3856,7 +3852,7 @@ def run_module(module, arg_def):
     # ********************************************************************
     # Verify the destination type is USS and the destination does not exist.
     # Verify one of the following:
-    #    The source is a partitioned data set 
+    #    The source is a partitioned data set
     #    The source ends with a trailing slash and is intended to be a directory
     #    The source is a GDG
     if (
@@ -3867,7 +3863,7 @@ def run_module(module, arg_def):
             or src_ds_type == "GDG"
         )
     ):
-        # Scenario 1: Module fails if user attempts to write data set (not member) to 
+        # Scenario 1: Module fails if user attempts to write data set (not member) to
         # USS file (i.e. a non-directory)
         if os.path.isfile(dest):
             module.fail_json(

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2923,12 +2923,43 @@ def test_copy_ps_to_non_existing_uss_file_missing_parents(ansible_zos_module):
 
     src:    Sequential data set populated with special-character content.
     dest:   /tmp/test/newdir/<random> (parent dirs absent).
-    assert: Copy succeeds, dest file is created, content is readable via cat.
+    assert: Copy fails; zos_copy must not create parent directories when copying
+            from a PS source to a non-existent USS file.
     """
     hosts = ansible_zos_module
     src_ds = get_tmp_ds_name()
     parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
     dest = get_random_file_name(dir=parent_dir)
+
+    try:
+        hosts.all.shell(cmd=f"decho '{DUMMY_DATA_SPECIAL_CHARS}' '{src_ds}' ")
+        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
+        stat_res = hosts.all.stat(path=dest)
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is not None
+            assert result.get("changed") is False
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is False
+    finally:
+        hosts.all.file(path=parent_dir, state="absent")
+        hosts.all.zos_data_set(name=src_ds, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.seq
+def test_copy_ps_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
+    """
+    Copy a sequential data set to a USS path whose parent directories do not exist.
+
+    src:    Sequential data set populated with special-character content.
+    dest:   /tmp/test/newdir/<random>/ (parent dirs absent).
+    assert: Copy succeeds, dest file is created, content is readable via cat.
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir, suffix='/')
 
     try:
         hosts.all.shell(cmd=f"decho '{DUMMY_DATA_SPECIAL_CHARS}' '{src_ds}' ")
@@ -2948,10 +2979,11 @@ def test_copy_ps_to_non_existing_uss_file_missing_parents(ansible_zos_module):
             assert result.get("stat").get("exists") is True
         for result in verify_copy.contacted.values():
             assert result.get("rc") == 0
-            assert result.get("stdout") != ""
+            assert result.get("stdout") == ""
     finally:
         hosts.all.file(path=dest, state="absent")
         hosts.all.zos_data_set(name=src_ds, state="absent")
+
 
 
 @pytest.mark.uss

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3019,6 +3019,135 @@ def test_copy_pds_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
 
 @pytest.mark.uss
 @pytest.mark.pds
+def test_copy_pds_to_non_existing_uss_dir_missing_parents_trailing_slash(ansible_zos_module):
+    """
+    Copy a partitioned data set to a USS path whose parent directories do not exist,
+    using a trailing slash in the destination path.
+
+    src:    Partitioned data set with member.
+    dest:   /tmp/test/newdir/<random>/ (trailing slash, parent dirs absent).
+    assert: Copy succeeds, dest directory is created, all members are present as files.
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    src_ds_mem = f"{src_ds}(MEM1)"
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir, suffix='/')
+
+    try:
+        ds_creation_result = hosts.all.zos_data_set(
+            name=src_ds,
+            type="pds",
+            space_primary=5,
+            space_type="m",
+            record_format="fba",
+            record_length=80,
+            replace=True,
+            state="present"
+        )
+        for result in ds_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        member_creation_result = hosts.all.zos_data_set(
+            name=src_ds_mem,
+            state="present",
+            type="member",
+            replace=True
+        )
+        for result in member_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
+        stat_res = hosts.all.stat(path=dest)
+        verify_dest = hosts.all.shell(cmd=f"ls {dest}{src_ds}")
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") is not None
+            assert result.get("dest_created") is True
+            assert result.get("src") is not None
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+        for v_res in verify_dest.contacted.values():
+            assert v_res.get("rc") == 0
+            files = v_res.get("stdout_lines", [])
+            assert len(files) == 1, f"Expected 1 member, found: {files}"
+
+    finally:
+        hosts.all.file(path=dest, state="absent")
+        hosts.all.zos_data_set(name=src_ds, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.pds
+@pytest.mark.parametrize("src_type", ["pds", "pdse"])
+def test_copy_pds_to_existing_uss_dir(ansible_zos_module, src_type):
+    """
+    Copy a PDS to a USS directory that already exists.
+
+    src:    PDS with members populated with dummy data.
+    dest:   /tmp/<random> (existing USS directory).
+    assert: Copy succeeds, a subdirectory named after the data set is present inside
+            dest, and all members are present as files within it.
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    dest = get_random_file_name(dir=TMP_DIRECTORY)
+    dest_path = "{0}/{1}".format(dest, src_ds)
+
+    try:
+        ds_creation_result = hosts.all.zos_data_set(
+            name=src_ds,
+            type=src_type,
+            space_primary=5,
+            space_type="m",
+            record_format="fba",
+            record_length=80,
+            replace=True,
+            state="present"
+        )
+        for result in ds_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        members = ["MEM1", "MEM2"]
+        for member in members:
+            hosts.all.shell(
+                cmd="decho '{0}' '{1}({2})'".format(DUMMY_DATA, src_ds, member),
+                executable=SHELL_EXECUTABLE
+            )
+
+        hosts.all.file(path=dest, state="directory")
+
+        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
+        stat_res = hosts.all.stat(path=dest_path)
+        verify_dest = hosts.all.shell(
+            cmd="ls {0}".format(dest_path), executable=SHELL_EXECUTABLE
+        )
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest
+            assert result.get("src") is not None
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is True
+        for v_res in verify_dest.contacted.values():
+            assert v_res.get("rc") == 0
+            files = v_res.get("stdout_lines", [])
+            assert len(files) == len(members), f"Expected {len(members)} members, found: {files}"
+
+    finally:
+        hosts.all.file(path=dest, state="absent")
+        hosts.all.zos_data_set(name=src_ds, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.pds
 def test_copy_pdse_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
     """
     Copy a PDSE to a USS path whose parent directories do not exist.
@@ -5104,6 +5233,105 @@ def test_copy_member_to_existing_uss_file(ansible_zos_module, args):
 
 @pytest.mark.uss
 @pytest.mark.pdse
+@pytest.mark.parametrize("ds_type", ["pds", "pdse"])
+def test_copy_member_to_non_existing_uss_file_missing_parents(ansible_zos_module, ds_type):
+    """
+    Copy a PDS/PDSE member to a USS file path whose parent directories do not exist,
+    with no trailing slash in the destination path.
+
+    src:    PDS or PDSE member populated with dummy data.
+    dest:   /tmp/test/newdir/<random> (no trailing slash, parent dirs absent).
+    assert: Copy succeeds, dest is created as a regular file, content is readable.
+    """
+    hosts = ansible_zos_module
+    data_set = get_tmp_ds_name()
+    src = "{0}(MEMBER)".format(data_set)
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir)
+
+    try:
+        hosts.all.zos_data_set(name=data_set, state="present", type=ds_type)
+        hosts.all.shell(
+            cmd="decho '{0}' '{1}'".format(DUMMY_DATA, src),
+            executable=SHELL_EXECUTABLE
+        )
+
+        copy_res = hosts.all.zos_copy(src=src, dest=dest, remote_src=True)
+        stat_res = hosts.all.stat(path=dest)
+        verify_copy = hosts.all.shell(
+            cmd="head {0}".format(dest), executable=SHELL_EXECUTABLE
+        )
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest
+            assert result.get("dest_created") is True
+            assert result.get("src") is not None
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is False
+        for result in verify_copy.contacted.values():
+            assert result.get("rc") == 0
+            assert result.get("stdout") != ""
+
+    finally:
+        hosts.all.zos_data_set(name=data_set, state="absent")
+        hosts.all.file(path=dest, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.pdse
+@pytest.mark.parametrize("ds_type", ["pds", "pdse"])
+def test_copy_member_to_non_existing_uss_file_with_extension_missing_parents(ansible_zos_module, ds_type):
+    """
+    Copy a PDS member to a USS file path that includes a file extension and whose
+    parent directories do not exist, with no trailing slash in the destination path.
+
+    src:    PDS member populated with dummy data.
+    dest:   /tmp/test/newdir/<random>.txt (file extension, no trailing slash, parent dirs absent).
+    assert: Content copies into dest file, dest is created as a regular file with the given extension,
+            content is readable.
+    """
+    hosts = ansible_zos_module
+    data_set = get_tmp_ds_name()
+    src = "{0}(MEMBER)".format(data_set)
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir, suffix='.txt')
+
+    try:
+        hosts.all.zos_data_set(name=data_set, state="present", type=ds_type)
+        hosts.all.shell(
+            cmd="decho '{0}' '{1}'".format(DUMMY_DATA, src),
+            executable=SHELL_EXECUTABLE
+        )
+
+        copy_res = hosts.all.zos_copy(src=src, dest=dest, remote_src=True)
+        stat_res = hosts.all.stat(path=dest)
+        verify_copy = hosts.all.shell(
+            cmd="head {0}".format(dest), executable=SHELL_EXECUTABLE
+        )
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest
+            assert result.get("dest_created") is True
+            assert result.get("src") is not None
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is False
+        for result in verify_copy.contacted.values():
+            assert result.get("rc") == 0
+            assert result.get("stdout") != ""
+
+    finally:
+        hosts.all.zos_data_set(name=data_set, state="absent")
+        hosts.all.file(path=dest, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.pdse
 @pytest.mark.aliases
 @pytest.mark.parametrize("src_type", ["pds", "pdse"])
 def test_copy_pdse_to_uss_dir(ansible_zos_module, src_type):
@@ -5196,6 +5424,56 @@ def test_copy_member_to_uss_dir(ansible_zos_module, src_type):
             assert result.get("stdout") != ""
     finally:
         # hosts.all.zos_data_set(name=src_ds, state="absent")
+        hosts.all.file(path=dest, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.pdse
+@pytest.mark.parametrize("src_type", ["pds", "pdse"])
+def test_copy_member_to_uss_dir_missing_parents_trailing_slash(ansible_zos_module, src_type):
+    """
+    Copy a PDS member to a USS directory path whose parent directories do not exist,
+    using a trailing slash in the destination path.
+
+    src:    PDS member populated with dummy data.
+    dest:   /tmp/test/newdir/<random>/ (trailing slash, parent dirs absent).
+    assert: Copy succeeds, dest directory is created, member is present as a file inside it.
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    src = "{0}(MEMBER)".format(src_ds)
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir, suffix='/')
+    dest_file = f"{dest}MEMBER"
+
+    try:
+        hosts.all.zos_data_set(name=src_ds, type=src_type, state="present")
+        hosts.all.shell(
+            cmd="decho '{0}' '{1}'".format(DUMMY_DATA, src),
+            executable=SHELL_EXECUTABLE
+        )
+
+        copy_res = hosts.all.zos_copy(src=src, dest=dest, remote_src=True)
+        stat_res = hosts.all.stat(path=dest_file)
+        verify_copy = hosts.all.shell(
+            cmd="head {0}".format(dest_file), executable=SHELL_EXECUTABLE
+        )
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") is not None
+            assert result.get("dest_created") is True
+            assert result.get("src") is not None
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isdir") is False
+        for result in verify_copy.contacted.values():
+            assert result.get("rc") == 0
+            assert result.get("stdout") != ""
+
+    finally:
+        hosts.all.zos_data_set(name=src_ds, state="absent")
         hosts.all.file(path=dest, state="absent")
 
 

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2952,8 +2952,7 @@ def test_copy_ps_to_uss_file_missing_parent_dirs(ansible_zos_module):
             assert result.get("msg") is None
             assert result.get("changed") is True
             assert result.get("dest") == dest
-            assert result.get("dest_created") is not None
-            assert result.get("src") is not None
+            assert result.get("dest_created") is True
         for result in stat_with_parent_dirs_res.contacted.values():
             assert result.get("stat").get("exists") is True
         for result in verify_copy.contacted.values():
@@ -2980,9 +2979,7 @@ def test_copy_ps_to_uss_dir_missing_parent_dirs(ansible_zos_module):
         hosts.all.shell(cmd=f"decho '{DUMMY_DATA_SPECIAL_CHARS}' '{src_ds}' ")
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
         stat_res = hosts.all.stat(path=dest)
-        verify_copy = hosts.all.shell(
-            cmd="cat {0}".format(dest), executable=SHELL_EXECUTABLE
-        )
+        verify_copy = hosts.all.shell(cmd=f"ls {dest}", executable=SHELL_EXECUTABLE)
 
         for result in copy_res.contacted.values():
             assert result.get("msg") is None
@@ -2994,7 +2991,7 @@ def test_copy_ps_to_uss_dir_missing_parent_dirs(ansible_zos_module):
             assert result.get("stat").get("exists") is True
         for result in verify_copy.contacted.values():
             assert result.get("rc") == 0
-            assert result.get("stdout") == ""
+            assert len(result.get("stdout_lines")) == 1
     finally:
         hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
         hosts.all.zos_data_set(name=src_ds, state="absent")
@@ -3002,7 +2999,8 @@ def test_copy_ps_to_uss_dir_missing_parent_dirs(ansible_zos_module):
 
 @pytest.mark.uss
 @pytest.mark.pds
-def test_copy_pds_to_uss_dir_missing_parent_dirs(ansible_zos_module):
+@pytest.mark.parametrize("src_type", ["pds", "pdse"])
+def test_copy_pds_to_uss_dir_missing_parent_dirs(ansible_zos_module, src_type):
     """
     Copy a partitioned data set to a USS path whose parent directories do not exist.
     """
@@ -3015,7 +3013,7 @@ def test_copy_pds_to_uss_dir_missing_parent_dirs(ansible_zos_module):
     try:
         ds_creation_result = hosts.all.zos_data_set(
             name=src_ds,
-            type="pds",
+            type=src_type,
             space_primary=5,
             space_type="m",
             record_format="fba",
@@ -3074,33 +3072,36 @@ def test_copy_gds_to_uss_file_missing_parent_dirs(ansible_zos_module):
 
         # Attempt to copy GDS to a USS path with missing parent dirs
         src_gds = f"{src_ds}.G0001V00"
-
         copy_res = hosts.all.zos_copy(
             src=src_gds,
             dest=dest,
             remote_src=True
         )
+        stat_res = hosts.all.stat(path=dest)
         # Copy fails - zos_copy cannot create parent directories for GDS to USS file copy
         for result in copy_res.contacted.values():
             assert result.get("msg") is not None
             assert result.get("changed") is False
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is False
 
+        # Create parent directories and re-attempt copy
         hosts.all.shell(cmd=f"mkdir -p {parent_dir}")
         copy_with_parent_dirs_res = hosts.all.zos_copy(
             src=src_gds,
             dest=dest,
             remote_src=True
         )
-        verify_dest = hosts.all.shell(
-            cmd=f"ls {dest}", executable=SHELL_EXECUTABLE
-        )
+        verify_copy = hosts.all.shell(cmd="cat {0}".format(dest), executable=SHELL_EXECUTABLE)
+
+        # Copy succeeds
         for cp_res in copy_with_parent_dirs_res.contacted.values():
             assert cp_res.get("msg") is None
             assert cp_res.get("changed") is True
             assert cp_res.get("dest") is not None
             assert cp_res.get("dest_created") is True
             assert cp_res.get("src") is not None
-        for v_res in verify_dest.contacted.values():
+        for v_res in verify_copy.contacted.values():
             assert v_res.get("rc") == 0
             assert len(v_res.get("stdout_lines", [])) > 0
 
@@ -3112,9 +3113,48 @@ def test_copy_gds_to_uss_file_missing_parent_dirs(ansible_zos_module):
 
 @pytest.mark.uss
 @pytest.mark.gdg
+def test_copy_gds_to_uss_dir_missing_parent_dirs(ansible_zos_module):
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir, suffix='/')
+
+    try:
+        hosts.all.shell(cmd=f"dtouch -tGDG -L3 {src_ds}")
+        hosts.all.shell(cmd=f"""dtouch -tSEQ "{src_ds}(+1)" """)
+        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}.G0001V00" """)
+
+        # Attempt to copy GDS to a USS path with missing parent dirs
+        src_gds = f"{src_ds}.G0001V00"
+        copy_res = hosts.all.zos_copy(
+            src=src_gds,
+            dest=dest,
+            remote_src=True
+        )
+        verify_dest = hosts.all.shell(
+            cmd=f"ls {dest}", executable=SHELL_EXECUTABLE
+        )
+        for cp_res in copy_res.contacted.values():
+            assert cp_res.get("msg") is None
+            assert cp_res.get("changed") is True
+            assert cp_res.get("dest") is not None
+            assert cp_res.get("dest_created") is True
+            assert cp_res.get("src") is not None
+        for v_res in verify_dest.contacted.values():
+            assert v_res.get("rc") == 0
+            assert len(v_res.get("stdout_lines", [])) == 1
+
+    finally:
+        hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
+        hosts.all.shell(cmd=f"drm {src_ds}")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")   
+
+
+@pytest.mark.uss
+@pytest.mark.gdg
 def test_copy_gdg_to_uss_dir_missing_parent_dirs(ansible_zos_module):
     """
-    Copy a GDS to a USS path whose parent directories do not exist.
+    Copy a GDG to a USS path whose parent directories do not exist.
     """
     hosts = ansible_zos_module
     src_ds = get_tmp_ds_name()
@@ -5016,20 +5056,20 @@ def test_copy_member_to_existing_uss_file(ansible_zos_module, args):
 
 @pytest.mark.uss
 @pytest.mark.pdse
-@pytest.mark.parametrize("ds_type", ["pds", "pdse"])
-def test_copy_member_to_uss_file_missing_parent_dirs(ansible_zos_module, ds_type):
+@pytest.mark.parametrize("src_type", ["pds", "pdse"])
+def test_copy_member_to_uss_file_missing_parent_dirs(ansible_zos_module, src_type):
     """
     Copy a PDS/PDSE member to a USS file path whose parent directories do not exist,
     with no trailing slash in the destination path.
     """
     hosts = ansible_zos_module
-    data_set = get_tmp_ds_name()
-    src = "{0}(MEMBER)".format(data_set)
+    src_data_set = get_tmp_ds_name()
+    src = "{0}(MEMBER)".format(src_data_set)
     parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
     dest = get_random_file_name(dir=parent_dir)
 
     try:
-        hosts.all.zos_data_set(name=data_set, state="present", type=ds_type)
+        hosts.all.zos_data_set(name=src_data_set, state="present", type=src_type)
         hosts.all.shell(
             cmd="decho '{0}' '{1}'".format(DUMMY_DATA, src),
             executable=SHELL_EXECUTABLE
@@ -5069,58 +5109,53 @@ def test_copy_member_to_uss_file_missing_parent_dirs(ansible_zos_module, ds_type
             assert result.get("stdout") != ""
 
     finally:
+        hosts.all.zos_data_set(name=src_data_set, state="absent")
         hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
-        hosts.all.file(path=parent_dir, state="absent")
 
 
 @pytest.mark.uss
 @pytest.mark.pdse
-@pytest.mark.parametrize("ds_type", ["pds", "pdse"])
-def test_copy_member_to_non_existing_uss_file_with_extension_missing_parents(ansible_zos_module, ds_type):
+@pytest.mark.parametrize("src_type", ["pds", "pdse"])
+def test_copy_member_to_uss_dir_missing_parent_dirs(ansible_zos_module, src_type):
     """
-    Copy a PDS member to a USS file path that includes a file extension and whose
-    parent directories do not exist, with no trailing slash in the destination path.
-
-    src:    PDS member populated with dummy data.
-    dest:   /tmp/test/newdir/<random>.txt (file extension, no trailing slash, parent dirs absent).
-    assert: Content copies into dest file, dest is created as a regular file with the given extension,
-            content is readable.
+    Copy a PDS/PDSE member to a USS directory path whose parent directories do not exist,
+    with a trailing slash in the destination path.
     """
     hosts = ansible_zos_module
-    data_set = get_tmp_ds_name()
-    src = "{0}(MEMBER)".format(data_set)
+    src_data_set = get_tmp_ds_name()
+    src = "{0}(MEMBER)".format(src_data_set)
     parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
-    dest = get_random_file_name(dir=parent_dir, suffix='.txt')
+    dest = get_random_file_name(dir=parent_dir, suffix='/')
 
     try:
-        hosts.all.zos_data_set(name=data_set, state="present", type=ds_type)
+        hosts.all.zos_data_set(name=src_data_set, state="present", type=src_type)
         hosts.all.shell(
             cmd="decho '{0}' '{1}'".format(DUMMY_DATA, src),
             executable=SHELL_EXECUTABLE
         )
 
+        # Attempt to copy member to a USS dir with missing parent dirs
         copy_res = hosts.all.zos_copy(src=src, dest=dest, remote_src=True)
         stat_res = hosts.all.stat(path=dest)
-        verify_copy = hosts.all.shell(
-            cmd="head {0}".format(dest), executable=SHELL_EXECUTABLE
-        )
+        verify_copy = hosts.all.shell(cmd="cat {0}/MEMBER".format(dest), executable=SHELL_EXECUTABLE)
 
+        member_file = os.path.join(dest, "MEMBER")
         for result in copy_res.contacted.values():
             assert result.get("msg") is None
             assert result.get("changed") is True
-            assert result.get("dest") == dest
+            assert result.get("dest") == member_file
             assert result.get("dest_created") is True
             assert result.get("src") is not None
         for result in stat_res.contacted.values():
             assert result.get("stat").get("exists") is True
-            assert result.get("stat").get("isdir") is False
+            assert result.get("stat").get("isdir") is True
         for result in verify_copy.contacted.values():
             assert result.get("rc") == 0
             assert result.get("stdout") != ""
 
     finally:
-        hosts.all.zos_data_set(name=data_set, state="absent")
-        hosts.all.file(path=dest, state="absent")
+        hosts.all.zos_data_set(name=src_data_set, state="absent")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
 
 
 @pytest.mark.uss
@@ -5217,56 +5252,6 @@ def test_copy_member_to_uss_dir(ansible_zos_module, src_type):
             assert result.get("stdout") != ""
     finally:
         # hosts.all.zos_data_set(name=src_ds, state="absent")
-        hosts.all.file(path=dest, state="absent")
-
-
-@pytest.mark.uss
-@pytest.mark.pdse
-@pytest.mark.parametrize("src_type", ["pds", "pdse"])
-def test_copy_member_to_uss_dir_missing_parents_trailing_slash(ansible_zos_module, src_type):
-    """
-    Copy a PDS member to a USS directory path whose parent directories do not exist,
-    using a trailing slash in the destination path.
-
-    src:    PDS member populated with dummy data.
-    dest:   /tmp/test/newdir/<random>/ (trailing slash, parent dirs absent).
-    assert: Copy succeeds, dest directory is created, member is present as a file inside it.
-    """
-    hosts = ansible_zos_module
-    src_ds = get_tmp_ds_name()
-    src = "{0}(MEMBER)".format(src_ds)
-    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
-    dest = get_random_file_name(dir=parent_dir, suffix='/')
-    dest_file = f"{dest}MEMBER"
-
-    try:
-        hosts.all.zos_data_set(name=src_ds, type=src_type, state="present")
-        hosts.all.shell(
-            cmd="decho '{0}' '{1}'".format(DUMMY_DATA, src),
-            executable=SHELL_EXECUTABLE
-        )
-
-        copy_res = hosts.all.zos_copy(src=src, dest=dest, remote_src=True)
-        stat_res = hosts.all.stat(path=dest_file)
-        verify_copy = hosts.all.shell(
-            cmd="head {0}".format(dest_file), executable=SHELL_EXECUTABLE
-        )
-
-        for result in copy_res.contacted.values():
-            assert result.get("msg") is None
-            assert result.get("changed") is True
-            assert result.get("dest") is not None
-            assert result.get("dest_created") is True
-            assert result.get("src") is not None
-        for result in stat_res.contacted.values():
-            assert result.get("stat").get("exists") is True
-            assert result.get("stat").get("isdir") is False
-        for result in verify_copy.contacted.values():
-            assert result.get("rc") == 0
-            assert result.get("stdout") != ""
-
-    finally:
-        hosts.all.zos_data_set(name=src_ds, state="absent")
         hosts.all.file(path=dest, state="absent")
 
 

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2917,14 +2917,9 @@ def test_copy_ps_to_non_existing_uss_file(ansible_zos_module):
 
 @pytest.mark.uss
 @pytest.mark.seq
-def test_copy_ps_to_non_existing_uss_file_missing_parents(ansible_zos_module):
+def test_copy_ps_to_uss_file_missing_parent_dirs(ansible_zos_module):
     """
     Copy a sequential data set to a USS path whose parent directories do not exist.
-
-    src:    Sequential data set populated with special-character content.
-    dest:   /tmp/test/newdir/<random> (parent dirs absent).
-    assert: Copy fails; zos_copy must not create parent directories when copying
-            from a PS source to a non-existent USS file.
     """
     hosts = ansible_zos_module
     src_ds = get_tmp_ds_name()
@@ -2932,29 +2927,49 @@ def test_copy_ps_to_non_existing_uss_file_missing_parents(ansible_zos_module):
     dest = get_random_file_name(dir=parent_dir)
 
     try:
+        # Attempt to copy sequential data set to a USS path with missing parent dirs
         hosts.all.shell(cmd=f"decho '{DUMMY_DATA_SPECIAL_CHARS}' '{src_ds}' ")
         copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
         stat_res = hosts.all.stat(path=dest)
 
+        # Copy fails - zos_copy cannot create parent directories for PS to USS file copy
         for result in copy_res.contacted.values():
             assert result.get("msg") is not None
             assert result.get("changed") is False
         for result in stat_res.contacted.values():
             assert result.get("stat").get("exists") is False
+
+        # Create parent dirs and re-attempt copy
+        hosts.all.shell(cmd=f"mkdir -p {parent_dir}")
+        copy_with_parent_dirs_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
+        stat_with_parent_dirs_res = hosts.all.stat(path=dest)
+        verify_copy = hosts.all.shell(
+            cmd="cat {0}".format(dest), executable=SHELL_EXECUTABLE
+        )
+
+        # Copy succeeds - zos_copy can create missing destination for PS to USS file copy
+        for result in copy_with_parent_dirs_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest
+            assert result.get("dest_created") is not None
+            assert result.get("src") is not None
+        for result in stat_with_parent_dirs_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+        for result in verify_copy.contacted.values():
+            assert result.get("rc") == 0
+            assert result.get("stdout") != ""
+
     finally:
-        hosts.all.file(path=parent_dir, state="absent")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
         hosts.all.zos_data_set(name=src_ds, state="absent")
 
 
 @pytest.mark.uss
 @pytest.mark.seq
-def test_copy_ps_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
+def test_copy_ps_to_uss_dir_missing_parent_dirs(ansible_zos_module):
     """
     Copy a sequential data set to a USS path whose parent directories do not exist.
-
-    src:    Sequential data set populated with special-character content.
-    dest:   /tmp/test/newdir/<random>/ (parent dirs absent).
-    assert: Copy succeeds, dest file is created, content is readable via cat.
     """
     hosts = ansible_zos_module
     src_ds = get_tmp_ds_name()
@@ -2981,20 +2996,15 @@ def test_copy_ps_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
             assert result.get("rc") == 0
             assert result.get("stdout") == ""
     finally:
-        hosts.all.file(path=dest, state="absent")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
         hosts.all.zos_data_set(name=src_ds, state="absent")
-
 
 
 @pytest.mark.uss
 @pytest.mark.pds
-def test_copy_pds_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
+def test_copy_pds_to_uss_dir_missing_parent_dirs(ansible_zos_module):
     """
     Copy a partitioned data set to a USS path whose parent directories do not exist.
-
-    src:    Partitioned data set with member.
-    dest:   /tmp/test/newdir/<random> (parent dirs absent).
-    assert: Copy succeeds, dest directory is created, all members are present as files.
     """
     hosts = ansible_zos_module
     src_ds = get_tmp_ds_name()
@@ -3045,280 +3055,13 @@ def test_copy_pds_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
             assert len(files) == 1, f"Expected 1 member, found: {files}"
 
     finally:
-        hosts.all.file(path=dest, state="absent")
-        hosts.all.zos_data_set(name=src_ds, state="absent")
-
-
-@pytest.mark.uss
-@pytest.mark.pds
-def test_copy_pds_to_non_existing_uss_dir_missing_parents_trailing_slash(ansible_zos_module):
-    """
-    Copy a partitioned data set to a USS path whose parent directories do not exist,
-    using a trailing slash in the destination path.
-
-    src:    Partitioned data set with member.
-    dest:   /tmp/test/newdir/<random>/ (trailing slash, parent dirs absent).
-    assert: Copy succeeds, dest directory is created, all members are present as files.
-    """
-    hosts = ansible_zos_module
-    src_ds = get_tmp_ds_name()
-    src_ds_mem = f"{src_ds}(MEM1)"
-    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
-    dest = get_random_file_name(dir=parent_dir, suffix='/')
-
-    try:
-        ds_creation_result = hosts.all.zos_data_set(
-            name=src_ds,
-            type="pds",
-            space_primary=5,
-            space_type="m",
-            record_format="fba",
-            record_length=80,
-            replace=True,
-            state="present"
-        )
-        for result in ds_creation_result.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("failed", False) is False
-
-        member_creation_result = hosts.all.zos_data_set(
-            name=src_ds_mem,
-            state="present",
-            type="member",
-            replace=True
-        )
-        for result in member_creation_result.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("failed", False) is False
-
-        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
-        stat_res = hosts.all.stat(path=dest)
-        verify_dest = hosts.all.shell(cmd=f"ls {dest}{src_ds}")
-
-        for result in copy_res.contacted.values():
-            assert result.get("msg") is None
-            assert result.get("changed") is True
-            assert result.get("dest") is not None
-            assert result.get("dest_created") is True
-            assert result.get("src") is not None
-        for result in stat_res.contacted.values():
-            assert result.get("stat").get("exists") is True
-        for v_res in verify_dest.contacted.values():
-            assert v_res.get("rc") == 0
-            files = v_res.get("stdout_lines", [])
-            assert len(files) == 1, f"Expected 1 member, found: {files}"
-
-    finally:
-        hosts.all.file(path=dest, state="absent")
-        hosts.all.zos_data_set(name=src_ds, state="absent")
-
-
-@pytest.mark.uss
-@pytest.mark.pds
-@pytest.mark.parametrize("src_type", ["pds", "pdse"])
-def test_copy_pds_to_existing_uss_dir(ansible_zos_module, src_type):
-    """
-    Copy a PDS to a USS directory that already exists.
-
-    src:    PDS with members populated with dummy data.
-    dest:   /tmp/<random> (existing USS directory).
-    assert: Copy succeeds, a subdirectory named after the data set is present inside
-            dest, and all members are present as files within it.
-    """
-    hosts = ansible_zos_module
-    src_ds = get_tmp_ds_name()
-    dest = get_random_file_name(dir=TMP_DIRECTORY)
-    dest_path = "{0}/{1}".format(dest, src_ds)
-
-    try:
-        ds_creation_result = hosts.all.zos_data_set(
-            name=src_ds,
-            type=src_type,
-            space_primary=5,
-            space_type="m",
-            record_format="fba",
-            record_length=80,
-            replace=True,
-            state="present"
-        )
-        for result in ds_creation_result.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("failed", False) is False
-
-        members = ["MEM1", "MEM2"]
-        for member in members:
-            hosts.all.shell(
-                cmd="decho '{0}' '{1}({2})'".format(DUMMY_DATA, src_ds, member),
-                executable=SHELL_EXECUTABLE
-            )
-
-        hosts.all.file(path=dest, state="directory")
-
-        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
-        stat_res = hosts.all.stat(path=dest_path)
-        verify_dest = hosts.all.shell(
-            cmd="ls {0}".format(dest_path), executable=SHELL_EXECUTABLE
-        )
-
-        for result in copy_res.contacted.values():
-            assert result.get("msg") is None
-            assert result.get("changed") is True
-            assert result.get("dest") == dest
-            assert result.get("src") is not None
-        for result in stat_res.contacted.values():
-            assert result.get("stat").get("exists") is True
-            assert result.get("stat").get("isdir") is True
-        for v_res in verify_dest.contacted.values():
-            assert v_res.get("rc") == 0
-            files = v_res.get("stdout_lines", [])
-            assert len(files) == len(members), f"Expected {len(members)} members, found: {files}"
-
-    finally:
-        hosts.all.file(path=dest, state="absent")
-        hosts.all.zos_data_set(name=src_ds, state="absent")
-
-
-@pytest.mark.uss
-@pytest.mark.pds
-def test_copy_pdse_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
-    """
-    Copy a PDSE to a USS path whose parent directories do not exist.
-
-    src:    Partitioned data set with member.
-    dest:   /tmp/test/newdir/<random> (parent dirs absent).
-    assert: Copy succeeds, dest directory is created, all members are present as files.
-    """
-    hosts = ansible_zos_module
-    src_ds = get_tmp_ds_name()
-    src_ds_mem = f"{src_ds}(MEM1)"
-    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
-    dest = get_random_file_name(dir=parent_dir)
-
-    try:
-        ds_creation_result = hosts.all.zos_data_set(
-            name=src_ds,
-            type="pdse",
-            space_primary=5,
-            space_type="m",
-            record_format="fba",
-            record_length=80,
-            replace=True,
-            state="present"
-        )
-        for result in ds_creation_result.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("failed", False) is False
-
-        member_creation_result = hosts.all.zos_data_set(
-            name=src_ds_mem,
-            state="present",
-            type="member",
-            replace=True
-        )
-        for result in member_creation_result.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("failed", False) is False
-
-        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
-        stat_res = hosts.all.stat(path=dest)
-        verify_dest = hosts.all.shell(cmd=f"ls {dest}/{src_ds}")
-
-        for result in copy_res.contacted.values():
-            assert result.get("msg") is None
-            assert result.get("changed") is True
-            assert result.get("dest") == dest
-            assert result.get("dest_created") is True
-            assert result.get("src") is not None
-        for result in stat_res.contacted.values():
-            assert result.get("stat").get("exists") is True
-        for v_res in verify_dest.contacted.values():
-            assert v_res.get("rc") == 0
-            files = v_res.get("stdout_lines", [])
-            assert len(files) == 1, f"Expected 1 member, found: {files}"
-
-    finally:
-        hosts.all.file(path=dest, state="absent")
-        hosts.all.zos_data_set(name=src_ds, state="absent")
-
-
-@pytest.mark.uss
-@pytest.mark.pds
-def test_copy_pds_to_existing_uss_file_fails(ansible_zos_module):
-    """
-    Copy a partitioned data set to a USS file.
-
-    src:    Partitioned data set with member.
-    dest:   /tmp//<random> (USS file).
-    assert: Copy fails (failed=True), error message is present, dest unchanged
-    """
-    hosts = ansible_zos_module
-    src_ds = get_tmp_ds_name()
-    src_ds_mem = f"{src_ds}(MEM1)"
-    dest = get_random_file_name(dir=TMP_DIRECTORY)
-
-    try:
-        # Create USS file
-        uss_file_creation_result = hosts.all.zos_copy(
-            content="| Test",
-            dest=dest,
-            encoding={
-                "from": "UTF-8",
-                "to": "IBM-1047"
-            }
-        )
-        for result in uss_file_creation_result.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("failed", False) is False
-
-        # Create PDS
-        ds_creation_result = hosts.all.zos_data_set(
-            name=src_ds,
-            type="pds",
-            space_primary=5,
-            space_type="m",
-            record_format="fba",
-            record_length=80,
-            replace=True,
-            state="present"
-        )
-        for result in ds_creation_result.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("failed", False) is False
-
-        member_creation_result = hosts.all.zos_data_set(
-            name=src_ds_mem,
-            state="present",
-            type="member",
-            replace=True
-        )
-        for result in member_creation_result.contacted.values():
-            assert_msg = result.get("stdout", "")
-            print(result)
-            assert result.get("changed") is True
-            assert result.get("failed", False) is False
-
-        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
-        for result in copy_res.contacted.values():
-            error_msg = "Cannot write a partitioned data set (PDS) to a USS file."
-            assert result.get("failed") is True
-            assert result.get("changed") is False
-            assert error_msg in result.get("msg")
-
-    finally:
-        hosts.all.file(path=dest, state="absent")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
         hosts.all.zos_data_set(name=src_ds, state="absent")
 
 
 @pytest.mark.uss
 @pytest.mark.gdg
-def test_copy_gds_to_non_existing_uss_file_missing_parents(ansible_zos_module):
-    """
-    Copy a GDS to a USS path whose parent directories do not exist.
-
-    src:    GDS
-    dest:   /tmp/test/newdir/<random> (parent dirs absent)
-    assert: Copy succeeds, dest is a regular file (not directory), content is readable
-    """
+def test_copy_gds_to_uss_file_missing_parent_dirs(ansible_zos_module):
     hosts = ansible_zos_module
     src_ds = get_tmp_ds_name()
     parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
@@ -3327,10 +3070,23 @@ def test_copy_gds_to_non_existing_uss_file_missing_parents(ansible_zos_module):
     try:
         hosts.all.shell(cmd=f"dtouch -tGDG -L3 {src_ds}")
         hosts.all.shell(cmd=f"""dtouch -tSEQ "{src_ds}(+1)" """)
-        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}(0)" """)
+        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}.G0001V00" """)
 
-        src_gds = f"{src_ds}(0)"
-        copy_results = hosts.all.zos_copy(
+        # Attempt to copy GDS to a USS path with missing parent dirs
+        src_gds = f"{src_ds}.G0001V00"
+
+        copy_res = hosts.all.zos_copy(
+            src=src_gds,
+            dest=dest,
+            remote_src=True
+        )
+        # Copy fails - zos_copy cannot create parent directories for GDS to USS file copy
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is not None
+            assert result.get("changed") is False
+
+        hosts.all.shell(cmd=f"mkdir -p {parent_dir}")
+        copy_with_parent_dirs_res = hosts.all.zos_copy(
             src=src_gds,
             dest=dest,
             remote_src=True
@@ -3338,7 +3094,7 @@ def test_copy_gds_to_non_existing_uss_file_missing_parents(ansible_zos_module):
         verify_dest = hosts.all.shell(
             cmd=f"ls {dest}", executable=SHELL_EXECUTABLE
         )
-        for cp_res in copy_results.contacted.values():
+        for cp_res in copy_with_parent_dirs_res.contacted.values():
             assert cp_res.get("msg") is None
             assert cp_res.get("changed") is True
             assert cp_res.get("dest") is not None
@@ -3351,18 +3107,14 @@ def test_copy_gds_to_non_existing_uss_file_missing_parents(ansible_zos_module):
     finally:
         hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
         hosts.all.shell(cmd=f"drm {src_ds}")
-        hosts.all.file(path=dest, state="absent")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
 
 
 @pytest.mark.uss
 @pytest.mark.gdg
-def test_copy_gdg_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
+def test_copy_gdg_to_uss_dir_missing_parent_dirs(ansible_zos_module):
     """
     Copy a GDS to a USS path whose parent directories do not exist.
-
-    src:    GDG
-    dest:   /tmp/test/newdir/<random> (parent dirs absent)
-    assert: Copy succeeds, dest is a directory, generations are inside
     """
     hosts = ansible_zos_module
     src_ds = get_tmp_ds_name()
@@ -3393,12 +3145,11 @@ def test_copy_gdg_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
             assert v_res.get("rc") == 0
             files = v_res.get("stdout_lines", [])
             assert len(files) == 1, f"Expected 1 generation file, found: {files}"
-            assert re.search(r"\.G\d+V\d+$", files[0])
 
     finally:
         hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
         hosts.all.shell(cmd=f"drm {src_ds}")
-        hosts.all.file(path=dest, state="absent")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
 
 
 @pytest.mark.uss
@@ -5266,14 +5017,10 @@ def test_copy_member_to_existing_uss_file(ansible_zos_module, args):
 @pytest.mark.uss
 @pytest.mark.pdse
 @pytest.mark.parametrize("ds_type", ["pds", "pdse"])
-def test_copy_member_to_non_existing_uss_file_missing_parents(ansible_zos_module, ds_type):
+def test_copy_member_to_uss_file_missing_parent_dirs(ansible_zos_module, ds_type):
     """
     Copy a PDS/PDSE member to a USS file path whose parent directories do not exist,
     with no trailing slash in the destination path.
-
-    src:    PDS or PDSE member populated with dummy data.
-    dest:   /tmp/test/newdir/<random> (no trailing slash, parent dirs absent).
-    assert: Copy succeeds, dest is created as a regular file, content is readable.
     """
     hosts = ansible_zos_module
     data_set = get_tmp_ds_name()
@@ -5288,19 +5035,33 @@ def test_copy_member_to_non_existing_uss_file_missing_parents(ansible_zos_module
             executable=SHELL_EXECUTABLE
         )
 
+        # Attempt to copy member to a USS file with missing parent dirs
         copy_res = hosts.all.zos_copy(src=src, dest=dest, remote_src=True)
         stat_res = hosts.all.stat(path=dest)
+
+        # Copy fails - zos_copy cannot create parent directories for member to USS file copy
+        for result in copy_res.contacted.values():
+            assert result.get("failed") is True
+            assert result.get("msg") is not None
+            assert result.get("changed") is False
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is False
+
+        # Create parent dirs and re-attempt copy
+        hosts.all.shell(cmd=f"mkdir -p {parent_dir}")
+        copy_with_parent_dirs_res = hosts.all.zos_copy(src=src, dest=dest, remote_src=True)
+        stat_with_parent_dirs_res = hosts.all.stat(path=dest)
         verify_copy = hosts.all.shell(
-            cmd="head {0}".format(dest), executable=SHELL_EXECUTABLE
+            cmd="cat {0}".format(dest), executable=SHELL_EXECUTABLE
         )
 
-        for result in copy_res.contacted.values():
+        for result in copy_with_parent_dirs_res.contacted.values():
             assert result.get("msg") is None
             assert result.get("changed") is True
             assert result.get("dest") == dest
             assert result.get("dest_created") is True
             assert result.get("src") is not None
-        for result in stat_res.contacted.values():
+        for result in stat_with_parent_dirs_res.contacted.values():
             assert result.get("stat").get("exists") is True
             assert result.get("stat").get("isdir") is False
         for result in verify_copy.contacted.values():
@@ -5308,8 +5069,8 @@ def test_copy_member_to_non_existing_uss_file_missing_parents(ansible_zos_module
             assert result.get("stdout") != ""
 
     finally:
-        hosts.all.zos_data_set(name=data_set, state="absent")
-        hosts.all.file(path=dest, state="absent")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
+        hosts.all.file(path=parent_dir, state="absent")
 
 
 @pytest.mark.uss

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -5002,19 +5002,23 @@ def test_copy_member_to_uss_dir_missing_parent_dirs(ansible_zos_module, src_type
 
         # Attempt to copy member to a USS dir with missing parent dirs
         copy_res = hosts.all.zos_copy(src=src, dest=dest, remote_src=True)
-        stat_res = hosts.all.stat(path=dest)
-        verify_copy = hosts.all.shell(cmd="cat {0}/MEMBER".format(dest), executable=SHELL_EXECUTABLE)
-
         member_file = os.path.join(dest, "MEMBER")
+        stat_dest = hosts.all.stat(path=dest)
+        stat_member = hosts.all.stat(path=member_file)
+        verify_copy = hosts.all.shell(cmd="cat {0}".format(member_file), executable=SHELL_EXECUTABLE)
+
         for result in copy_res.contacted.values():
             assert result.get("msg") is None
             assert result.get("changed") is True
-            assert result.get("dest") == member_file
+            assert result.get("dest") == dest
             assert result.get("dest_created") is True
             assert result.get("src") is not None
-        for result in stat_res.contacted.values():
+        for result in stat_dest.contacted.values():
             assert result.get("stat").get("exists") is True
             assert result.get("stat").get("isdir") is True
+        for result in stat_member.contacted.values():
+            assert result.get("stat").get("exists") is True
+            assert result.get("stat").get("isreg") is True
         for result in verify_copy.contacted.values():
             assert result.get("rc") == 0
             assert result.get("stdout") != ""

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -3009,7 +3009,71 @@ def test_copy_pds_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
             assert result.get("stat").get("exists") is True
         for v_res in verify_dest.contacted.values():
             assert v_res.get("rc") == 0
-            assert len(v_res.get("stdout_lines", [])) > 0
+            files = v_res.get("stdout_lines", [])
+            assert len(files) == 1, f"Expected 1 member, found: {files}"
+
+    finally:
+        hosts.all.file(path=dest, state="absent")
+        hosts.all.zos_data_set(name=src_ds, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.pds
+def test_copy_pdse_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
+    """
+    Copy a PDSE to a USS path whose parent directories do not exist.
+
+    src:    Partitioned data set with member.
+    dest:   /tmp/test/newdir/<random> (parent dirs absent).
+    assert: Copy succeeds, dest directory is created, all members are present as files.
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    src_ds_mem = f"{src_ds}(MEM1)"
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir)
+
+    try:
+        ds_creation_result = hosts.all.zos_data_set(
+            name=src_ds,
+            type="pdse",
+            space_primary=5,
+            space_type="m",
+            record_format="fba",
+            record_length=80,
+            replace=True,
+            state="present"
+        )
+        for result in ds_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        member_creation_result = hosts.all.zos_data_set(
+            name=src_ds_mem,
+            state="present",
+            type="member",
+            replace=True
+        )
+        for result in member_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
+        stat_res = hosts.all.stat(path=dest)
+        verify_dest = hosts.all.shell(cmd=f"ls {dest}/{src_ds}")
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest
+            assert result.get("dest_created") is True
+            assert result.get("src") is not None
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+        for v_res in verify_dest.contacted.values():
+            assert v_res.get("rc") == 0
+            files = v_res.get("stdout_lines", [])
+            assert len(files) == 1, f"Expected 1 member, found: {files}"
 
     finally:
         hosts.all.file(path=dest, state="absent")

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -4772,7 +4772,7 @@ def test_copy_multiple_data_set_members_in_loop(ansible_zos_module):
 
 
 @pytest.mark.uss
-@pytest.mark.pds
+@pytest.mark.pdse
 @pytest.mark.parametrize("src_type", ["pds", "pdse"])
 def test_copy_pds_to_uss_dir_missing_parent_dirs(ansible_zos_module, src_type):
     """
@@ -7093,7 +7093,7 @@ def test_copy_file_to_seq_data_set_max_name_length(ansible_zos_module):
 
 
 # This test is added to validate the fix for the GitHub issue #2510
-@pytest.mark.pds
+@pytest.mark.pdse
 def test_copy_file_to_pds_member_with_lrecl_mismatch_cleanup(ansible_zos_module):
     """
     Test remote cleanup functionality when copy fails due to LRECL mismatch.
@@ -7646,8 +7646,7 @@ def test_copy_file_to_new_gds_with_lrecl_mismatch_cleanup(ansible_zos_module):
         hosts.all.zos_data_set(name=gdg_base, state="absent")
 
 
-
-@pytest.mark.pds
+@pytest.mark.pdse
 def test_copy_pds_members_bulk_with_partial_failure_cleanup(ansible_zos_module):
     """
     Test remote cleanup functionality for bulk PDS member copy with partial failures.

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2998,201 +2998,6 @@ def test_copy_ps_to_uss_dir_missing_parent_dirs(ansible_zos_module):
 
 
 @pytest.mark.uss
-@pytest.mark.pds
-@pytest.mark.parametrize("src_type", ["pds", "pdse"])
-def test_copy_pds_to_uss_dir_missing_parent_dirs(ansible_zos_module, src_type):
-    """
-    Copy a partitioned data set to a USS path whose parent directories do not exist.
-    """
-    hosts = ansible_zos_module
-    src_ds = get_tmp_ds_name()
-    src_ds_mem = f"{src_ds}(MEM1)"
-    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
-    dest = get_random_file_name(dir=parent_dir)
-
-    try:
-        ds_creation_result = hosts.all.zos_data_set(
-            name=src_ds,
-            type=src_type,
-            space_primary=5,
-            space_type="m",
-            record_format="fba",
-            record_length=80,
-            replace=True,
-            state="present"
-        )
-        for result in ds_creation_result.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("failed", False) is False
-
-        member_creation_result = hosts.all.zos_data_set(
-            name=src_ds_mem,
-            state="present",
-            type="member",
-            replace=True
-        )
-        for result in member_creation_result.contacted.values():
-            assert result.get("changed") is True
-            assert result.get("failed", False) is False
-
-        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
-        stat_res = hosts.all.stat(path=dest)
-        verify_dest = hosts.all.shell(cmd=f"ls {dest}/{src_ds}")
-
-        for result in copy_res.contacted.values():
-            assert result.get("msg") is None
-            assert result.get("changed") is True
-            assert result.get("dest") == dest
-            assert result.get("dest_created") is True
-            assert result.get("src") is not None
-        for result in stat_res.contacted.values():
-            assert result.get("stat").get("exists") is True
-        for v_res in verify_dest.contacted.values():
-            assert v_res.get("rc") == 0
-            files = v_res.get("stdout_lines", [])
-            assert len(files) == 1, f"Expected 1 member, found: {files}"
-
-    finally:
-        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
-        hosts.all.zos_data_set(name=src_ds, state="absent")
-
-
-@pytest.mark.uss
-@pytest.mark.gdg
-def test_copy_gds_to_uss_file_missing_parent_dirs(ansible_zos_module):
-    hosts = ansible_zos_module
-    src_ds = get_tmp_ds_name()
-    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
-    dest = get_random_file_name(dir=parent_dir)
-
-    try:
-        hosts.all.shell(cmd=f"dtouch -tGDG -L3 {src_ds}")
-        hosts.all.shell(cmd=f"""dtouch -tSEQ "{src_ds}(+1)" """)
-        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}.G0001V00" """)
-
-        # Attempt to copy GDS to a USS path with missing parent dirs
-        src_gds = f"{src_ds}.G0001V00"
-        copy_res = hosts.all.zos_copy(
-            src=src_gds,
-            dest=dest,
-            remote_src=True
-        )
-        stat_res = hosts.all.stat(path=dest)
-        # Copy fails - zos_copy cannot create parent directories for GDS to USS file copy
-        for result in copy_res.contacted.values():
-            assert result.get("msg") is not None
-            assert result.get("changed") is False
-        for result in stat_res.contacted.values():
-            assert result.get("stat").get("exists") is False
-
-        # Create parent directories and re-attempt copy
-        hosts.all.shell(cmd=f"mkdir -p {parent_dir}")
-        copy_with_parent_dirs_res = hosts.all.zos_copy(
-            src=src_gds,
-            dest=dest,
-            remote_src=True
-        )
-        verify_copy = hosts.all.shell(cmd="cat {0}".format(dest), executable=SHELL_EXECUTABLE)
-
-        # Copy succeeds
-        for cp_res in copy_with_parent_dirs_res.contacted.values():
-            assert cp_res.get("msg") is None
-            assert cp_res.get("changed") is True
-            assert cp_res.get("dest") is not None
-            assert cp_res.get("dest_created") is True
-            assert cp_res.get("src") is not None
-        for v_res in verify_copy.contacted.values():
-            assert v_res.get("rc") == 0
-            assert len(v_res.get("stdout_lines", [])) > 0
-
-    finally:
-        hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
-        hosts.all.shell(cmd=f"drm {src_ds}")
-        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
-
-
-@pytest.mark.uss
-@pytest.mark.gdg
-def test_copy_gds_to_uss_dir_missing_parent_dirs(ansible_zos_module):
-    hosts = ansible_zos_module
-    src_ds = get_tmp_ds_name()
-    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
-    dest = get_random_file_name(dir=parent_dir, suffix='/')
-
-    try:
-        hosts.all.shell(cmd=f"dtouch -tGDG -L3 {src_ds}")
-        hosts.all.shell(cmd=f"""dtouch -tSEQ "{src_ds}(+1)" """)
-        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}.G0001V00" """)
-
-        # Attempt to copy GDS to a USS path with missing parent dirs
-        src_gds = f"{src_ds}.G0001V00"
-        copy_res = hosts.all.zos_copy(
-            src=src_gds,
-            dest=dest,
-            remote_src=True
-        )
-        verify_dest = hosts.all.shell(
-            cmd=f"ls {dest}", executable=SHELL_EXECUTABLE
-        )
-        for cp_res in copy_res.contacted.values():
-            assert cp_res.get("msg") is None
-            assert cp_res.get("changed") is True
-            assert cp_res.get("dest") is not None
-            assert cp_res.get("dest_created") is True
-            assert cp_res.get("src") is not None
-        for v_res in verify_dest.contacted.values():
-            assert v_res.get("rc") == 0
-            assert len(v_res.get("stdout_lines", [])) == 1
-
-    finally:
-        hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
-        hosts.all.shell(cmd=f"drm {src_ds}")
-        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")   
-
-
-@pytest.mark.uss
-@pytest.mark.gdg
-def test_copy_gdg_to_uss_dir_missing_parent_dirs(ansible_zos_module):
-    """
-    Copy a GDG to a USS path whose parent directories do not exist.
-    """
-    hosts = ansible_zos_module
-    src_ds = get_tmp_ds_name()
-    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
-    dest = get_random_file_name(dir=parent_dir)
-
-    try:
-        hosts.all.shell(cmd=f"dtouch -tGDG -L3 {src_ds}")
-        hosts.all.shell(cmd=f"""dtouch -tSEQ "{src_ds}(+1)" """)
-        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}(0)" """)
-
-        copy_results = hosts.all.zos_copy(
-            src=src_ds,
-            dest=dest,
-            remote_src=True
-        )
-        verify_dest = hosts.all.shell(
-            cmd=f"ls {dest}", executable=SHELL_EXECUTABLE
-        )
-
-        for cp_res in copy_results.contacted.values():
-            assert cp_res.get("msg") is None
-            assert cp_res.get("changed") is True
-            assert cp_res.get("dest") is not None
-            assert cp_res.get("dest_created") is True
-            assert cp_res.get("src") is not None
-        for v_res in verify_dest.contacted.values():
-            assert v_res.get("rc") == 0
-            files = v_res.get("stdout_lines", [])
-            assert len(files) == 1, f"Expected 1 generation file, found: {files}"
-
-    finally:
-        hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
-        hosts.all.shell(cmd=f"drm {src_ds}")
-        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
-
-
-@pytest.mark.uss
 @pytest.mark.seq
 @pytest.mark.parametrize("replace", [False, True])
 def test_copy_ps_to_existing_uss_file(ansible_zos_module, replace):
@@ -4967,6 +4772,67 @@ def test_copy_multiple_data_set_members_in_loop(ansible_zos_module):
 
 
 @pytest.mark.uss
+@pytest.mark.pds
+@pytest.mark.parametrize("src_type", ["pds", "pdse"])
+def test_copy_pds_to_uss_dir_missing_parent_dirs(ansible_zos_module, src_type):
+    """
+    Copy a partitioned data set to a USS path whose parent directories do not exist.
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    src_ds_mem = f"{src_ds}(MEM1)"
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir)
+
+    try:
+        ds_creation_result = hosts.all.zos_data_set(
+            name=src_ds,
+            type=src_type,
+            space_primary=5,
+            space_type="m",
+            record_format="fba",
+            record_length=80,
+            replace=True,
+            state="present"
+        )
+        for result in ds_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        member_creation_result = hosts.all.zos_data_set(
+            name=src_ds_mem,
+            state="present",
+            type="member",
+            replace=True
+        )
+        for result in member_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
+        stat_res = hosts.all.stat(path=dest)
+        verify_dest = hosts.all.shell(cmd=f"ls {dest}/{src_ds}")
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest
+            assert result.get("dest_created") is True
+            assert result.get("src") is not None
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+        for v_res in verify_dest.contacted.values():
+            assert v_res.get("rc") == 0
+            files = v_res.get("stdout_lines", [])
+            assert len(files) == 1, f"Expected 1 member, found: {files}"
+
+    finally:
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
+        hosts.all.zos_data_set(name=src_ds, state="absent")
+
+
+
+@pytest.mark.uss
 @pytest.mark.pdse
 @pytest.mark.parametrize("ds_type", ["pds", "pdse"])
 def test_copy_member_to_non_existing_uss_file(ansible_zos_module, ds_type):
@@ -6278,6 +6144,141 @@ def test_copy_gdg_to_uss_dir(ansible_zos_module):
         hosts.all.shell(cmd=f"""drm "{src_data_set}(0)" """)
         hosts.all.shell(cmd=f"drm {src_data_set}")
         hosts.all.file(path=dest, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.gdg
+def test_copy_gds_to_uss_file_missing_parent_dirs(ansible_zos_module):
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir)
+
+    try:
+        hosts.all.shell(cmd=f"dtouch -tGDG -L3 {src_ds}")
+        hosts.all.shell(cmd=f"""dtouch -tSEQ "{src_ds}(+1)" """)
+        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}.G0001V00" """)
+
+        # Attempt to copy GDS to a USS path with missing parent dirs
+        src_gds = f"{src_ds}.G0001V00"
+        copy_res = hosts.all.zos_copy(
+            src=src_gds,
+            dest=dest,
+            remote_src=True
+        )
+        stat_res = hosts.all.stat(path=dest)
+        # Copy fails - zos_copy cannot create parent directories for GDS to USS file copy
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is not None
+            assert result.get("changed") is False
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is False
+
+        # Create parent directories and re-attempt copy
+        hosts.all.shell(cmd=f"mkdir -p {parent_dir}")
+        copy_with_parent_dirs_res = hosts.all.zos_copy(
+            src=src_gds,
+            dest=dest,
+            remote_src=True
+        )
+        verify_copy = hosts.all.shell(cmd="cat {0}".format(dest), executable=SHELL_EXECUTABLE)
+
+        # Copy succeeds
+        for cp_res in copy_with_parent_dirs_res.contacted.values():
+            assert cp_res.get("msg") is None
+            assert cp_res.get("changed") is True
+            assert cp_res.get("dest") is not None
+            assert cp_res.get("dest_created") is True
+            assert cp_res.get("src") is not None
+        for v_res in verify_copy.contacted.values():
+            assert v_res.get("rc") == 0
+            assert len(v_res.get("stdout_lines", [])) > 0
+
+    finally:
+        hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
+        hosts.all.shell(cmd=f"drm {src_ds}")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.gdg
+def test_copy_gds_to_uss_dir_missing_parent_dirs(ansible_zos_module):
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir, suffix='/')
+
+    try:
+        hosts.all.shell(cmd=f"dtouch -tGDG -L3 {src_ds}")
+        hosts.all.shell(cmd=f"""dtouch -tSEQ "{src_ds}(+1)" """)
+        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}.G0001V00" """)
+
+        # Attempt to copy GDS to a USS path with missing parent dirs
+        src_gds = f"{src_ds}.G0001V00"
+        copy_res = hosts.all.zos_copy(
+            src=src_gds,
+            dest=dest,
+            remote_src=True
+        )
+        verify_dest = hosts.all.shell(
+            cmd=f"ls {dest}", executable=SHELL_EXECUTABLE
+        )
+        for cp_res in copy_res.contacted.values():
+            assert cp_res.get("msg") is None
+            assert cp_res.get("changed") is True
+            assert cp_res.get("dest") is not None
+            assert cp_res.get("dest_created") is True
+            assert cp_res.get("src") is not None
+        for v_res in verify_dest.contacted.values():
+            assert v_res.get("rc") == 0
+            assert len(v_res.get("stdout_lines", [])) == 1
+
+    finally:
+        hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
+        hosts.all.shell(cmd=f"drm {src_ds}")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")   
+
+
+@pytest.mark.uss
+@pytest.mark.gdg
+def test_copy_gdg_to_uss_dir_missing_parent_dirs(ansible_zos_module):
+    """
+    Copy a GDG to a USS path whose parent directories do not exist.
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir)
+
+    try:
+        hosts.all.shell(cmd=f"dtouch -tGDG -L3 {src_ds}")
+        hosts.all.shell(cmd=f"""dtouch -tSEQ "{src_ds}(+1)" """)
+        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}(0)" """)
+
+        copy_results = hosts.all.zos_copy(
+            src=src_ds,
+            dest=dest,
+            remote_src=True
+        )
+        verify_dest = hosts.all.shell(
+            cmd=f"ls {dest}", executable=SHELL_EXECUTABLE
+        )
+
+        for cp_res in copy_results.contacted.values():
+            assert cp_res.get("msg") is None
+            assert cp_res.get("changed") is True
+            assert cp_res.get("dest") is not None
+            assert cp_res.get("dest_created") is True
+            assert cp_res.get("src") is not None
+        for v_res in verify_dest.contacted.values():
+            assert v_res.get("rc") == 0
+            files = v_res.get("stdout_lines", [])
+            assert len(files) == 1, f"Expected 1 generation file, found: {files}"
+
+    finally:
+        hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
+        hosts.all.shell(cmd=f"drm {src_ds}")
+        hosts.all.file(path=os.path.join(TMP_DIRECTORY, "test"), state="absent")
 
 
 @pytest.mark.parametrize("new_gdg", [True, False])

--- a/tests/functional/modules/test_zos_copy_func.py
+++ b/tests/functional/modules/test_zos_copy_func.py
@@ -2917,6 +2917,267 @@ def test_copy_ps_to_non_existing_uss_file(ansible_zos_module):
 
 @pytest.mark.uss
 @pytest.mark.seq
+def test_copy_ps_to_non_existing_uss_file_missing_parents(ansible_zos_module):
+    """
+    Copy a sequential data set to a USS path whose parent directories do not exist.
+
+    src:    Sequential data set populated with special-character content.
+    dest:   /tmp/test/newdir/<random> (parent dirs absent).
+    assert: Copy succeeds, dest file is created, content is readable via cat.
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir)
+
+    try:
+        hosts.all.shell(cmd=f"decho '{DUMMY_DATA_SPECIAL_CHARS}' '{src_ds}' ")
+        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
+        stat_res = hosts.all.stat(path=dest)
+        verify_copy = hosts.all.shell(
+            cmd="cat {0}".format(dest), executable=SHELL_EXECUTABLE
+        )
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest
+            assert result.get("dest_created") is True
+            assert result.get("src") is not None
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+        for result in verify_copy.contacted.values():
+            assert result.get("rc") == 0
+            assert result.get("stdout") != ""
+    finally:
+        hosts.all.file(path=dest, state="absent")
+        hosts.all.zos_data_set(name=src_ds, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.pds
+def test_copy_pds_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
+    """
+    Copy a partitioned data set to a USS path whose parent directories do not exist.
+
+    src:    Partitioned data set with member.
+    dest:   /tmp/test/newdir/<random> (parent dirs absent).
+    assert: Copy succeeds, dest directory is created, all members are present as files.
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    src_ds_mem = f"{src_ds}(MEM1)"
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir)
+
+    try:
+        ds_creation_result = hosts.all.zos_data_set(
+            name=src_ds,
+            type="pds",
+            space_primary=5,
+            space_type="m",
+            record_format="fba",
+            record_length=80,
+            replace=True,
+            state="present"
+        )
+        for result in ds_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        member_creation_result = hosts.all.zos_data_set(
+            name=src_ds_mem,
+            state="present",
+            type="member",
+            replace=True
+        )
+        for result in member_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
+        stat_res = hosts.all.stat(path=dest)
+        verify_dest = hosts.all.shell(cmd=f"ls {dest}/{src_ds}")
+
+        for result in copy_res.contacted.values():
+            assert result.get("msg") is None
+            assert result.get("changed") is True
+            assert result.get("dest") == dest
+            assert result.get("dest_created") is True
+            assert result.get("src") is not None
+        for result in stat_res.contacted.values():
+            assert result.get("stat").get("exists") is True
+        for v_res in verify_dest.contacted.values():
+            assert v_res.get("rc") == 0
+            assert len(v_res.get("stdout_lines", [])) > 0
+
+    finally:
+        hosts.all.file(path=dest, state="absent")
+        hosts.all.zos_data_set(name=src_ds, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.pds
+def test_copy_pds_to_existing_uss_file_fails(ansible_zos_module):
+    """
+    Copy a partitioned data set to a USS file.
+
+    src:    Partitioned data set with member.
+    dest:   /tmp//<random> (USS file).
+    assert: Copy fails (failed=True), error message is present, dest unchanged
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    src_ds_mem = f"{src_ds}(MEM1)"
+    dest = get_random_file_name(dir=TMP_DIRECTORY)
+
+    try:
+        # Create USS file
+        uss_file_creation_result = hosts.all.zos_copy(
+            content="| Test",
+            dest=dest,
+            encoding={
+                "from": "UTF-8",
+                "to": "IBM-1047"
+            }
+        )
+        for result in uss_file_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        # Create PDS
+        ds_creation_result = hosts.all.zos_data_set(
+            name=src_ds,
+            type="pds",
+            space_primary=5,
+            space_type="m",
+            record_format="fba",
+            record_length=80,
+            replace=True,
+            state="present"
+        )
+        for result in ds_creation_result.contacted.values():
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        member_creation_result = hosts.all.zos_data_set(
+            name=src_ds_mem,
+            state="present",
+            type="member",
+            replace=True
+        )
+        for result in member_creation_result.contacted.values():
+            assert_msg = result.get("stdout", "")
+            print(result)
+            assert result.get("changed") is True
+            assert result.get("failed", False) is False
+
+        copy_res = hosts.all.zos_copy(src=src_ds, dest=dest, remote_src=True)
+        for result in copy_res.contacted.values():
+            error_msg = "Cannot write a partitioned data set (PDS) to a USS file."
+            assert result.get("failed") is True
+            assert result.get("changed") is False
+            assert error_msg in result.get("msg")
+
+    finally:
+        hosts.all.file(path=dest, state="absent")
+        hosts.all.zos_data_set(name=src_ds, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.gdg
+def test_copy_gds_to_non_existing_uss_file_missing_parents(ansible_zos_module):
+    """
+    Copy a GDS to a USS path whose parent directories do not exist.
+
+    src:    GDS
+    dest:   /tmp/test/newdir/<random> (parent dirs absent)
+    assert: Copy succeeds, dest is a regular file (not directory), content is readable
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir)
+
+    try:
+        hosts.all.shell(cmd=f"dtouch -tGDG -L3 {src_ds}")
+        hosts.all.shell(cmd=f"""dtouch -tSEQ "{src_ds}(+1)" """)
+        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}(0)" """)
+
+        src_gds = f"{src_ds}(0)"
+        copy_results = hosts.all.zos_copy(
+            src=src_gds,
+            dest=dest,
+            remote_src=True
+        )
+        verify_dest = hosts.all.shell(
+            cmd=f"ls {dest}", executable=SHELL_EXECUTABLE
+        )
+        for cp_res in copy_results.contacted.values():
+            assert cp_res.get("msg") is None
+            assert cp_res.get("changed") is True
+            assert cp_res.get("dest") is not None
+            assert cp_res.get("dest_created") is True
+            assert cp_res.get("src") is not None
+        for v_res in verify_dest.contacted.values():
+            assert v_res.get("rc") == 0
+            assert len(v_res.get("stdout_lines", [])) > 0
+
+    finally:
+        hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
+        hosts.all.shell(cmd=f"drm {src_ds}")
+        hosts.all.file(path=dest, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.gdg
+def test_copy_gdg_to_non_existing_uss_dir_missing_parents(ansible_zos_module):
+    """
+    Copy a GDS to a USS path whose parent directories do not exist.
+
+    src:    GDG
+    dest:   /tmp/test/newdir/<random> (parent dirs absent)
+    assert: Copy succeeds, dest is a directory, generations are inside
+    """
+    hosts = ansible_zos_module
+    src_ds = get_tmp_ds_name()
+    parent_dir = os.path.join(TMP_DIRECTORY, "test", "newdir")
+    dest = get_random_file_name(dir=parent_dir)
+
+    try:
+        hosts.all.shell(cmd=f"dtouch -tGDG -L3 {src_ds}")
+        hosts.all.shell(cmd=f"""dtouch -tSEQ "{src_ds}(+1)" """)
+        hosts.all.shell(cmd=f"""decho "{DUMMY_DATA}" "{src_ds}(0)" """)
+
+        copy_results = hosts.all.zos_copy(
+            src=src_ds,
+            dest=dest,
+            remote_src=True
+        )
+        verify_dest = hosts.all.shell(
+            cmd=f"ls {dest}", executable=SHELL_EXECUTABLE
+        )
+
+        for cp_res in copy_results.contacted.values():
+            assert cp_res.get("msg") is None
+            assert cp_res.get("changed") is True
+            assert cp_res.get("dest") is not None
+            assert cp_res.get("dest_created") is True
+            assert cp_res.get("src") is not None
+        for v_res in verify_dest.contacted.values():
+            assert v_res.get("rc") == 0
+            files = v_res.get("stdout_lines", [])
+            assert len(files) == 1, f"Expected 1 generation file, found: {files}"
+            assert re.search(r"\.G\d+V\d+$", files[0])
+
+    finally:
+        hosts.all.shell(cmd=f"""drm "{src_ds}(0)" """)
+        hosts.all.shell(cmd=f"drm {src_ds}")
+        hosts.all.file(path=dest, state="absent")
+
+
+@pytest.mark.uss
+@pytest.mark.seq
 @pytest.mark.parametrize("replace", [False, True])
 def test_copy_ps_to_existing_uss_file(ansible_zos_module, replace):
     hosts = ansible_zos_module

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -7,6 +7,7 @@ markers =
     uss: uss test cases.
     seq: sequential data sets test cases.
     pdse: partitioned data sets test cases.
+    gdg: generation data group test cases.
     vsam: VSAM data sets test cases.
     template: Jinja2 templating test cases.
     aliases: aliases option test cases.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #2525 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
zos_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
**Bugs:**
`zos_copy` fails with the error `"Cannot write a partitioned data set (PDS) to a USS file"` when attempting to copy a PDS to a non-existent USS directory.
- The module requires the target directory to exist before the copy operation, which contradicts the documented behavior that: `"If C(dest) has missing parent directories, they will be created."`

As part of this bugfix, research was done to determine whether the `zos_copy `module functionality aligns with the [ansible.builtin.copy module](https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/copy_module.html). The following scenarios were tested with the `ansible.builtin.copy`, and then reviewed with `zos_copy` for PDS/PDSE, PDS/PDSE members, sequential data sets, GDG, GDS, USS directories, and USS files to determine their effect on copy:
- Trailing slash on destination
- Parent directories of destination path missing
- Destination missing

The following scenarios did not align with the ansible.builtin.copy functionality and were updated for `zos_copy` so that copy succeeds:
- PDS to USS directory copy
- PDS member to USS directory copy
- Sequential data set to USS directory copy
- GDG to USS directory copy
- GDS to USS directory copy

**Fixes:**
`plugins/module_utils/copy.py`
- Fixed GDG to nonexistent USS directory copy by adding functionality to create new GDG-named USS directory if it does not exist before copying over GDS files.

`plugins/modules/zos_copy.py`
- Updated documentation to specify USS path copy outcomes based on source and destination
- Create `_src_produces_uss_file` helper function to determine whether a `src` would result in copy to a USS file if the `dest` type is USS.
- Update functionality to generate new destination name from source basename in copy scenarios where the source is copied as a file or directory into the specified destination.
- Updated check to handle copy to USS directory when destination does not exist by creating the destination path for sources that would produce a USS directory or creating the parent directories for sources that would produce a USS file, else defaulting to original error message.
   - To account for destination creation, updated `res_args` assignment with `setdefault` so if a `res_args` is set prior, it is not overridden by the later assignment.

**Validation:**
[zos_copy_uss_dest_bug.xlsx](https://github.com/user-attachments/files/32257268/zos_copy_uss_dest_bug.xlsx)
- This file includes the expected, actual, and updated outcomes of copy for PDS/PDSE > USS, PS > USS, GDG/GDS > USS, and USS > USS (found in tabs within the Excel file).
- The expected outcomes are based on the outcomes of the `ansible.builtin.copy` module where possible (in cases that would not introduce breaking changes). These outcomes are included in the first tab of the Excel file.

Testing playbooks
- Located in playbooks/zos_copy_bugfix_2525 of ansible-core-dev-docs repository
- Playbooks test copy scenarios from Excel spreadsheet, with each copy scenario associated with a test case (EX Scenario 1 in Excel file -> TC1 in playbook)

The following playbook tasks previously resulted in errors, but following the bugfix should successfully perform copy:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
    - name: "1 - pds to uss dir, no trailing slash, no parent dirs, no dest dir"
      zos_copy:
        src: "{{ src_pds }}"
        dest: "{{ dest_path }}"
        remote_src: true

    - name: "2 - pds to uss dir, trailing slash, no parent dirs, no dest dir"
      zos_copy:
        src: "{{ src_pds }}"
        dest: "{{ dest_path }}/"
        remote_src: true

    - name: "3 - pds member to dir, trailing slash, no parent dirs, no dest dir"
      zos_copy:
        src: "{{ src_pds_mem1 }}"
        dest: "{{ dest_path }}/"
        remote_src: true

    - name: "4 - PS to USS dir, trailing slash, no parent dirs, no dest dir"
      zos_copy:
        src: "{{ src_ps }}"
        dest: "{{ dest_path }}/"
        remote_src: true

    - name: "5 - gdg to uss dir, no trailing slash, no parent dirs, no dest dir"
      zos_copy:
        src: "{{ src_gdg }}"
        dest: "{{ dest_path }}"
        remote_src: true

    - name: "6 - gdg to uss dir, trailing slash, no parent dirs, no dest dir"
      zos_copy:
        src: "{{ src_gdg }}"
        dest: "{{ dest_path }}/"
        remote_src: true

    - name: "7 - gds to dir, trailing slash, no parent dirs, no dest dir"
      zos_copy:
        src: "{{ src_gds }}"
        dest: "{{ dest_path }}/"
        remote_src: true

```