### PR TITLE
[Enhancement] [zos_backup_restore] - Return ADRDSSU output using new parameters stdout and stderr

### DIFF
--- a/changelogs/fragments/1469_zos_backup_restore_return_operation_log.yml
+++ b/changelogs/fragments/1469_zos_backup_restore_return_operation_log.yml
@@ -1,6 +1,6 @@
 minor_changes:
-   - zos_backup_restore - Added new response parameters(stdout, stderr, stdout_lines,
-     stderr_lines) to returns the ADRDSSU operation log  unconditionally so users can
-     inspect which data sets were selected, processed, or filtered during backup and
-     restore operations.
+   - zos_backup_restore - Added new response parameters (stdout, stderr, stdout_lines,
+     and stderr_lines) to return the ADRDSSU operation log, allowing users to inspect
+     which data sets were selected, processed, or filtered during backup and restore
+     operations.
      (https://github.com/ansible-collections/ibm_zos_core/issues/2579).

--- a/changelogs/fragments/1469_zos_backup_restore_return_operation_log.yml
+++ b/changelogs/fragments/1469_zos_backup_restore_return_operation_log.yml
@@ -1,0 +1,6 @@
+minor_changes:
+   - zos_backup_restore - Added new response parameters(stdout, stderr, stdout_lines,
+     stderr_lines) to returns the ADRDSSU operation log  unconditionally so users can
+     inspect which data sets were selected, processed, or filtered during backup and
+     restore operations.
+     (https://github.com/ansible-collections/ibm_zos_core/issues/2579).

--- a/plugins/modules/zos_backup_restore.py
+++ b/plugins/modules/zos_backup_restore.py
@@ -363,7 +363,6 @@ options:
           - If I(hlq) is not provided, the original HLQ remains unchanged.
         type: str
         required: false
-
 attributes:
   action:
     support: none
@@ -611,6 +610,40 @@ message:
   returned: always
   type: str
   sample: ""
+stdout:
+  description:
+    - The raw standard output captured from the ADRDSSU operation.
+    - When I(operation=backup), contains the output from the DZIP (ADRDSSU DUMP) operation.
+    - When I(operation=restore), contains the output from the DUNZIP (ADRDSSU RESTORE) operation.
+  returned: always
+  type: str
+  sample: "ADR454I (001)-DTDSC(01), THE FOLLOWING DATA SETS WERE SUCCESSFULLY PROCESSED\n
+           DYNATRAC.MEPCRC01.SZDTAUTH\nADR006I (001)-STEND(02), EXECUTION ENDS"
+stderr:
+  description:
+    - The raw standard error captured from the ADRDSSU operation.
+    - When I(operation=backup), contains the error output from the DZIP operation.
+    - When I(operation=restore), contains the error output from the DUNZIP operation.
+    - Populated when errors or warnings are encountered.
+  returned: always
+  type: str
+  sample: null
+stdout_lines:
+  description:
+    - The I(stdout) output split into a list of lines.
+  returned: always
+  type: list
+  elements: str
+  sample: ["ADR454I (001)-DTDSC(01), THE FOLLOWING DATA SETS WERE SUCCESSFULLY PROCESSED",
+           "DYNATRAC.MEPCRC01.SZDTAUTH", "ADR006I (001)-STEND(02), EXECUTION ENDS"]
+stderr_lines:
+  description:
+    - The I(stderr) output split into a list of lines.
+    - Populated when errors or warnings are encountered.
+  returned: always
+  type: list
+  elements: str
+  sample: null
 """
 
 import traceback
@@ -632,9 +665,11 @@ from ansible_collections.ibm.ibm_zos_core.plugins.module_utils.log import Single
 try:
     from zoautil_py import datasets
     from zoautil_py import exceptions as zoau_exceptions
+    from zoautil_py.ztypes import ZOAUResponse
 except ImportError:
     datasets = ZOAUImportError(traceback.format_exc())
     zoau_exceptions = ZOAUImportError(traceback.format_exc())
+    ZOAUResponse = ZOAUImportError(traceback.format_exc())
 
 
 def main():
@@ -645,7 +680,15 @@ def main():
     fail_json
         Any error ocurred during execution.
     """
-    result = dict(changed=False, message="", backup_name="")
+    result = dict(
+        changed=False,
+        message="",
+        backup_name="",
+        stdout=None,
+        stderr=None,
+        stdout_lines=None,
+        stderr_lines=None,
+    )
     module_args = dict(
         access=dict(
             type='dict',
@@ -760,7 +803,7 @@ def main():
             module.fail_json(msg="access.share cannot be used with full_volume. These options are mutually exclusive.")
 
         if operation == "backup":
-            backup(
+            zoau_response = backup(
                 backup_name=backup_name,
                 include_data_sets=resolve_gds_name_if_any(data_sets.get("include")),
                 exclude_data_sets=resolve_gds_name_if_any(data_sets.get("exclude")),
@@ -779,7 +822,7 @@ def main():
                 access=access,
             )
         else:
-            restore(
+            zoau_response = restore(
                 backup_name=backup_name,
                 include_data_sets=data_sets.get("include"),
                 exclude_data_sets=data_sets.get("exclude"),
@@ -796,6 +839,10 @@ def main():
                 sphere=sphere,
                 access=access,
             )
+        result["stdout"] = zoau_response.stdout_response
+        result["stderr"] = zoau_response.stderr_response
+        result["stdout_lines"] = zoau_response.stdout_response.splitlines() if zoau_response.stdout_response else []
+        result["stderr_lines"] = zoau_response.stderr_response.splitlines() if zoau_response.stderr_response else []
         result["backup_name"] = backup_name
         result["changed"] = True
 
@@ -968,10 +1015,17 @@ def backup(
         Specifies ADRDSSU keywords that is passed directly to the dunzip utility.
     access : dict
         Specifies keywords for share and administration permission.
+
+    Returns
+    -------
+    ZOAUResponse
+        The response object from dzip, containing stdout_response and stderr_response.
     """
     args = locals()
     zoau_args = to_dzip_args(**args)
-    datasets.dzip(**zoau_args)
+    zoau_response = ZOAUResponse(rc=0, stdout_response="", stderr_response="", command="", response_format="")
+    datasets.dzip(**zoau_args, response=zoau_response)
+    return zoau_response
 
 
 def restore(
@@ -1046,6 +1100,11 @@ def restore(
     access : dict
         Specifies keywords for share and administration permission.
 
+    Returns
+    -------
+    ZOAUResponse
+        The response object from dunzip, containing stdout_response and stderr_response.
+
     Raises
     ------
     ZOAUException
@@ -1053,13 +1112,11 @@ def restore(
     """
     args = locals()
     zoau_args = to_dunzip_args(**args)
-    dunzip_output = ""
+    zoau_response = ZOAUResponse(rc=0, stdout_response="", stderr_response="", command="", response_format="")
     try:
-        rc = datasets.dunzip(**zoau_args)
-    except zoau_exceptions.ZOAUException as dunzip_exception:
-        dunzip_output = dunzip_exception.response.stdout_response
-        dunzip_output = dunzip_output + dunzip_exception.response.stderr_response
-        rc = get_real_rc(dunzip_output)
+        rc = datasets.dunzip(**zoau_args, response=zoau_response)
+    except zoau_exceptions.ZOAUException:
+        rc = get_real_rc(zoau_response.stdout_response + zoau_response.stderr_response)
     failed = False
     if rc > 0 and rc <= 4:
         if recover is not True:
@@ -1068,8 +1125,11 @@ def restore(
         failed = True
     if failed:
         raise zoau_exceptions.ZOAUException(
-            "{0}, RC={1}".format(dunzip_output, rc)
+            "{0}, RC={1}".format(
+                zoau_response.stdout_response + zoau_response.stderr_response, rc
+            )
         )
+    return zoau_response
 
 
 def set_adrdssu_keywords(sphere, sms=None, access=None):

--- a/tests/functional/modules/test_zos_backup_restore_func.py
+++ b/tests/functional/modules/test_zos_backup_restore_func.py
@@ -1824,3 +1824,126 @@ def test_restore_fails_when_names_is_empty_list(ansible_zos_module):
     finally:
         delete_data_set_or_file(hosts, data_set_name)
         delete_data_set_or_file(hosts, backup_name)
+
+
+# ---------------------------------------------------------------------------- #
+#              Tests for stdout / stderr return fields (issue 1469)            #
+# ---------------------------------------------------------------------------- #
+
+
+def assert_stdout_fields_present(results):
+    """Assert that stdout, stderr, stdout_lines and stderr_lines are all
+    returned in the module result and have the correct types.
+
+    ``stdout`` and ``stdout_lines`` must be non-empty because ADRDSSU always
+    writes at least one ADR* message on a successful operation.
+    ``stderr`` and ``stderr_lines`` may be empty on a clean run.
+    """
+    for result in results.contacted.values():
+        stdout = result.get("stdout")
+        stderr = result.get("stderr")
+        stdout_lines = result.get("stdout_lines")
+        stderr_lines = result.get("stderr_lines")
+
+        assert stdout is not None, "stdout must be present in module result"
+        assert stderr is not None, "stderr must be present in module result"
+        assert stdout_lines is not None, "stdout_lines must be present in module result"
+        assert stderr_lines is not None, "stderr_lines must be present in module result"
+
+        assert isinstance(stdout, str), \
+            f"stdout must be str, got {type(stdout)}"
+        assert isinstance(stderr, str), \
+            f"stderr must be str, got {type(stderr)}"
+        assert isinstance(stdout_lines, list), \
+            f"stdout_lines must be list, got {type(stdout_lines)}"
+        assert isinstance(stderr_lines, list), \
+            f"stderr_lines must be list, got {type(stderr_lines)}"
+
+        assert len(stdout) > 0, \
+            "stdout must not be empty — ADRDSSU always writes ADR* messages"
+        assert len(stdout_lines) > 0, \
+            "stdout_lines must not be empty when stdout is non-empty"
+
+        # stdout_lines must be the splitlines of stdout
+        assert stdout_lines == stdout.splitlines(), \
+            "stdout_lines must equal stdout.splitlines()"
+
+
+@pytest.mark.ds
+def test_backup_returns_stdout_fields(ansible_zos_module):
+    """Verify that a backup operation always populates stdout, stderr,
+    stdout_lines and stderr_lines in the module result, and that stdout
+    contains the ADRDSSU job log (ADR* messages).
+    """
+    hosts = ansible_zos_module
+    data_set_name = get_tmp_ds_name()
+    backup_name = get_tmp_ds_name(1, 1)
+    try:
+        delete_data_set_or_file(hosts, data_set_name)
+        delete_data_set_or_file(hosts, backup_name)
+        create_sequential_data_set_with_contents(hosts, data_set_name, DATA_SET_CONTENTS)
+
+        results = hosts.all.zos_backup_restore(
+            operation="backup",
+            data_sets=dict(include=data_set_name),
+            backup_name=backup_name,
+            overwrite=True,
+        )
+        assert_module_did_not_fail(results)
+        assert_stdout_fields_present(results)
+
+        for result in results.contacted.values():
+            # ADRDSSU always writes ADR-prefixed messages in its output
+            assert search(r"ADR\d{3}I", result.get("stdout", "")) is not None, \
+                "stdout must contain at least one ADR*I message from ADRDSSU DUMP"
+    finally:
+        delete_data_set_or_file(hosts, data_set_name)
+        delete_data_set_or_file(hosts, backup_name)
+        delete_remnants(hosts)
+
+
+@pytest.mark.ds
+def test_restore_returns_stdout_fields(ansible_zos_module):
+    """Verify that a restore operation always populates stdout, stderr,
+    stdout_lines and stderr_lines in the module result, and that stdout
+    contains the ADRDSSU job log with data set filtering results.
+    """
+    hosts = ansible_zos_module
+    data_set_name = get_tmp_ds_name()
+    backup_name = get_tmp_ds_name(1, 1)
+    new_hlq = get_random_q()
+    try:
+        delete_data_set_or_file(hosts, data_set_name)
+        delete_data_set_or_file(hosts, backup_name)
+        create_sequential_data_set_with_contents(hosts, data_set_name, DATA_SET_CONTENTS)
+
+        backup_results = hosts.all.zos_backup_restore(
+            operation="backup",
+            data_sets=dict(include=data_set_name),
+            backup_name=backup_name,
+            overwrite=True,
+        )
+        assert_module_did_not_fail(backup_results)
+
+        restore_results = hosts.all.zos_backup_restore(
+            operation="restore",
+            backup_name=backup_name,
+            overwrite=True,
+            recover=True,
+            output=dict(hlq=new_hlq),
+        )
+        assert_module_did_not_fail(restore_results)
+        assert_stdout_fields_present(restore_results)
+
+        for result in restore_results.contacted.values():
+            stdout = result.get("stdout", "")
+            # ADRDSSU always writes ADR-prefixed messages in its output
+            assert search(r"ADR\d{3}I", stdout) is not None, \
+                "stdout must contain at least one ADR*I message from ADRDSSU RESTORE"
+            # ADR801I is the data set filtering completion message
+            assert search(r"ADR801I", stdout) is not None, \
+                "stdout must contain ADR801I (DATA SET FILTERING IS COMPLETE)"
+    finally:
+        delete_data_set_or_file(hosts, data_set_name)
+        delete_data_set_or_file(hosts, backup_name)
+        delete_remnants(hosts, [new_hlq])


### PR DESCRIPTION
##### SUMMARY
 Fixes #1469

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
zos_backup_restore

##### ADDITIONAL INFORMATION
- Returns the ADRDSSU operation log (stdout, stderr, stdout_lines, stderr_lines) unconditionally so users can inspect                        which data sets were selected, processed, or filtered during backup and restore operations.
