### PR TITLE
[Bug] [zos_job_query] [zos_job_output] ZOAU v1.4.3.0 jls update

### DIFF
--- a/plugins/module_utils/job.py
+++ b/plugins/module_utils/job.py
@@ -103,9 +103,10 @@ def job_output(job_id=None, owner=None, job_name=None, dd_name=None, sysin=False
         "job_name": job_name,
         "dd_name": dd_name
     })
-    job_id = parsed_args.get("job_id") or "*"
+    job_id = parsed_args.get("job_id")
+    # Defaults to wildcard
     job_name = parsed_args.get("job_name") or "*"
-    owner = parsed_args.get("owner") or "*"
+    owner = parsed_args.get("owner")
     dd_name = parsed_args.get("dd_name") or ""
 
     job_detail = _get_job_status(

--- a/plugins/modules/zos_job_output.py
+++ b/plugins/modules/zos_job_output.py
@@ -46,16 +46,19 @@ options:
         (e.g "STC02560", "STC*")
     type: str
     required: false
+    default: null
   job_name:
     description:
       - The name of the batch job. (e.g "TCPIP", "C*")
     type: str
     required: false
+    default: "*"
   owner:
     description:
       - The owner who ran the job. (e.g "IBMUSER", "*")
     type: str
     required: false
+    default: null
   dd_name:
     description:
       - Data definition name (show only this DD on a found job).
@@ -510,9 +513,9 @@ def run_module():
         Any exception while fetching jobs.
     """
     module_args = dict(
-        job_id=dict(type="str", required=False),
-        job_name=dict(type="str", required=False),
-        owner=dict(type="str", required=False),
+        job_id=dict(type="str", required=False, default=None),
+        job_name=dict(type="str", required=False, default="*"),
+        owner=dict(type="str", required=False, default=None),
         dd_name=dict(type="str", required=False, aliases=['ddname']),
         sysin_dd=dict(type="bool", required=False, default=False),
     )
@@ -675,7 +678,6 @@ def run_module():
         module.fail_json(msg=repr(e), **results)
 
     module.exit_json(**results)
-
 
 def main():
     run_module()

--- a/plugins/modules/zos_job_query.py
+++ b/plugins/modules/zos_job_query.py
@@ -455,17 +455,13 @@ def query_jobs(job_name, job_id, owner):
     except Exception as e:
         raise RuntimeError("Error querying jobs: " + str(e))
 
-    # When all three filters are provided as explicit (non-wildcard) values and
-    # the job_id lookup returned no real job (only the synthetic _job_not_found
+    # When the job_id lookup returned no real job (only the synthetic _job_not_found
     # sentinel), the combination is unresolvable — treat it as a failure so the
     # module surfaces an error consistent with v2.0.0 failure path.
-    explicit_job_name = job_name and job_name != "*"
-    if job_id and explicit_job_name and owner:
-        if jobs and jobs[0].get("job_not_found"):
-            raise RuntimeError(
-                "Error querying jobs: " + jobs[0]["ret_code"]["msg_txt"]
-            )
-
+    if jobs and jobs[0].get("job_not_found"):
+      raise RuntimeError(
+          "Error querying jobs: " + jobs[0]["ret_code"]["msg_txt"]
+      )
     return jobs
 
 

--- a/tests/functional/modules/test_zos_job_output_func.py
+++ b/tests/functional/modules/test_zos_job_output_func.py
@@ -94,6 +94,7 @@ def test_zos_job_output_invalid_job_name(ansible_zos_module):
     for result in results.contacted.values():
         assert result.get("changed") is False
         assert result.get("msg", False) is False
+        assert result.get("failed", False) is False
         assert result.get("jobs") is not None
 
         job = result.get("jobs")[0]
@@ -126,7 +127,7 @@ def test_zos_job_output_invalid_job_name(ansible_zos_module):
         assert rc.get("msg_txt") is not None
 
         dds = job.get("dds")[0]
-        assert dds.get("dd_name") is None
+        assert dds.get("dd_name") == "unavailable"
         assert dds.get("record_count") == 0
         assert dds.get("id") is None
         assert dds.get("stepname") is None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes changes to `zos_job_query` and `zos_job_output` from new ZOAU v1.4.3.0 `jls` command returned output.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`zos_job_query`
`zos_job_output`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The following test cases were failing as a result of the ZOAU `jls` command bug fix that changes the job not found response from a ZOAU exception to an empty job list (which aligns with the existing ZOAU `dls` data set not found response).

**FIX 1: `test_zos_job_output_invalid_job_name`**
This test case was failing because the expected defaults for `job_id` and `owner` are `None`, but were returning as `*`.  Previously with ZOAU v1.4.1.1, an invalid `job_name` raised a ZOAU exception, and was caught by the module ZOAU exception handler that returned a empty job list. This empty job list displayed the user-passed parameters, so `job_id` and `owner` were returned as `null`.

Example:
```
    - name: "job_name"
      zos_job_output:
        job_name: "INVALID"
```
The user-passed parameters are `job_name: "INVALID"`, `job_id: null`, and `owner: null`. These are the parameters being used when a ZOAU exception is raised, and an empty job list is returned.

However, now that ZOAU v1.4.3.0 returns an empty job list for an invalid `job_name`, the `zos_job_output` module returns the sentinel `job_not_found` message that returns the actual `job_id` and `owner` that was used in the output request. The change uncovered a bug in that the defaults for all parameters are set to `*` instead of `None` in the `job_output` call. 

Example:
```
entries = jobs.fetch_multiple(job_id="*", job_name="INVALID", job_owner="*", include_extended=True)
```
At the point where the ZOAU `fetch_multiple` call is made, all parameters that were not passed by the user defaulted to `*` instead of `null` - so when the job list is returned, the parameters show `*` instead of `null` (which was the scenario causing the test to fail).

The updated branch now sets the following defaults for each parameter with the documentation updated to reflect the change:

- job_name -> null
- job_id -> null
- owner -> null

This change aligns the `zos_job_output` default parameters for `job_id`, `job_name`, and `owner` with that of the `zos_job_query` module. The default of `job_name` is `null` instead of `*` because the `zos_job_output` test case `test_zos_job_output_no_owner` indicates that when a parameter is missing, the expected outcome is a stderr message denoting that a `job_name`, `job_id`, or `owner` must be passed to `zos_job_output`. This reveals that `zos_job_output` will not default to making a job output request if no parameters are passed. 

Line 561 in `zos_job_output.py`
```
    if not job_id and not job_name and not owner:
        module.fail_json(msg="Please provide a job_id or job_name or owner", stderr="", **results)
```

**Validation**
The following outcomes should occur for `zos_job_output`:
<img width="1344" height="404" alt="image" src="https://github.com/user-attachments/assets/ea5f526b-0d55-4c35-8edf-3791fa165de7" />

Where the previous ZOAU v1.4.1.1 exception was formatted as:
```
fatal: [zos_host]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "dd_name": null,
            "job_id": "JOB99999",
            "job_name": null,
            "owner": null,
            "sysin_dd": false
        }
    },
    "msg": "ZOAU exception  rc 8",
    "stderr": "BGYSC3503E Failed to retrieve job list.\n",
    "stderr_lines": [
        "BGYSC3503E Failed to retrieve job list."
    ]
}
```
And the new ZOAU v1.4.3.0 job not found message is formatted as:
```
fatal: [zos_host]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "dd_name": null,
            "job_id": "JOB99999",
            "job_name": "*",
            "owner": null,
            "sysin_dd": false
        }
    },
    "msg": "The job with job_id JOB99999 could not be found.",
    "stderr": "The job with job_id JOB99999 could not be found.",
    "stderr_lines": [
        "The job with job_id JOB99999 could not be found."
    ]
}
```


**FIX 2: `test_zos_job_query_job_not_found`**
This test case was failing because each job not found case was returning as a change instead of a failure (which is the expected result of ZOAU v1.4.1.1). Since ZOAU v1.4.3.0 now returns an empty job list where it was previously returning a ZOAU exception, the `zos_job_query` module was interpreting the returned empty job list as a success. I have updated the code to identify if no jobs have been found in the returned list, and if so, an exception is raised in parity with the v1.4.1.1 job not found outcomes.

**Validation**
The following outcomes should occur for `zos_job_query`:
<img width="1834" height="398" alt="image" src="https://github.com/user-attachments/assets/3d3b8035-71a2-4043-af78-d0fbbcfe317e" />

Where the previous ZOAU v1.4.1.1 exception was formatted as:
```
fatal: [zos_host]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "job_id": "JOB99999",
            "job_name": "*",
            "owner": null
        }
    },
    "msg": "Error querying jobs: [ZOAUResponse]\n\trc: 8\n\tresponse_format: UTF-8\n\tstdout_response: \n\tstderr_response: BGYSC3503E Failed to retrieve job list.\n\n\tcommand: jls -j -o owner,name,id,status,ccode,jobclass,serviceclass,priority,asid,creationdate,creationtime,queueposition,jobtype,executiontime,executionseconds,system,subsystem,onode,xnode,membname,programname,cputime,srbtime -- 'JOB99999'"
}
```
The ZOAU v1.4.3.0 empty job list was formatted as:
```
changed: [zos_host] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "job_id": "JOB99999",
            "job_name": "*",
            "owner": null
        }
    },
    "jobs": [
        {
            "asid": null,
            "content_type": null,
            "cpu_time": null,
            "creation_date": null,
            "creation_time": null,
            "execution_node": null,
            "execution_time": null,
            "job_class": null,
            "job_id": "JOB99999",
            "job_name": "*",
            "origin_node": null,
            "owner": null,
            "priority": null,
            "program_name": null,
            "queue_position": null,
            "ret_code": {
                "code": null,
                "msg": "JOB NOT FOUND",
                "msg_code": null,
                "msg_txt": "The job with job_id JOB99999 could not be found."
            },
            "steps": [],
            "subsystem": null,
            "svc_class": null,
            "system": null
        }
    ]
}
```
And the new ZOAU v1.4.3.0 job not found message is formatted as:
```
fatal: [zos_host]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "job_id": "JOB99999",
            "job_name": "HI",
            "owner": null
        }
    },
    "msg": "Error querying jobs: The job HI with job_id JOB99999 could not be found."
}
```